### PR TITLE
Remove full-domain only

### DIFF
--- a/packages/gatsby-remark-rewrite-images/rewrite-images.js
+++ b/packages/gatsby-remark-rewrite-images/rewrite-images.js
@@ -1,6 +1,6 @@
 const mediaDomain = 'https://media.alexwilson.tech/'
 const rewriteImage = (src) => src
-    .replace(/^https?\:\/\/alexwilson.tech\//, '')
+    .replace(/^https?\:\/\/alexwilson.tech\//, '/')
     .replace(/^\/pictures\//, mediaDomain)
 
 module.exports = rewriteImage


### PR DESCRIPTION
# Why?
I accidentally broke images by removing the trailing slash which allows the pictures path to be replaced.

# What?
Replace `https://alexwilson.tech/` with `/`

# Anything else?
This library probably needs some tests!