### PR TITLE
WIP: Update graphQL schema

### DIFF
--- a/components/legacy-components/src/article-card/article-card.js
+++ b/components/legacy-components/src/article-card/article-card.js
@@ -5,7 +5,7 @@ import ResponsiveImage from '../responsive-image'
 
 export default function articleCard({article, withBody = true, withImage = true, withDate = true}) {
 
-  const date = new Date(article.fields.date)
+  const date = new Date(article.date)
 
   return (
     <div className="alex-card">
@@ -13,13 +13,13 @@ export default function articleCard({article, withBody = true, withImage = true,
       <div className="alex-card__content--container">
 
         <div className="alex-card__title">
-          <h3><Link to={ article.fields.slug }>{ article.frontmatter.title }</Link></h3>
+          <h3><Link to={ article.slug }>{ article.title }</Link></h3>
         </div>
 
         {(withBody !== false) ?
           <div className="alex-card__abstract">
           <p>
-            { article.excerpt }
+            { article.content.excerpt }
           </p>
         </div>
         :null}
@@ -34,9 +34,9 @@ export default function articleCard({article, withBody = true, withImage = true,
 
       </div>
 
-      {(withImage !== false && article.fields.thumbnail) ?
+      {(withImage !== false && article.image && article.image.thumbnail) ?
         <div className="alex-card__image">
-          <ResponsiveImage src={ article.fields.thumbnail } width={ 400 } />
+          <ResponsiveImage src={ article.image.thumbnail } width={ 400 } />
         </div>
       :null}
 

--- a/services/personal-website/gatsby-node.js
+++ b/services/personal-website/gatsby-node.js
@@ -104,19 +104,18 @@ exports.createPages = async ({ graphql, actions }) => {
       topics: allTopic {
         nodes {
           topicId
+          topic
           slug
         }
       }
     }
   `)
 
-  console.log("asdf", data.content.length)
-
   data.content.nodes.forEach((node) => {
     // Create a page
     createPage({
       path: node.slug,
-      component: node.type === "talk" ? path.resolve(`./src/templates/talk.js`) : path.resolve(`./src/templates/article.js`),
+      component: node.type === "talks" ? path.resolve(`./src/templates/talk.js`) : path.resolve(`./src/templates/article.js`),
       context: {
         contentId: node.contentId
       }

--- a/services/personal-website/package-lock.json
+++ b/services/personal-website/package-lock.json
@@ -38,7 +38,8 @@
 				"react": "^17.0.1",
 				"react-dom": "^17.0.1",
 				"react-helmet": "^6.0.0",
-				"sass": "^1.45.0"
+				"sass": "^1.45.0",
+				"uuid": "^8.3.2"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.9.0",
@@ -4731,9 +4732,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4749,6 +4750,18 @@
 			"dependencies": {
 				"acorn": "^7.1.1",
 				"acorn-walk": "^7.1.1"
+			}
+		},
+		"node_modules/acorn-globals/node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/acorn-import-assertions": {
@@ -5834,6 +5847,15 @@
 			"resolved": "https://registry.npmjs.org/better-queue-memory/-/better-queue-memory-1.0.4.tgz",
 			"integrity": "sha512-SWg5wFIShYffEmJpI6LgbL8/3Dqhku7xI1oEiy6FroP9DbcZlG0ZDjxvPdP9t7hTGW40IpIcC6zVoGT1oxjOuA=="
 		},
+		"node_modules/better-queue/node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
 		"node_modules/big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -6031,6 +6053,14 @@
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/boxen/node_modules/type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 			"engines": {
 				"node": ">=8"
 			}
@@ -9368,6 +9398,17 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
+		"node_modules/espree/node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -10873,6 +10914,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gatsby-cli/node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
 		"node_modules/gatsby-cli/node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -11221,6 +11271,15 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
 			"integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
 		},
+		"node_modules/gatsby-plugin-sharp/node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
 		"node_modules/gatsby-plugin-sitemap": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-5.4.0.tgz",
@@ -11434,6 +11493,15 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
 			"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+		},
+		"node_modules/gatsby-recipes/node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
 		},
 		"node_modules/gatsby-recipes/node_modules/webidl-conversions": {
 			"version": "3.0.1",
@@ -11996,14 +12064,6 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-		},
-		"node_modules/gatsby/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
 		},
 		"node_modules/gatsby/node_modules/webidl-conversions": {
 			"version": "3.0.1",
@@ -12734,6 +12794,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/hasha/node_modules/type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/hast-to-hyperscript": {
@@ -16459,18 +16527,6 @@
 				"canvas": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/jsdom/node_modules/acorn": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-			"integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-			"dev": true,
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/jsdom/node_modules/form-data": {
@@ -23438,11 +23494,16 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+			"optional": true,
+			"peer": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/type-is": {
@@ -23473,6 +23534,19 @@
 			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
 			"dependencies": {
 				"is-typedarray": "^1.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -24141,12 +24215,11 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"bin": {
-				"uuid": "bin/uuid"
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/v8-compile-cache": {
@@ -24446,17 +24519,6 @@
 			"integrity": "sha512-RXQXioY6MhzM4CNQwmBwKXYgBs6ulaiQ8bkNQEl2J6Z+V+s7lgl/wGvaI/I0dLnYKB8cKsxQc17QOAVIphPLDw==",
 			"dependencies": {
 				"debug": "^3.0.0"
-			}
-		},
-		"node_modules/webpack/node_modules/acorn": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-			"integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/webpack/node_modules/glob-to-regexp": {
@@ -28748,9 +28810,9 @@
 			}
 		},
 		"acorn": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
 		},
 		"acorn-globals": {
 			"version": "6.0.0",
@@ -28760,6 +28822,14 @@
 			"requires": {
 				"acorn": "^7.1.1",
 				"acorn-walk": "^7.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+					"dev": true
+				}
 			}
 		},
 		"acorn-import-assertions": {
@@ -29584,6 +29654,13 @@
 				"better-queue-memory": "^1.0.1",
 				"node-eta": "^0.9.0",
 				"uuid": "^3.0.0"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+				}
 			}
 		},
 		"better-queue-memory": {
@@ -29750,6 +29827,11 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
+				},
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
 				}
 			}
 		},
@@ -32268,6 +32350,13 @@
 				"acorn": "^7.4.0",
 				"acorn-jsx": "^5.3.1",
 				"eslint-visitor-keys": "^1.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+				}
 			}
 		},
 		"esprima": {
@@ -33314,11 +33403,6 @@
 					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
 				},
-				"uuid": {
-					"version": "8.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-				},
 				"webidl-conversions": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -33491,6 +33575,11 @@
 					"version": "0.20.2",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 				},
 				"webidl-conversions": {
 					"version": "3.0.1",
@@ -33743,6 +33832,11 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
 					"integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 				}
 			}
 		},
@@ -33911,6 +34005,11 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
 					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 				},
 				"webidl-conversions": {
 					"version": "3.0.1",
@@ -34864,6 +34963,13 @@
 			"requires": {
 				"is-stream": "^2.0.0",
 				"type-fest": "^0.8.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+				}
 			}
 		},
 		"hast-to-hyperscript": {
@@ -37781,12 +37887,6 @@
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "8.6.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-					"integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-					"dev": true
-				},
 				"form-data": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -42977,9 +43077,11 @@
 			"dev": true
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+			"optional": true,
+			"peer": true
 		},
 		"type-is": {
 			"version": "1.6.18",
@@ -43007,6 +43109,12 @@
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
+		},
+		"typescript": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+			"peer": true
 		},
 		"unbox-primitive": {
 			"version": "1.0.1",
@@ -43491,9 +43599,9 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",
@@ -43653,11 +43761,6 @@
 				"webpack-sources": "^3.2.2"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "8.6.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-					"integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw=="
-				},
 				"glob-to-regexp": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",

--- a/services/personal-website/package.json
+++ b/services/personal-website/package.json
@@ -55,7 +55,8 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.0.0",
-    "sass": "^1.45.0"
+    "sass": "^1.45.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/services/personal-website/src/components/related-articles.js
+++ b/services/personal-website/src/components/related-articles.js
@@ -5,33 +5,29 @@ import ArticleCard from "@alexwilson/legacy-components/src/article-card"
 export default ({article: currentArticle}) => {
   const data = useStaticQuery(graphql`
     query RelatedArticles {
-      posts: allMarkdownRemark(
-        sort: { order: DESC, fields: [fields___date] }
+      posts: allContent(
+        sort: { order: DESC, fields: [date] }
         filter: {
-          frontmatter: {
-            date: {ne: null},
-            tags: {ne: null}
-          },
-          fields: {type: {eq: "posts"}}
+          type: {eq: "posts"}
         }
         limit: 1000
       ) {
         nodes {
-          id
-          fields {
+          contentId
+          slug
+          date
+          title
+          topics {
+            topicId
+            topic
             slug
-            date
-          }
-          frontmatter {
-            title
-            tags
           }
         }
       }
     }
   `)
 
-  const currentArticleTags = currentArticle.frontmatter.tags || []
+  const currentArticleTopics = currentArticle.topics.map(topic => topic.topicId) || []
 
   const maxArticles = 3
   const relatedArticles = new Set()
@@ -39,13 +35,13 @@ export default ({article: currentArticle}) => {
     if (relatedArticles.size >= maxArticles) break;
 
     for (const article of data.posts.nodes) {
-      if (article.id === currentArticle.id) continue;
+      if (article.contentId === currentArticle.contentId) continue;
       if (relatedArticles.size >= maxArticles) break;
 
       let similarity = 0
 
-      for (const tag of article.frontmatter.tags) {
-        if (currentArticleTags.includes(tag)) {
+      for (const topic of article.topics.map(topic => topic.topicId)) {
+        if (currentArticleTopics.includes(topic)) {
           similarity++;
         }
       }
@@ -61,7 +57,7 @@ export default ({article: currentArticle}) => {
   return (
     <>
       {Array.from(relatedArticles.values()).map(
-        article => <ArticleCard key={article.id} article={article} withBody={false} withDate={false}
+        article => <ArticleCard key={article.contentId} article={article} withBody={false} withDate={false}
       />)}
     </>
   )

--- a/services/personal-website/src/pages/blog.js
+++ b/services/personal-website/src/pages/blog.js
@@ -7,8 +7,8 @@ import ArticleCard from "@alexwilson/legacy-components/src/article-card"
   return (<Layout location={location}>
     <div className="alex-stream">
       <h1>My Blog</h1>
-      <h4>{data.allMarkdownRemark.totalCount} Posts</h4>
-      {data.allMarkdownRemark.edges.map(({ node }) => (
+      <h4>{data.content.totalCount} Posts</h4>
+      {data.content.edges.map(({ node }) => (
           <ArticleCard key={node.id} article={node} />
       ))}
     </div>
@@ -18,31 +18,32 @@ import ArticleCard from "@alexwilson/legacy-components/src/article-card"
 export default BlogPage
 
 export const query = graphql`
+  fragment BlogPageContent on MarkdownRemark {
+    excerpt: excerpt
+  }
   query {
-    allMarkdownRemark(
+    content: allContent(
       filter: {
-        frontmatter: {date: {ne: null}},
-        fields: {type: {eq: "posts"}}
+        type: {eq: "posts"}
       }
       sort: {
-        fields: [frontmatter___date],
+        fields: [date],
         order: DESC
       }
     ) {
       totalCount
       edges {
         node {
-          id
-          fields {
-            slug
-            date
+          contentId
+          title
+          date
+          slug
+          image {
             thumbnail
           }
-          frontmatter {
-            title
-            date
+          content: parent {
+            ...BlogPageContent
           }
-          excerpt
         }
       }
     }

--- a/services/personal-website/src/pages/index.js
+++ b/services/personal-website/src/pages/index.js
@@ -14,8 +14,8 @@ const IndexPage = ({ data, location }) => (
         <section className="alex-home__section">
             <h2><a className="heading" href="/blog/">Latest Writing</a></h2>
             <div className="alex-home__tilestack">
-            {data.allButWeeknotes.edges.map(({ node }) =>
-              <div key={node.id} className="alex-home__tilestack-item">
+            {data.allButWeeknotes.nodes.map((node) =>
+              <div key={node.contentId} className="alex-home__tilestack-item">
                 <ArticleCard article={node} withImage={false} withDate={false} />
               </div>
             )}
@@ -24,8 +24,8 @@ const IndexPage = ({ data, location }) => (
         <section className="alex-home__section">
             <h2><a className="heading" href="/topic/weeknotes">Latest Weeknotes</a></h2>
             <div className="alex-home__tilestack">
-            {data.onlyWeeknotes.edges.map(({ node }) =>
-              <div key={node.id} className="alex-home__tilestack-item">
+            {data.onlyWeeknotes.nodes.map((node) =>
+              <div key={node.contentId} className="alex-home__tilestack-item">
                 <ArticleCard article={node} withImage={false} withDate={false} />
               </div>
             )}
@@ -36,47 +36,42 @@ const IndexPage = ({ data, location }) => (
 )
 
 export const query = graphql`
+  fragment HomepageContent on MarkdownRemark {
+    excerpt: excerpt
+  }
+
   query {
-    allButWeeknotes: allMarkdownRemark(
-      sort: { fields: [frontmatter___date], order: DESC },
-      filter: { frontmatter: { tags: { nin: ["weeknotes"] } } }
+    allButWeeknotes: allContent(
+      sort: {fields: [date], order: DESC}
+      filter: { topics: { elemMatch: { topic: { ne: "weeknotes" }} }}
       limit: 3
     ) {
-      totalCount
-      edges {
-        node {
-          id
-          fields {
-            slug
-          }
-          frontmatter {
-            title
-            date
-          }
-          excerpt
+      nodes {
+        contentId
+        title
+        slug
+        date
+        content: parent {
+          ...HomepageContent
         }
       }
     }
-    onlyWeeknotes: allMarkdownRemark(
-      sort: { fields: [frontmatter___date], order: DESC },
-      filter: { frontmatter: { tags: { in: ["weeknotes"] } } }
+    onlyWeeknotes: allContent(
+      sort: {fields: [date], order: DESC}
+      filter: { topics: { elemMatch: { topic: { eq: "weeknotes" }} }}
       limit: 3
     ) {
-      totalCount
-      edges {
-        node {
-          id
-          fields {
-            slug
-          }
-          frontmatter {
-            title
-            date
-          }
-          excerpt
+      nodes {
+        contentId
+        title
+        slug
+        date
+        content: parent {
+          ...HomepageContent
         }
       }
     }
   }
+
 `
 export default IndexPage

--- a/services/personal-website/src/pages/talks.js
+++ b/services/personal-website/src/pages/talks.js
@@ -7,7 +7,7 @@ const TalksPage = ({ data, location }) => {
   return (<Layout location={location}>
     <div className="alex-stream">
       <h1>Talks</h1>
-      {data.allMarkdownRemark.edges.map(({ node }) => (
+      {data.talks.edges.map(({ node }) => (
           <ArticleCard key={node.id} article={node} />
       ))}
     </div>
@@ -17,30 +17,31 @@ const TalksPage = ({ data, location }) => {
 export default TalksPage
 
 export const query = graphql`
+  fragment TalkPageContent on MarkdownRemark {
+    excerpt: excerpt
+  }
   query {
-    allMarkdownRemark(
+    talks: allContent(
       filter: {
-        frontmatter: {date: {ne: null}},
-        fields: {type: {eq: "talks"}}
+        type: {eq: "talks"}
       }
       sort: {
-        fields: [frontmatter___date],
+        fields: [date],
         order: DESC
       }
     ) {
-      totalCount
       edges {
         node {
-          id
-          fields {
-            slug
-            date
+          contentId
+          title
+          date
+          slug
+          image {
+            thumbnail
           }
-          frontmatter {
-            title
-            date
+          content: parent {
+            ...BlogPageContent
           }
-          excerpt
         }
       }
     }

--- a/services/personal-website/src/schema/on-create-node.js
+++ b/services/personal-website/src/schema/on-create-node.js
@@ -1,0 +1,140 @@
+const {v5} = require('uuid')
+
+const contentFromMarkdownRemark = ({node, getNode}) => {
+  const contentId = node.frontmatter.id
+  const slug = `/content/${contentId}`
+  const title = node.frontmatter['title'] || ''
+  const date = new Date(node.frontmatter.date)
+
+  // Determine content type by looking at collection (aka parent node)
+  // @todo Move this into directly article schema instead?
+  const { sourceInstanceName: type } = getNode(node.parent)
+
+  let image = undefined
+  let thumbnail = undefined
+  if (node.frontmatter && node.frontmatter.image) {
+    image = node.frontmatter.image_cropped ? node.frontmatter.image_cropped : node.frontmatter.image
+    thumbnail = node.frontmatter.thumbnail ? node.frontmatter.thumbnail : node.frontmatter.image
+  }
+
+  const legacySlugs = []
+  if (node.frontmatter && node.frontmatter['_legacy_slug']) {
+    legacySlugs.push(node.frontmatter['_legacy_slug'])
+  }
+
+  // Content schema
+  const content = {
+    contentId,
+    slug,
+    title,
+    type,
+    date,
+    image: {
+      image,
+      thumbnail
+    },
+    deprecatedFields: {
+      legacySlugs
+    },
+    topics: []
+  }
+
+  return content
+}
+
+const topicsFromMarkdownRemark = ({node}) => {
+
+  const topics = []
+
+  if (node.frontmatter && node.frontmatter.tags) {
+    for (const topicSlug of node.frontmatter.tags) {
+
+      const topic = {
+        // Deterministically generate a UUIDv5 from a topic slug, namespaced to `https://alexwilson.tech/topics/`.
+        topicId: v5(topicSlug, v5('https://alexwilson.tech/topic/', v5.URL)),
+        slug: topicSlug
+      }
+
+      topics.push(topic)
+    }
+
+  }
+
+  return topics
+}
+
+const createTopicNode = (topic, {node, createNodeId, getNode, createContentDigest, actions}) => {
+  const {createNode, createParentChildLink} = actions
+
+  const topicNodeId = createNodeId(topic.topicId)
+
+  let topicNode = getNode(topicNodeId)
+  if (!topicNode) {
+    topicNode = {
+      id: topicNodeId,
+      parent: node.id,
+      children: [],
+      internal: {
+        content: topic.slug,
+        type: "Topic"
+      },
+      ...topic
+    }
+
+    topicNode.internal.contentDigest = createContentDigest(topicNode)
+    createNode(topicNode)
+
+    // For Gatsby cache we assign the current MarkdownRemark node as a parent.
+    // This is semantically wrong however while topics are stored in articles
+    // this will have to do.
+    createParentChildLink({ parent: node, child: topicNode})
+  }
+
+  return topicNode
+}
+
+const createContentNode = (content, {node, createNodeId, createContentDigest, actions}) => {
+  const { createNode, createParentChildLink} = actions
+    // Export to new node type.
+    const contentNode = {
+      id: createNodeId(content.contentId),
+      parent: node.id,
+      children: [],
+      internal: {
+        content: JSON.stringify(node),
+        type: "Content"
+      },
+      ...content
+    }
+
+    contentNode.internal.contentDigest = createContentDigest(contentNode)
+    createNode(contentNode)
+
+    // For Gatsby cache we assign the current MarkdownRemark node as a parent.
+    // This is semantically correct.
+    createParentChildLink({ parent: node, child: contentNode })
+}
+
+
+// Keeping these fields on MarkdownRemark is legacy behaviour
+const createMarkdownRemarkFields = ({content, node, actions}) => {
+  const {createNodeField} = actions
+
+  createNodeField({ node, name: 'id', value: content.contentId })
+  createNodeField({ node, name: 'title', value: content.title })
+  createNodeField({ node, name: 'date', value: content.date })
+  createNodeField({ node, name: 'slug', value: content.slug })
+  createNodeField({ node, name: 'type', value: content.type })
+
+  if (content.image.image) {
+    createNodeField({ node, name: 'image', value: content.image.image })
+  }
+  if (content.image.thumbnail) {
+    createNodeField({ node, name: 'thumbnail', value: content.image.thumbnail })
+  }
+  if (content.deprecatedFields.legacySlugs.length === 1) {
+    createNodeField({ node, name: '_legacy_slug', value: content.deprecatedFields.legacySlugs.shift() })
+  }
+}
+
+module.exports = { createMarkdownRemarkFields, contentFromMarkdownRemark, topicsFromMarkdownRemark, createTopicNode, createContentNode }

--- a/services/personal-website/src/templates/article.js
+++ b/services/personal-website/src/templates/article.js
@@ -36,7 +36,7 @@ const ArticleTemplate = ({ data, location }) => {
           <div className="alex-article__main__byline">
             Posted
 
-            {/* {(post.frontmatter.author ? */}
+            {(post.author && post.author.name ?
               <>
                 {` by `}
                 <span itemProp="author" itemType="http://schema.org/Person">
@@ -45,7 +45,7 @@ const ArticleTemplate = ({ data, location }) => {
                   </a>
                 </span>
               </>
-            {/* :null)} */}
+            :null)}
 
             {(datePublished ?
               <>
@@ -163,7 +163,11 @@ export const pageQuery = graphql`
   }
   query BlogPostBySlug($contentId: String!) {
     content(contentId: {eq: $contentId}) {
+      contentId
       title
+      author {
+        name
+      }
       topics {
         topicId
         topic

--- a/services/personal-website/src/templates/article.js
+++ b/services/personal-website/src/templates/article.js
@@ -1,6 +1,8 @@
 import React from "react"
 import { graphql, Link } from "gatsby"
 
+import { format } from "date-fns"
+
 import Header from "@alexwilson/legacy-components/src/header"
 import ShareWidget from "@alexwilson/legacy-components/src/share-widget"
 import Webmentions from "@alexwilson/legacy-components/src/webmentions"
@@ -18,23 +20,23 @@ const InfoBox = ({icon, children}) => (
 )
 
 const ArticleTemplate = ({ data, location }) => {
-  const post = data.markdownRemark
+  const post = data.content
   const url = new URL(location.pathname, data.site.siteMetadata.siteUrl)
-  const alternativeUrl = new URL(post.fields['_legacy_slug'], data.site.siteMetadata.siteUrl)
+  const alternativeUrls = post.deprecatedFields.legacySlugs.map(slug => new URL(slug, data.site.siteMetadata.siteUrl))
 
-  const datePublished = new Date(post.frontmatter.date)
-  const dateModified = new Date(post.frontmatter.last_modified_at || datePublished)
+  const datePublished = new Date(post.date)
+  const dateModified = new Date(post.flast_modified_at || datePublished)
 
   return (
     <Layout location={location}>
-      <Header location={location} image={post.fields.image} />
+      <Header location={location} image={post.image.image} />
       <div className="alex-article">
-        <h1 class="alex-article__headline" itemProp="name headline">{post.frontmatter.title}</h1>
+        <h1 class="alex-article__headline" itemProp="name headline">{post.title}</h1>
         <div className="alex-article__main">
           <div className="alex-article__main__byline">
             Posted
 
-            {(post.frontmatter.author ?
+            {/* {(post.frontmatter.author ? */}
               <>
                 {` by `}
                 <span itemProp="author" itemType="http://schema.org/Person">
@@ -43,7 +45,7 @@ const ArticleTemplate = ({ data, location }) => {
                   </a>
                 </span>
               </>
-            :null)}
+            {/* :null)} */}
 
             {(datePublished ?
               <>
@@ -52,19 +54,19 @@ const ArticleTemplate = ({ data, location }) => {
                   className="alex-article__main__date"
                   dateTime={datePublished}
                   itemProp="datePublished"
-                >{post.fields.formattedDate}</time>.
+                >{format(new Date(post.date), "PPPP")}</time>.
               </>
             :null)}
 
-            {(post.frontmatter.image_credit ?
+            {(post.image.credit ?
               <>
-                {` ${post.frontmatter.image_credit}`}
+                {` ${post.image.credit}`}
               </>
             :null)}
 
           </div>
           <article
-            dangerouslySetInnerHTML={{ __html: post.html }}
+            dangerouslySetInnerHTML={{ __html: post.content.html }}
             className="alex-article__body article-description"
             itemProp="articleBody"
           />
@@ -105,13 +107,13 @@ const ArticleTemplate = ({ data, location }) => {
 
           <div className="alex-article__aside-start">
 
-            {post.frontmatter.tags ?
+            {post.topics ?
             <div className="alex-article__topics">
               <strong>Topics: </strong>
               <ul>
-              {post.frontmatter.tags.map(topic => {
-                return <li key={topic}>
-                  <Link to={`/topic/${topic}`}>{topic}</Link>
+              {post.topics.map(topic => {
+                return <li key={topic.topicId}>
+                  <Link to={topic.slug}>{topic.topic}</Link>
                 </li>
               })}
               </ul>
@@ -130,20 +132,20 @@ const ArticleTemplate = ({ data, location }) => {
 
           <div className="alex-article__aside-bottom alex-article__sharing-block">
 
-            <ShareWidget title={post.frontmatter.title} url={url} />
-            <Webmentions urls={[url, `${url}/`, alternativeUrl]} />
+            <ShareWidget title={post.title} url={url} />
+            <Webmentions urls={[url, `${url}/`, ...alternativeUrls]} />
 
           </div>
 
         </div>
 
       </div>
-      <SEO title={post.frontmatter.title} description={post.excerpt}>
+      <SEO title={post.title} description={post.excerpt}>
         <script type="application/ld+json">{JSON.stringify(Article({
           url: url,
-          title: post.frontmatter.title,
-          image: post.fields.image,
-          description: post.frontmatter.excerpt,
+          title: post.title,
+          image: post.image.image,
+          description: post.content.excerpt,
           dateModified: dateModified,
           datePublished: datePublished
         }))}</script>
@@ -155,25 +157,29 @@ const ArticleTemplate = ({ data, location }) => {
 export default ArticleTemplate
 
 export const pageQuery = graphql`
-  query BlogPostBySlug($slug: String!) {
-    markdownRemark(fields: { slug: { eq: $slug } }) {
-      id
-      html
-      excerpt
-      frontmatter {
-        title
-        tags
-        date
-        last_modified_at
-        author
-        image_credit
-      }
-      fields {
-        formattedDate: date(formatString: "dddd, MMMM Do, YYYY")
-        image
-        date
+  fragment ArticleContent on MarkdownRemark {
+    html
+    excerpt: excerpt
+  }
+  query BlogPostBySlug($contentId: String!) {
+    content(contentId: {eq: $contentId}) {
+      title
+      topics {
+        topicId
+        topic
         slug
-        _legacy_slug
+      }
+      date
+      image {
+        image
+        credit
+      }
+      content: parent {
+        ...ArticleContent
+      }
+      slug
+      deprecatedFields {
+        legacySlugs
       }
     }
     site {

--- a/services/personal-website/src/templates/talk.js
+++ b/services/personal-website/src/templates/talk.js
@@ -4,18 +4,18 @@ import ShareWidget from "@alexwilson/legacy-components/src/share-widget"
 import Layout from "../components/layout"
 
 const TalkTemplate = ({ data, location }) => {
-  const post = data.markdownRemark
+  const post = data.content
   return (
     <Layout location={location}>
       <div class="alex-article">
         <div class="alex-article__main">
-          <h1 itemprop="name headline">{post.frontmatter.title}</h1>
+          <h1 itemprop="name headline">{post.title}</h1>
           <article
-            dangerouslySetInnerHTML={{ __html: post.html }}
+            dangerouslySetInnerHTML={{ __html: post.content.html }}
             className="alex-article__body article-description"
             itemprop="articleBody"
           />
-          <ShareWidget title={post.frontmatter.title} url={new URL(location.pathname, data.site.siteMetadata.siteUrl)} />
+          <ShareWidget title={post.title} url={new URL(post.slug, data.site.siteMetadata.siteUrl)} />
         </div>
         <div class="alex-article__aside">
         </div>
@@ -27,15 +27,21 @@ const TalkTemplate = ({ data, location }) => {
 export default TalkTemplate
 
 export const pageQuery = graphql`
-  query TalkBySlug($slug: String!) {
-    markdownRemark(fields: { slug: { eq: $slug } }) {
-      id
-      html
-      frontmatter {
-        title
-        date
-        author
-        image_credit
+  fragment TalkContent on MarkdownRemark {
+    html
+    excerpt: excerpt
+  }
+  query TalkBySlug($contentId: String!) {
+    content(contentId: {eq: $contentId}) {
+      contentId
+      title
+      date
+      slug
+      content: parent {
+        ...TalkContent
+      }
+      image {
+        credit
       }
     }
     site {

--- a/services/personal-website/src/templates/topic.js
+++ b/services/personal-website/src/templates/topic.js
@@ -6,63 +6,39 @@ import Layout from "../components/layout"
 
 const TopicsTemplate = ({ pageContext, data, location }) => {
   const { topic } = pageContext
-  const { totalCount } = data.allMarkdownRemark
+  const { totalCount } = data.allContent
 
   return (<Layout location={location}>
     <div class="alex-stream">
       <h1>{`${totalCount} post${totalCount === 1 ? "" : "s"} tagged with "${topic}"`}</h1>
-      {data.allMarkdownRemark.edges.map(({ node }) => (
+      {data.allContent.edges.map(({ node }) => (
           <ArticleCard key={node.id} article={node} />
       ))}
     </div>
   </Layout>)
 }
 
-TopicsTemplate.propTypes = {
-  pageContext: PropTypes.shape({
-    tag: PropTypes.string.isRequired,
-  }),
-  data: PropTypes.shape({
-    allMarkdownRemark: PropTypes.shape({
-      totalCount: PropTypes.number.isRequired,
-      edges: PropTypes.arrayOf(
-        PropTypes.shape({
-          node: PropTypes.shape({
-            frontmatter: PropTypes.shape({
-              title: PropTypes.string.isRequired,
-            }),
-            fields: PropTypes.shape({
-              slug: PropTypes.string.isRequired,
-            }),
-          }),
-        }).isRequired
-      ),
-    }),
-  }),
-}
-
 export default TopicsTemplate
 
 export const pageQuery = graphql`
+  fragment TopicPageContent on MarkdownRemark {
+    excerpt: excerpt
+  }
   query($topic: String) {
-    allMarkdownRemark(
-      limit: 2000
-      sort: { fields: [frontmatter___date], order: DESC }
-      filter: { frontmatter: { tags: { in: [$topic] } } }
+    allContent(
+      sort: { fields: [date], order: DESC }
+      filter: { topics: { elemMatch: { slug: { eq: $topic }} }}
     ) {
       totalCount
       edges {
         node {
-          id
-          fields {
-            slug
-            date
+          contentId
+          title
+          slug
+          date
+          content: parent {
+            ...TopicPageContent
           }
-          frontmatter {
-            title
-            date
-          }
-          excerpt
         }
       }
     }

--- a/services/personal-website/src/templates/topic.js
+++ b/services/personal-website/src/templates/topic.js
@@ -6,12 +6,12 @@ import Layout from "../components/layout"
 
 const TopicsTemplate = ({ pageContext, data, location }) => {
   const { topic } = pageContext
-  const { totalCount } = data.allContent
+  const { totalCount } = data.content
 
   return (<Layout location={location}>
     <div class="alex-stream">
-      <h1>{`${totalCount} post${totalCount === 1 ? "" : "s"} tagged with "${topic}"`}</h1>
-      {data.allContent.edges.map(({ node }) => (
+      <h1>{`${totalCount} post${totalCount === 1 ? "" : "s"} tagged with "${data.topic.topic}"`}</h1>
+      {data.content.edges.map(({ node }) => (
           <ArticleCard key={node.id} article={node} />
       ))}
     </div>
@@ -24,10 +24,13 @@ export const pageQuery = graphql`
   fragment TopicPageContent on MarkdownRemark {
     excerpt: excerpt
   }
-  query($topic: String) {
-    allContent(
+  query($topicId: String) {
+    topic(topicId: {eq: $topicId}) {
+      topic
+    }
+    content: allContent(
       sort: { fields: [date], order: DESC }
-      filter: { topics: { elemMatch: { slug: { eq: $topic }} }}
+      filter: { topics: { elemMatch: { topicId: { eq: $topicId }} }}
     ) {
       totalCount
       edges {


### PR DESCRIPTION
# Why?
In trying to open up horizons beyond Gatsby:
* It's impossible to do anything meaningful with Topics as they only exist inside a closure.
* Content/Articles are a mix between frontmatter & hacked-together fields.

# What?
* Port to a specific schema, built on-top of MarkdownRemark.
* Introduce two new content-types: `Content` & `Topic`
* Seed Topic with tags.
* Remove as many customisations as possible.
* Simplify the data-model.

# Anything else?
This is the biggest change I've made in quite some time, effectively rewriting large portions of the back-end.  I'm playing this one carefully.