### PR TITLE
Migrate slugs to UUIDs

### DIFF
--- a/packages/personal-website/gatsby-node.js
+++ b/packages/personal-website/gatsby-node.js
@@ -1,6 +1,20 @@
 const path = require(`path`)
+const fs = require(`fs`).promises
 const { createFilePath } = require(`gatsby-source-filesystem`)
 const { generateBlogSlug, generateTalkSlug } = require('./src/lib/slug-generation')
+
+// Persist redirects to `/redirects.json`
+const writeRedirectsFile = (redirects) => {
+  const plainRedirects = Object.create(null)
+  for (let [oldUrl, newUrl] of redirects) {
+    plainRedirects[oldUrl] = newUrl
+  }
+
+  const redirectsPath = path.join(process.cwd(), 'public', 'redirects.json')
+  fs.writeFile(redirectsPath, JSON.stringify(plainRedirects), 'utf8')
+    .then(_ => console.info(`REDIRECTS_INFO: Redirects saved saved to ${redirectsPath}`))
+    .catch(_ => console.error(`REDIRECTS_ERROR: Error writing redirects to ${redirectsPath}`))
+}
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions
@@ -33,30 +47,27 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 
     // Customise per-content-type.
     const { sourceInstanceName } = getNode(node.parent)
-    createNodeField({
-      node,
-      name: `type`,
-      value: sourceInstanceName
-    })
-    switch (sourceInstanceName) {
-      case 'talks': {
-        const filePath = createFilePath({ node, getNode, basePath: 'talks' })
-        createNodeField({ node, name: `slug`, value: generateTalkSlug(filePath) })
-        break
-      }
+    createNodeField({ node, name: `type`, value: sourceInstanceName })
 
-      case 'posts': {
-        const filePath = createFilePath({ node, getNode, basePath: 'pages' })
-        createNodeField({ node, name: `slug`, value: generateBlogSlug(filePath) })
-        break
-      }
+    let legacySlug = ""
+    if (sourceInstanceName === "talks") {
+      legacySlug = generateTalkSlug(createFilePath({ node, getNode, basePath: 'talks' }))
+    } else if (sourceInstanceName === "posts") {
+      legacySlug = generateBlogSlug(createFilePath({ node, getNode, basePath: 'pages' }))
     }
+    createNodeField({ node, name: `legacyslug`, value: legacySlug })
+
+    const {uuid} = node.frontmatter
+    const slug = `/content/${uuid}`
+    createNodeField({ node, name: 'uuid', value: uuid })
+    createNodeField({ node, name: 'slug', value: slug })
   }
 }
 
 exports.createPages = ({ graphql, actions }) => {
   const { createPage } = actions
   const topics = new Set()
+  const redirects = new Map()
   return graphql(`
     {
       allMarkdownRemark {
@@ -70,6 +81,7 @@ exports.createPages = ({ graphql, actions }) => {
             fields {
               type
               slug
+              legacyslug
             }
           }
         }
@@ -85,6 +97,7 @@ exports.createPages = ({ graphql, actions }) => {
           component: path.resolve(`./src/templates/talk.js`),
           context: {
             slug: node.fields.slug,
+            'legacyslug': node.fields['legacyslug']
           },
         })
         break
@@ -96,17 +109,20 @@ exports.createPages = ({ graphql, actions }) => {
           component: path.resolve(`./src/templates/article.js`),
           context: {
             slug: node.fields.slug,
+            'legacyslug': node.fields['legacyslug']
           },
         })
         break
       }
-
     }
+
+    redirects.set(node.fields['legacyslug'], node.fields['slug'])
 
     // Collect all tags into a set.
     if (node.frontmatter.tags) {
       node.frontmatter.tags.forEach(tag => topics.add(tag))
     }
+
   })
 
   // Create topic pages for each tag
@@ -120,5 +136,6 @@ exports.createPages = ({ graphql, actions }) => {
     })
   }
 
+  writeRedirectsFile(redirects)
 })
 }

--- a/packages/personal-website/gatsby-node.js
+++ b/packages/personal-website/gatsby-node.js
@@ -57,9 +57,9 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
     }
     createNodeField({ node, name: `legacyslug`, value: legacySlug })
 
-    const {uuid} = node.frontmatter
+    const uuid = node.frontmatter.id
     const slug = `/content/${uuid}`
-    createNodeField({ node, name: 'uuid', value: uuid })
+    createNodeField({ node, name: 'id', value: uuid })
     createNodeField({ node, name: 'slug', value: slug })
   }
 }
@@ -80,6 +80,7 @@ exports.createPages = ({ graphql, actions }) => {
             }
             fields {
               type
+              id
               slug
               legacyslug
             }

--- a/packages/personal-website/src/templates/article.js
+++ b/packages/personal-website/src/templates/article.js
@@ -15,6 +15,7 @@ import Webmentions from "../components/webmentions"
 export default ({ data, location }) => {
   const post = data.markdownRemark
   const url = new URL(location.pathname, data.site.siteMetadata.siteUrl)
+  const alternativeUrl = new URL(post.fields.legacyslug, data.site.siteMetadata.siteUrl)
 
   const datePublished = new Date(post.frontmatter.date)
   const dateModified = new Date(post.frontmatter.last_modified_at || datePublished)
@@ -66,7 +67,7 @@ export default ({ data, location }) => {
           <hr />
           <h3 className="share">Share</h3>
           <ShareWidget title={post.frontmatter.title} url={url} />
-          <Webmentions url={url} />
+          <Webmentions urls={[url, alternativeUrl]} />
 
         </div>
 
@@ -123,6 +124,7 @@ export const pageQuery = graphql`
         image
         date
         slug
+        legacyslug
       }
     }
     site {

--- a/packages/personal-website/static/redirects.json
+++ b/packages/personal-website/static/redirects.json
@@ -1,1 +1,0 @@
-{"/__test":"/__test-was-ok!"}


### PR DESCRIPTION
# What?
Migrate away from permalink-style URLs to UUID format.

# Why?
Mostly a long-term pet-peeve, the permalinks have been a *real* pain to maintain and are absolutely an artefact of working with a static site. This enables sourcing pages dynamically from a CMS which is in-line with Edge.