### PR TITLE
Enforce maximum width in article grid with percentage units

### DIFF
--- a/services/personal-website/src/scss/pages/_article.scss
+++ b/services/personal-website/src/scss/pages/_article.scss
@@ -13,13 +13,13 @@
       "Aside";
 
     @include media(">tablet") {
-      grid-template-columns: 8fr 2fr;
+      grid-template-columns: 80% 20%;
       grid-template-areas:
         "Headline Headline"
         "Main Aside";
     }
     @include media(">desktop") {
-      grid-template-columns: 7fr 3fr;
+      grid-template-columns: 70% 30%;
       grid-template-areas:
         "Headline Headline"
         "Main Aside";
@@ -34,7 +34,6 @@
 
 .alex-article__main {
     grid-area: Main;
-    max-width: $max-width;
 }
 
 .alex-article__aside {


### PR DESCRIPTION
# Why?
Frame units deal with available space, and so when I'm using code blocks these can expand across the side of the page.

# What?
Move from frame units to percentages for the article page.