### PR TITLE
Add support for redirects generated by origin

### DIFF
--- a/packages/personal-website/static/redirects.json
+++ b/packages/personal-website/static/redirects.json
@@ -1,0 +1,1 @@
+{"/__test":"/__test-was-ok!"}

--- a/packages/worker-cdn-prod/index.js
+++ b/packages/worker-cdn-prod/index.js
@@ -48,6 +48,13 @@ addEventListener('fetch', event => {
           requestUrl.href.replace(requestUrl.host, 'alexwilson.tech')
         );
     };
+
+    const redirects = await fetch('https://alexwilson.tech/redirects.json')
+      .then(res => res.json())
+      .catch(() => {})
+    if (redirects && redirects[requestUrl.pathname]) {
+      return redirectTo(`https://alexwilson.tech${redirects[requestUrl.pathname]}`)
+    }
   
     switch (requestUrl.pathname) {
       case '/cv': {


### PR DESCRIPTION
# What?
Read the /redirects.json file on origin.

# Why?
To allow an origin incapable of serving a redirect (i.e. S3, Github Pages) to let Cloudflare know if something has moved/changed.