### PR TITLE
Create FileNodes for pictures

### DIFF
--- a/packages/personal-website/gatsby-config.js
+++ b/packages/personal-website/gatsby-config.js
@@ -52,9 +52,17 @@ module.exports = {
     },
 
     {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `pictures`,
+        path: Content.pictures,
+      },
+    },
+
+    {
       resolve: `gatsby-plugin-copy-files`,
       options: {
-        source: Content.pictures,
+        source: Content.pictures.replace(/\/$/, ''),
         destination: `/pictures`
       },
     },


### PR DESCRIPTION
# What?
Create FileNodes for picture directory, and use the copy-files-plugin to copy the entire directory.

# Why?
Without a FileNode this should have never worked - meanwhile the copy-files-plugin always resolved to the first FileNode within the directory, not the directory itself.
This meant that the pictures folder was not copied.