### PR TITLE
Validate & fix Feed

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -87,10 +87,34 @@ jobs:
     - name: Run Tests
       run: npx lerna run --scope @alexwilson/personal-website test
 
+  validate-feed:
+    name: "Validate feed"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: w3c/feedvalidator
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Download Website Artefact
+        uses: actions/download-artifact@v1
+        with:
+          name: site-artefact
+          path: public
+      - name: "Validate Artefacted Feed"
+        run: |
+          python src/demo.py public/feed.xml
+
   # Deploy to Github Pages environment
   deploy-ghpages:
     name: Deploy Gatsby to Github Pages
-    needs: test
+    needs: [test, validate-feed]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -107,6 +107,9 @@ jobs:
         with:
           name: site-artefact
           path: public
+      - name: "Update feed location for local testing"
+        run: |
+          sed -i 's|https://alexwilson.tech/feed.xml|http://www.feedvalidator.org/public/feed.xml|g' public/feed.xml
       - name: "Validate Artefacted Feed"
         run: |
           python src/demo.py public/feed.xml

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -109,6 +109,7 @@ jobs:
           path: public
       - name: "Update feed location for local testing"
         run: |
+          # Replace references to feed IRI with feedvalidator.org which W3C validator uses as a mock origin.
           sed -i 's|https://alexwilson.tech/feed.xml|http://www.feedvalidator.org/public/feed.xml|g' public/feed.xml
       - name: "Validate Artefacted Feed"
         run: |

--- a/services/personal-website/gatsby-config.js
+++ b/services/personal-website/gatsby-config.js
@@ -122,13 +122,15 @@ module.exports = {
           {
             serialize: ({ query: { site, allMarkdownRemark } }) => {
               return allMarkdownRemark.edges.map(edge => {
-                const url = (new URL(edge.node.fields.slug, site.siteMetadata.siteUrl)).toString()
+                const url = new URL(edge.node.fields.slug, site.siteMetadata.siteUrl)
+                const guid = url.toString()
+                url.searchParams.append('utm_source', 'feed')
                 return {
                   title: edge.node.frontmatter.title,
                   description: edge.node.snippet,
                   date: edge.node.frontmatter.date,
-                  url: url,
-                  guid: url,
+                  url: url.toString(),
+                  guid,
                   custom_elements: [{
                     "content:encoded": sanitizeHtml(
                       `${edge.node.preview}<br /><a href="${url}">Read the full article...</a>`,
@@ -140,7 +142,7 @@ module.exports = {
                     "atom:link": {
                       "_attr": {
                         "rel": "self",
-                        "href": url,
+                        "href": url.toString(),
                         "type": "text/html"
                       }
                     }

--- a/services/personal-website/gatsby-config.js
+++ b/services/personal-website/gatsby-config.js
@@ -1,3 +1,5 @@
+const sanitizeHtml = require("sanitize-html")
+
 module.exports = {
   siteMetadata: {
     title: `Alex Wilson`,
@@ -128,7 +130,13 @@ module.exports = {
                   url: url,
                   guid: url,
                   custom_elements: [{
-                    "content:encoded": `${edge.node.preview}<br /><a href="${url}">Continue reading...</a>`,
+                    "content:encoded": sanitizeHtml(
+                      `${edge.node.preview}<br /><a href="${url}">Read the full article...</a>`,
+                      {
+                        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+                        allowedAttributes: false
+                      }
+                    ),
                     "atom:link": {
                       "_attr": {
                         "rel": "self",

--- a/services/personal-website/gatsby-config.js
+++ b/services/personal-website/gatsby-config.js
@@ -123,23 +123,33 @@ module.exports = {
                 const url = (new URL(edge.node.fields.slug, site.siteMetadata.siteUrl)).toString()
                 return {
                   title: edge.node.frontmatter.title,
-                  description: edge.node.excerpt,
+                  description: edge.node.snippet,
                   date: edge.node.frontmatter.date,
                   url: url,
                   guid: url,
-                  custom_elements: [{ "content:encoded": edge.node.html }],
+                  custom_elements: [{
+                    "content:encoded": `${edge.node.preview}<br /><a href="${url}">Continue reading...</a>`,
+                    "atom:link": {
+                      "_attr": {
+                        "rel": "self",
+                        "href": url,
+                        "type": "text/html"
+                      }
+                    }
+                  }],
                 }
               })
             },
             query: `
               {
                 allMarkdownRemark(
+                  limit: 10,
                   sort: { order: DESC, fields: [frontmatter___date] },
                 ) {
                   edges {
                     node {
-                      excerpt
-                      html
+                      snippet: excerpt(pruneLength: 220, format: PLAIN)
+                      preview: excerpt(pruneLength: 600, format: HTML)
                       fields { slug }
                       frontmatter {
                         title
@@ -151,8 +161,24 @@ module.exports = {
               }
             `,
             output: "/feed.xml",
-            title: "Alex Wilson's Writing",
-            match: "^/blog/",
+            title: "Alex Wilson's writing",
+            description: "Alex on engineering, products & everything in-between",
+            match: "^/content/",
+            ttl: 360,
+            site_url: "https://alexwilson.tech/",
+            generator: "alexwilson.tech",
+            custom_namespaces: {
+              "atom": "http://www.w3.org/2005/Atom"
+            },
+            custom_elements: [{
+              "atom:link": {
+                "_attr": {
+                  "rel": "self",
+                  "href": "https://alexwilson.tech/feed.xml",
+                  "type": "application/rss+xml"
+                }
+              }
+            }]
           },
         ],
       },


### PR DESCRIPTION
# Why?
Today the feed isn't validated allowing bugs (like #2105) to affect a significant number of readers.

# What?
Using `github.com/w3c/feedvalidator`, start validating the RSS feed in continuous integration, and fix some of the top errors.

This includes some breaking changes to feeds such as truncating articles & stripping out invalid tags, however GUIDs will not change again.

# Anything else?
This workflow may prove useful when extracting feed functionality, and I'd like to separate it as its own GitHub action.