### PR TITLE
fix(github-pages): Use PWD instead of workspace

### DIFF
--- a/.github/actions/github-pages/entrypoint.sh
+++ b/.github/actions/github-pages/entrypoint.sh
@@ -7,7 +7,7 @@ echo "Deploying ${GITHUB_SHA} to GitHub Pages"
 REPOSITORY="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
 git config --global init.defaultBranch main
-git config --global --add safe.directory "{$GITHUB_WORKSPACE}"
+git config --global --add safe.directory "{$PWD}"
 
 git init
 git remote add origin $REPOSITORY


### PR DESCRIPTION
# Why? 
Following https://github.com/alexwilson/frontend/pull/2072 the GitHub Workspace is correctly added to the allow list, however this action navigates to another directory which is not necessarily the workspace.

# What?
Add `$PWD` to Git's `safe.directory` allow list instead of `$GITHUB_WORKSPACE`.