### PR TITLE
Run Actions on PR events

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1,24 +1,18 @@
+name: Build, Test and Deploy Gatsby
 on:
   push:
-    # Respond to a push event on every brannch other than Github Pages.
-    branches:
-      - '!gh-pages'
-      - '*'
-
   pull_request:
-    branches:
-      - '!gh-pages'
 
   # Scheduled build so pipeline failures are noticed quicker.
   schedule:
     - cron: '30 4 * * 3,6'
 
-name: Build, Test and Deploy Gatsby
 jobs:
   # Fetch dependencies and build Gatsby
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/gh-pages'
     steps:
     - name: Checkout
       uses: actions/checkout@master

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,14 @@
 name: Build, Test and Deploy Gatsby
 on:
-  push:
   pull_request:
-
-  # Scheduled build so pipeline failures are noticed quicker.
+  push:
+    branches:
+      - master
+      - main
   schedule:
+    # Scheduled build so pipeline failures are noticed quicker.
     - cron: '30 4 * * 3,6'
+
 
 jobs:
   # Fetch dependencies and build Gatsby

--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -1,19 +1,13 @@
+name: Monorepo Deploy Pipeline
 on:
+  # Push events & PRs.
   push:
-    # Respond to a push event on every brannch other than Github Pages.
-    branches:
-      - '!gh-pages'
-      - '*'
-
   pull_request:
-    branches:
-      - '!gh-pages'
 
   # Scheduled build so pipeline failures are noticed quicker.
   schedule:
     - cron: '30 4 * * 3,6'
 
-name: Monorepo Deploy Pipeline
 jobs:
 
   prepare:

--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -1,11 +1,12 @@
 name: Monorepo Deploy Pipeline
 on:
-  # Push events & PRs.
-  push:
   pull_request:
-
-  # Scheduled build so pipeline failures are noticed quicker.
+  push:
+    branches:
+      - master
+      - main
   schedule:
+    # Scheduled build so pipeline failures are noticed quicker.
     - cron: '30 4 * * 3,6'
 
 jobs:


### PR DESCRIPTION
# What?
Simplify `on:` directive in Github Action configuration so that `pull_request` events can kick off builds.

# Why?
Bots such as Dependabot don't fire a test run meaning that it's hard to merge PRs with any real confidence.  Also this has been rather awkward to read.