### PR TITLE
fix(rss): Construct absolute links w/ URL API

### DIFF
--- a/services/personal-website/gatsby-config.js
+++ b/services/personal-website/gatsby-config.js
@@ -120,14 +120,15 @@ module.exports = {
           {
             serialize: ({ query: { site, allMarkdownRemark } }) => {
               return allMarkdownRemark.edges.map(edge => {
-                const url = `${site.siteMetadata.siteUrl}${edge.node.fields.slug}`.replace(/\/\//g, '/');
-                return Object.assign({}, edge.node.frontmatter, {
+                const url = (new URL(edge.node.fields.slug, site.siteMetadata.siteUrl)).toString()
+                return {
+                  title: edge.node.frontmatter.title,
                   description: edge.node.excerpt,
                   date: edge.node.frontmatter.date,
-                  url,
+                  url: url,
                   guid: url,
                   custom_elements: [{ "content:encoded": edge.node.html }],
-                })
+                }
               })
             },
             query: `


### PR DESCRIPTION
# Why?
Links in the RSS feed are currently invalid, breaking the feed for several clients!

# What?
Logic designed to remove a double `/` in the URL also rewrites the scheme.  e.g. `https://alexwilson.tech/` becomes `https:/alexwilson.tech`.  This PR updates this link creation to use the (now-available) URL API.
The URL constructor [applies a relative link to an origin](https://nodejs.org/api/url.html#new-urlinput-base) which is perfect for this use-case.

# Anything else?
As this updates the GUID - this will probably confuse some RSS clients, so I'll include a warning in weeknotes.

If you're reading this from there, SORRY!
