### PR TITLE
Force Gatsby to use local packages

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Dependencies
       run: |
         npm ci --ignore-scripts
-        npx lerna bootstrap --scope @alexwilson/personal-website
+        npx lerna bootstrap --force-local --include-dependencies --scope @alexwilson/personal-website
     - name: Build
       run: npx lerna run --scope @alexwilson/personal-website build
       env:
@@ -87,7 +87,7 @@ jobs:
     - name: Install Dependencies
       run: |
         npm ci --ignore-scripts
-        npx lerna bootstrap --scope @alexwilson/personal-website
+        npx lerna bootstrap --force-local --include-dependencies --scope @alexwilson/personal-website
     - name: Run Tests
       run: npx lerna run --scope @alexwilson/personal-website test
 


### PR DESCRIPTION
# What?
Force Gatsby to use local packages, and bring local dependencies in-scope.

# Why?
Ever since scoping the lerna calls, Gatsby hasn't had access to the correct version of the `@alexwilson/content` package which resulted in failing builds.  This brings that package back in scope, and also requires that local packages are always used in preference to externally published ones.