### PR TITLE
fix(cms): Disable parcel scope-hoisting as it does not work!

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "Netlify-CMS distribution",
   "scripts": {
-    "build": "parcel build ./client/index.html --public-url=https://static.alexwilson.tech/cms/ --detailed-report --no-source-maps --log-level=verbose",
+    "build": "parcel build ./client/index.html --public-url=https://static.alexwilson.tech/cms/ --detailed-report --no-source-maps --no-scope-hoist --log-level=verbose",
     "deploy:client": "aws s3 sync --acl=public-read --delete ./dist/ s3://alex-static-assets/cms/",
     "deploy:worker": "wrangler publish",
     "deploy": "npm-run-all build deploy:*",
-    "test": "parcel build ./client/index.html --detailed-report --log-level=verbose --no-source-maps --no-optimize --no-scope-hoist",
+    "test": "npm-run-all build",
     "start": "parcel serve ./client/index.html --log-level=verbose"
   },
   "author": "Alex Wilson <alex@alexwilson.tech>",


### PR DESCRIPTION
# Why?
ParcelJS 2.0 introduces scope-hoisting as a default option.  When it is enabled , the `cms` project builds successfully HOWEVER those builds then all fail with `parcelRequire is not defined`

# What?
Disable scope-hoisting.

# Anything else?
See: 
- https://github.com/parcel-bundler/parcel/issues/1996 
- https://github.com/parcel-bundler/parcel/issues/5973
- https://github.com/parcel-bundler/parcel/issues/5814
