### PR TITLE
chore(ci): Remove gh-pages rebuild request

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -117,11 +117,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PAGES_GH_TOKEN }}
       with:
         args: public
-    - name: Trigger a Pages Update
-      uses: octokit/request-action@v2.x
-      with:
-        route: POST /repos/{owner}/{repo}/pages/builds
-        owner: ${{ github.event.repository.owner.login }}
-        repo: ${{ github.event.repository.name }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.PAGES_GH_TOKEN }}


### PR DESCRIPTION
# Why?
Previously GitHub Pages deployments couldn't be triggered by a GitHub action, and so a manual API call to the gh-pages API was required.  For the past few weeks that no longer seems to be the case, and I've noticed that regularly there's 2x gh-page deployments happening.

# What?
Remove the gh-page deployment creation API call from the `build-test-deploy` workflow.

# Anything else?
Yeah - monitor for this for a bit JUST TO BE SURE?
