### PR TITLE
CMS: Temporarily alias uuid/v4 to an ES module

### DIFF
--- a/packages/cms/lib/uuid-v4.js
+++ b/packages/cms/lib/uuid-v4.js
@@ -1,0 +1,2 @@
+import {v4} from 'uuid'
+export default v4

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -30,5 +30,8 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "uuid": "^8.3.2"
+  },
+  "alias": {
+    "uuid/v4": "./lib/uuid-v4"
   }
 }


### PR DESCRIPTION
# Why?
`netlify-cms` depends on an rather old version of `uuid` which in results in a module resolution collision whenever attempting to use a newer version of `uuid` (i.e. for ESM builds)

# What?
Alias the now-discontinued `uuid/v4` to a module which exports `v4` UUID generation, until Netlify update this dependency.

# Anything else?
See: https://github.com/netlify/netlify-cms/pull/4270
