### PR TITLE
Exclude @alexwilson/personal-website from Monorepo CI

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -13,7 +13,7 @@ on:
   schedule:
     - cron: '30 4 * * 3,6'
 
-name: Build, Test and Deploy
+name: Build, Test and Deploy Gatsby
 jobs:
   # Fetch dependencies and build Gatsby
   build:
@@ -46,7 +46,9 @@ jobs:
           node_modules
           */*/node_modules
     - name: Install Dependencies
-      run: npm ci
+      run: |
+        npm ci --ignore-scripts
+        npx lerna bootstrap --scope @alexwilson/personal-website
     - name: Build
       run: npx lerna run --scope @alexwilson/personal-website build
       env:
@@ -83,7 +85,9 @@ jobs:
           node_modules
           */*/node_modules
     - name: Install Dependencies
-      run: npm ci
+      run: |
+        npm ci --ignore-scripts
+        npx lerna bootstrap --scope @alexwilson/personal-website
     - name: Run Tests
       run: npx lerna run --scope @alexwilson/personal-website test
 

--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -31,13 +31,19 @@ jobs:
       id: cache-npm
       with:
         key: npm-${{ hashFiles('**/package-lock.json') }}
-        path: |
-          ~/.npm
+        path: ~/.npm
     - name: Install Dependencies
-      run: npm ci
+      run: |
+        npm ci --ignore-scripts
+        npx lerna bootstrap --ignore @alexwilson/personal-website
     - id: find-projects
       run: |
-        echo "##[set-output name=projects;]$(npx lerna list --json --all --loglevel silent | jq -rjc -n '.include |= inputs')"
+        echo "##[set-output name=projects;]$(     \
+          npx lerna list                          \
+            --json --all --loglevel silent        \
+            --ignore @alexwilson/personal-website \
+          | jq -rjc -n '.include |= inputs'       \
+        )"
 
   # Fetch dependencies and build Gatsby
   test:
@@ -57,10 +63,11 @@ jobs:
       id: cache-npm
       with:
         key: npm-${{ hashFiles('**/package-lock.json') }}
-        path: |
-          ~/.npm
+        path: ~/.npm
     - name: Install Dependencies
-      run: npm ci
+      run: |
+        npm ci --ignore-scripts
+        npx lerna bootstrap --ignore @alexwilson/personal-website
     - name: Test
       run: npx lerna run test --scope ${{ matrix.name }}
 
@@ -82,10 +89,11 @@ jobs:
       id: cache-npm
       with:
         key: npm-${{ hashFiles('**/package-lock.json') }}
-        path: |
-          ~/.npm
+        path: ~/.npm
     - name: Install Dependencies
-      run: npm ci
+      run: |
+        npm ci --ignore-scripts
+        npx lerna bootstrap --ignore @alexwilson/personal-website
     # @TODO: Remove this when Wrangler configuration is simpler
     # Wrangler is never cached as it's added to home directory
     # https://github.com/cloudflare/wrangler/issues/1286


### PR DESCRIPTION
# What?
Following the work in #744 & #1143, split Gatsby from monorepo CI

# Why?
Gatsby tends to have the longest build times, and including its dependencies *really* slows down the monorepo CI pipeline.