### PR TITLE
feat(header): Use translate for header animation

### DIFF
--- a/components/legacy-components/src/header/header.scss
+++ b/components/legacy-components/src/header/header.scss
@@ -37,14 +37,13 @@
       background-color: $header-link-background;
       height: 100%;
       transition: all 0.2s ease;
-      margin-left: 0;
+      translate: none;
       
       &[aria-expanded="false"] {
         height: 0;
-        float: left;
         visibility: hidden;
         overflow: hidden;
-        margin-left: -150%;
+        transform: translate(0%, -300%);
       }
     }
   }


### PR DESCRIPTION
# Why?
Using margin-based positioning results in _something_ but also introduces some layout weirdness and is janky on mobile devices.

# What?
Use top-down animation, powered by `transform: translate()`.
