### PR TITLE
feat: Auto-update dependencies when labelled

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,11 +1,13 @@
 name: Automatically Update Dependencies
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   auto-update-dependencies:
     name: approve and merge for dependency PRs
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
     - uses: hmarr/auto-approve-action@v2.0.0
       with:

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
-    - uses: hmarr/auto-approve-action@v2.0.0
+    - uses: hmarr/auto-approve-action@bca9db08da72b576ae3273e776e7ccf3f0a36e12
       with:
         github-token: "${{ secrets.PR_GH_TOKEN }}"
     - name: Enable Github Automerge


### PR DESCRIPTION
# Why?
Following on from #1518 - GitHub have updated how permissions in GitHub actions work.  Unfortunately this means that Dependabot workflows no longer have access to any read/write secrets.

# What?
Update to run in the `pull_request_target` scope, for when a label has been added (or removed).

This PR also updates the condition to check the pull_request payload for its original creator instead of relying on the individual actor - so that it is easier to debug!