### PR TITLE
feat(ci): Only run pipeline for updated packages

### DIFF
--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -7,7 +7,7 @@ on:
       - main
   schedule:
     # Scheduled build so pipeline failures are noticed quicker.
-    - cron: '30 4 * * 3,6'
+    - cron: '30 4 * * 1,3,5,0'
 
 jobs:
 
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
       with:
-        fetch-depth: 0
+        fetch-depth: 2
     - uses: actions/setup-node@master
     - name: Restore ~/npm & node_modules
       uses: actions/cache@master
@@ -32,13 +32,36 @@ jobs:
         npm ci --ignore-scripts
         npx lerna bootstrap --ignore @alexwilson/personal-website
     - id: find-projects
+      name: Find affected projects
       run: |
+        lerna_args=()
+        lerna_args+=('--all')
+        lerna_args+=('--loglevel silent')
+        lerna_args+=('--ignore @alexwilson/personal-website')
+
+        # Lerna attempts to find any changed packages since the last update...
+        if [[ $(npx lerna list ${lerna_args[@]} --since $MAIN_BRANCH | head -c1 | wc -c) -ne 0 ]]; then
+
+          # If there are some, and this isn't a scheduled build, we prefer to test
+          # and deploy only the updated packages.
+          # Scheduled builds always update & deploy everything.
+          if [ $GITHUB_EVENT_NAME != 'schedule' ]; then
+            lerna_args+=("--since $MAIN_BRANCH")
+          fi
+        fi
+
+        # Finally - we're ready to output as JSON for JQ to consume
+        lerna_args+=('--json')
+
+        echo "Github Event: $GITHUB_EVENT_NAME"
+        echo "$ npx lerna list ${lerna_args[@]}"
+        echo "$ jq ${jq_args[@]}"
         echo "##[set-output name=projects;]$(     \
-          npx lerna list                          \
-            --json --all --loglevel silent        \
-            --ignore @alexwilson/personal-website \
+          npx lerna list ${lerna_args[@]}         \
           | jq -rjc -n '.include |= inputs'       \
         )"
+      env:
+        MAIN_BRANCH: "master"
 
   # Fetch dependencies and build Gatsby
   test:


### PR DESCRIPTION
# Why?
In an effort to improve CI performance & improve the visibility of scheduled builds...

# What?
Test & deploy only the packages which have been updated since the last build.
