### PR TITLE
fix(github-pages): Add workspace as safe directory

### DIFF
--- a/.github/actions/github-pages/entrypoint.sh
+++ b/.github/actions/github-pages/entrypoint.sh
@@ -6,6 +6,9 @@ cd $*
 echo "Deploying ${GITHUB_SHA} to GitHub Pages"
 REPOSITORY="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
+git config --global init.defaultBranch main
+git config --global --add safe.directory "{$GITHUB_WORKSPACE}"
+
 git init
 git remote add origin $REPOSITORY
 git checkout -b gh-pages


### PR DESCRIPTION
# Why?
Today pushes to GitHub Pages fail as the GitHub workspace is owned by another user to the one running git, as seen in: https://github.com/alexwilson/frontend/runs/6138055046?check_suite_focus=true

# What?
Add the current workspace to the safe directory allowlist.
