### PR TITLE
feat: Add GitHub content-update repository dispatch

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     # Scheduled build so pipeline failures are noticed quicker.
     - cron: '30 4 * * 3,6'
+  repository_dispatch:
+    types:
+      - content-update
 
 
 jobs:


### PR DESCRIPTION
# Why?
To enable publishing when changes are made to other systems (and via API).

# What?
Subscribe to the `content-update` `repository_dispatch` event.
