### PR TITLE
feat: Use graphQL for Netlify CMs

### DIFF
--- a/packages/cms/client/config.yml
+++ b/packages/cms/client/config.yml
@@ -9,6 +9,7 @@ backend:
   branch: main
   base_url: https://alexwilson.tech/
   auth_endpoint: "auth/cms"
+  use_graphql: true
 
 # We serialize this to JavaScript on deploys instead of dynamically fetching.
 load_config_file: false


### PR DESCRIPTION
# Why?
For whatever reason I'm still frequently hit by GitHub rate limits (there's probably something accessing my account, as me, a lot...) which results in sign-outs in Netlify CMS.

# What?
Enable experimental graphQL-mode for Netlify CMS