### PR TITLE
Responsive Navigation

### DIFF
--- a/components/legacy-components/src/header/header.js
+++ b/components/legacy-components/src/header/header.js
@@ -7,8 +7,10 @@ import fetch from "isomorphic-fetch"
 const NavItemFactory = (linkImplementation) => {
   const LinkImplementation = (linkImplementation) ? linkImplementation : Link;
   const NavItem = ({url, rel, active, children}) => {
+    const classList = ["alex-header__nav-item"]
+    if (active) classList.push("alex-header__nav-item--active")
     return (
-    <li className={`alex-header__nav-item ${active ? "alex-header__nav-item--active" : undefined}`}>
+    <li className={classList.join(' ')}>
       <LinkImplementation rel={rel} to={url}>{children}</LinkImplementation>
     </li>
     );
@@ -91,7 +93,8 @@ class Header extends Component {
     this.headerNav = React.createRef()
     this.state = {
       backgroundImage: props.image, // Is this bad?
-      backgroundImageLoaded: false
+      backgroundImageLoaded: false,
+      navigationExpanded: false
     }
   }
 
@@ -136,10 +139,22 @@ class Header extends Component {
 
 
           <nav>
-              <ul className="alex-header__nav" id="menu" ref={this.headerNav}>
+              <a
+                className="alex-header__menu-button" role="button"
+                aria-pressed={this.state.navigationExpanded}
+                onClick={() => {this.setState({
+                    navigationExpanded: !this.state.navigationExpanded
+                  })
+                }}
+              >
+                <span></span>
+                <span></span>
+                <span></span>
+              </a>
+              <ul className="alex-header__nav" id="menu" ref={this.headerNav} aria-expanded={this.state.navigationExpanded}>
                 <this.navItem url="/" active={pathname === "/"}>Home</this.navItem>
                 <this.navItem url="/about-me/" active={pathname.startsWith("/about-me/")}>About Me</this.navItem>
-                <this.navItem url="/blog/" active={pathname.startsWith("/blog/")}>Writing</this.navItem>
+                <this.navItem url="/blog/" active={pathname.startsWith("/blog/")||pathname.startsWith("/content/")}>Writing</this.navItem>
                 <this.navItem url="/talks/" active={pathname.startsWith("/talks/")}>Speaking</this.navItem>
                 <this.navItem url="/consultancy/" active={pathname.startsWith("/consultancy/")}>Hire Me</this.navItem>
 

--- a/components/legacy-components/src/header/header.js
+++ b/components/legacy-components/src/header/header.js
@@ -77,7 +77,7 @@ class HeaderImage extends Component {
           className={`alex-header-image__main`}
           src={this.state.preloadedImage}
           style={{
-            opacity: this.state.preloadedImage !== undefined ? 1 : 0
+            opacity: this.props.blur !== true && this.state.preloadedImage !== undefined ? 1 : 0
           }}/>
       </picture>
     </div>
@@ -128,7 +128,7 @@ class Header extends Component {
     return (
       <header role="banner" className={`alex-header`} ref={this.header}>
 
-        <HeaderImage src={this.state.backgroundImage}/>
+        <HeaderImage src={this.state.backgroundImage} blur={this.state.navigationExpanded} />
 
         <div className="alex-header--container">
 
@@ -138,7 +138,7 @@ class Header extends Component {
           </div>
 
 
-          <nav>
+          <nav ref={this.headerNav} class="alex-header__nav--container">
               <a
                 className="alex-header__menu-button" role="button"
                 aria-pressed={this.state.navigationExpanded}
@@ -151,7 +151,7 @@ class Header extends Component {
                 <span></span>
                 <span></span>
               </a>
-              <ul className="alex-header__nav" id="menu" ref={this.headerNav} aria-expanded={this.state.navigationExpanded}>
+              <ul className="alex-header__nav" id="menu" aria-expanded={this.state.navigationExpanded}>
                 <this.navItem url="/" active={pathname === "/"}>Home</this.navItem>
                 <this.navItem url="/about-me/" active={pathname.startsWith("/about-me/")}>About Me</this.navItem>
                 <this.navItem url="/blog/" active={pathname.startsWith("/blog/")||pathname.startsWith("/content/")}>Writing</this.navItem>

--- a/components/legacy-components/src/header/header.scss
+++ b/components/legacy-components/src/header/header.scss
@@ -22,6 +22,58 @@
     padding: 0;
     list-style: none;
     display: flex;
+
+    @include media("<phone") {
+      &[aria-expanded="false"] {
+        display: none;
+        visibility: collapse;
+        height: 0;
+        overflow: hidden;
+      }
+      flex-wrap: wrap;
+      justify-items: center;
+      background-color: $header-link-background;
+      height: auto;
+      transition: all 0.1s ease-in;
+    }
+  }
+
+  &__menu-button {
+    @include media(">phone") {
+      display: none;
+      visibility: hidden;
+    }
+
+    position: relative;
+    display: block;
+    margin-bottom: 1em;
+    border: 0;
+    background-color: transparent;
+    cursor: pointer;
+    width: 1.5em;
+    height: 1.5em;
+
+    > span {
+      display: block;
+      background-color: white;
+      margin: 5px 0;
+      height: 2px;
+      width: 1.5em;
+      transition: all 0.1s ease-in;
+    }
+
+    &[aria-pressed="true"] {
+      margin-bottom: 0;
+      > span:nth-child(1) {
+        transform: translateY(7px) rotate(45deg);
+      }
+      > span:nth-child(2) {
+        opacity: 0;
+      }
+      > span:nth-child(3) {
+        transform: translateY(-7px) rotate(-45deg);
+      }
+    }
   }
 
   &__nav-item {

--- a/components/legacy-components/src/header/header.scss
+++ b/components/legacy-components/src/header/header.scss
@@ -18,23 +18,34 @@
   overflow: hidden;
 
   &__nav {
+
+    &--container {
+      @include media("<phone") {
+        padding-top: 1em;
+        padding-bottom: 1em;
+      }
+    }
+
     margin: 0;
     padding: 0;
     list-style: none;
     display: flex;
 
     @include media("<phone") {
-      &[aria-expanded="false"] {
-        display: none;
-        visibility: collapse;
-        height: 0;
-        overflow: hidden;
-      }
       flex-wrap: wrap;
       justify-items: center;
       background-color: $header-link-background;
-      height: auto;
-      transition: all 0.1s ease-in;
+      height: 100%;
+      transition: all 0.2s ease;
+      margin-left: 0;
+      
+      &[aria-expanded="false"] {
+        height: 0;
+        float: left;
+        visibility: hidden;
+        overflow: hidden;
+        margin-left: -150%;
+      }
     }
   }
 
@@ -46,7 +57,6 @@
 
     position: relative;
     display: block;
-    margin-bottom: 1em;
     border: 0;
     background-color: transparent;
     cursor: pointer;
@@ -55,15 +65,14 @@
 
     > span {
       display: block;
-      background-color: white;
+      background-color: $white;
       margin: 5px 0;
       height: 2px;
       width: 1.5em;
-      transition: all 0.1s ease-in;
+      transition: all 0.2s ease-in;
     }
 
     &[aria-pressed="true"] {
-      margin-bottom: 0;
       > span:nth-child(1) {
         transform: translateY(7px) rotate(45deg);
       }
@@ -129,7 +138,6 @@
 
     color: white;
     font-weight: 500;
-    // font-family: Overpass;
 
     padding: 1em 0 0 0;
     @include media(">tablet") {

--- a/components/legacy-components/src/util-palette/palette.scss
+++ b/components/legacy-components/src/util-palette/palette.scss
@@ -35,7 +35,7 @@
  $header-background: rgba(80, 80, 80, 0.95);
  $header-link: $blue;
  $header-link-active: $blue;
- $header-link-background: rgba($grey-5, 0.5);
+ $header-link-background: rgba($grey-5, 0.7);
 
  // Extracted from Bootstrap-Sass
  // https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss


### PR DESCRIPTION
# Why?
Navigation currently doesn't fit well on smaller screens, and links collapse together making it hard to read.

<img width="399" alt="image" src="https://user-images.githubusercontent.com/440052/173232264-8c3699da-3eb0-4de1-83bc-b2b43d8f883b.png">

# What?
Added new aria-state `expanded` to the navigation, hidden by default.  When active it applies a `flex-wrap` and a new background colour to improve visibility.  To control this aria-state I have added a button controlling navigation `aria-expanded` w/ basic CSS animation.

<img width="424" alt="image" src="https://user-images.githubusercontent.com/440052/173232285-8c3ee10c-6faf-45c1-80f2-0a01cd5499bf.png">
<img width="433" alt="image" src="https://user-images.githubusercontent.com/440052/173232274-878c1c17-31dc-4417-8f07-19ac7bd5b01a.png">

# Anything else?
This also updates the active state for `Writing` to be active for all content.  Ideally this should be somehow contextually aware beyond the URL path.
