### PR TITLE
chore(gh-pages): Migrate to octokit

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -114,6 +114,10 @@ jobs:
       with:
         args: public
     - name: Trigger a Pages Update
-      run: |
-        curl -sS -X POST -H "Authorization: Bearer ${{ secrets.PAGES_GH_TOKEN }}" \
-        https://api.github.com/repos/${{ github.repository }}/pages/builds
+      uses: octokit/request-action@v2.x
+      with:
+        route: POST /repos/{owner}/{repo}/dispatches
+        owner: ${{ github.repository_owner }}
+        repo: ${{ github.repository }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAGES_GH_TOKEN }}


### PR DESCRIPTION
# Why?
To improve maintainability I'm trying to remove some of the more esoteric parts of the deployment pipeline.

# What?
Migrate `pages update` to `octokit/request-action@v2.x`. 