### PR TITLE
chore(cms): Change label prefix to status

### DIFF
--- a/packages/cms/client/config.yml
+++ b/packages/cms/client/config.yml
@@ -10,6 +10,7 @@ backend:
   base_url: https://alexwilson.tech/
   auth_endpoint: "auth/cms"
   use_graphql: true
+  cms_label_prefix: status/
 
 # We serialize this to JavaScript on deploys instead of dynamically fetching.
 load_config_file: false


### PR DESCRIPTION
# Why?
Trying to make it easier to identify the status of an item in the editorial workflow of Netlify CMS.

# What?
Change the status prefix from the default of `netlify-cms/` to `status/`!
