### PR TITLE
chore: Move dependencies to `pull_request_target`

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,5 +1,5 @@
 name: Automatically Update Dependencies
-on: pull_request
+on: pull_request_target
 
 jobs:
   auto-update-dependencies:


### PR DESCRIPTION
# Why?
Github recently released a security update which sandboxes actions preventing them from having read-access to secrets in `pull_request` events.  The post in question is here: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

Both of these actions are "safe" in that they do not run unknown 3rd party code.

# What?
Move from `pull_request` (which is sandboxed) to `pull_request_target`.