### PR TITLE
fix(article): Apply 100% max-width

### DIFF
--- a/components/legacy-components/src/util-grid/grid.scss
+++ b/components/legacy-components/src/util-grid/grid.scss
@@ -1,9 +1,9 @@
 @use "sass:math";
 
-$max-width: 1020px;
+$max-width: 1200px;
 $max-columns: 10;
 
-@mixin alex-container($max-width: 1000px) {
+@mixin alex-container($max-width: 1200px) {
     max-width: $max-width;
     width: 90%;
     margin: 0 auto;

--- a/services/personal-website/src/scss/pages/_article.scss
+++ b/services/personal-website/src/scss/pages/_article.scss
@@ -1,10 +1,11 @@
 @import "~@alexwilson/legacy-components/src/util-palette/palette";
 
 .alex-article {
-    @include alex-container($max-width: 1020px);
+    @include alex-container();
     @include alex-row;
+
     display: grid;
-    grid-template-columns: auto;
+    grid-template-columns: 100%;
     grid-template-rows: auto;
     gap: 0 2em;
     grid-template-areas:
@@ -20,9 +21,13 @@
     }
     @include media(">desktop") {
       grid-template-columns: 70% 30%;
+      gap: 0 3em;
       grid-template-areas:
         "Headline Headline"
         "Main Aside";
+    }
+    @include media(">desktop") {
+      gap: 0 4em;
     }
 }
 
@@ -157,4 +162,3 @@
     list-style-image: url("/svg/twitter.svg");
   }
 }
-


### PR DESCRIPTION
# Why?
In #2108 I updated FR to %, but missed the top-level setting.  Meaning there was no max-width for phones!

# What?
Correct the %, and unify grid width.  This fixes responsive behaviour for all articles.
