### PR TITLE
feat(twitter): Enable twitter social cards

### DIFF
--- a/services/personal-website/gatsby-config.js
+++ b/services/personal-website/gatsby-config.js
@@ -93,7 +93,21 @@ module.exports = {
                 global: false
               }
             }
-          }
+          },
+          {
+            resolve: `gatsby-remark-twitter-cards`,
+            options: {
+              title: false,
+              separator: false,
+              author: 'Alex Wilson',
+              background: '#000000',
+              fontColor: '#FFFFFF',
+              titleFontSize: 96,
+              subtitleFontSize: 60,
+              fontStyle: 'monospace'
+            },
+
+          },
         ],
       },
     },

--- a/services/personal-website/gatsby-node.js
+++ b/services/personal-website/gatsby-node.js
@@ -6,6 +6,8 @@ const { contentFromMarkdownRemark, topicsFromMarkdownRemark, createTopicNode, cr
 exports.onCreateNode = ({ node, createNodeId, getNode, createContentDigest, actions }) => {
   if (node.internal.type === `MarkdownRemark`) {
 
+    const {createNodeField} = actions
+
     // Generate content & topic entities from RemarkNode
     const content = contentFromMarkdownRemark({ node, getNode })
     const topics = topicsFromMarkdownRemark({ node })
@@ -18,6 +20,9 @@ exports.onCreateNode = ({ node, createNodeId, getNode, createContentDigest, acti
       createTopicNode(topic, {node, createNodeId, getNode, createContentDigest, actions})
     }
     createContentNode(content, {node, createNodeId, createContentDigest, actions})
+
+    // For compat. with other plugins, stub the slug field.
+    createNodeField({ node, name: 'slug', value: content.slug })
   }
 }
 

--- a/services/personal-website/package-lock.json
+++ b/services/personal-website/package-lock.json
@@ -26,6 +26,7 @@
 				"gatsby-remark-embed-gist": "^1.1.9",
 				"gatsby-remark-embed-video": "^3.1.1",
 				"gatsby-remark-prismjs": "^6.4.0",
+				"gatsby-remark-twitter-cards": "^0.6.1",
 				"gatsby-source-filesystem": "^4.4.0",
 				"gatsby-source-git": "^1.1.0",
 				"gatsby-transformer-remark": "^5.4.0",
@@ -5341,6 +5342,7 @@
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
 			"integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
 			"deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.7.0",
@@ -11559,6 +11561,460 @@
 			"peerDependencies": {
 				"gatsby": "^4.0.0-next",
 				"prismjs": "^1.15.0"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-twitter-cards/-/gatsby-remark-twitter-cards-0.6.1.tgz",
+			"integrity": "sha512-oSz78mJMmVqm4WWGaJrg6OTakP/W34BdWzUB/MlQglRebzMngHX8sCU3Ny2r9GE5Udjyry6wRt6vKSP7AK7wUA==",
+			"dependencies": {
+				"jimp": "^0.16.1",
+				"path": "^0.12.7",
+				"wasm-twitter-card": "^0.3.0"
+			},
+			"peerDependencies": {
+				"gatsby": ">=2.0.0"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/bmp": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
+			"integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1",
+				"bmp-js": "^0.1.0"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/core": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
+			"integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1",
+				"any-base": "^1.1.0",
+				"buffer": "^5.2.0",
+				"exif-parser": "^0.1.12",
+				"file-type": "^9.0.0",
+				"load-bmfont": "^1.3.1",
+				"mkdirp": "^0.5.1",
+				"phin": "^2.9.1",
+				"pixelmatch": "^4.0.2",
+				"tinycolor2": "^1.4.1"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/custom": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
+			"integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/core": "^0.16.1"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/gif": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
+			"integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1",
+				"gifwrap": "^0.9.2",
+				"omggif": "^1.0.9"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/jpeg": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
+			"integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1",
+				"jpeg-js": "0.4.2"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-blit": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
+			"integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-blur": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
+			"integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-circle": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
+			"integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-color": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
+			"integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1",
+				"tinycolor2": "^1.4.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-contain": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
+			"integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5",
+				"@jimp/plugin-blit": ">=0.3.5",
+				"@jimp/plugin-resize": ">=0.3.5",
+				"@jimp/plugin-scale": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-cover": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
+			"integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5",
+				"@jimp/plugin-crop": ">=0.3.5",
+				"@jimp/plugin-resize": ">=0.3.5",
+				"@jimp/plugin-scale": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-crop": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
+			"integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-displace": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
+			"integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-dither": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
+			"integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-fisheye": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
+			"integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-flip": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
+			"integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5",
+				"@jimp/plugin-rotate": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-gaussian": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
+			"integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-invert": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
+			"integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-mask": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
+			"integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-normalize": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
+			"integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-print": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
+			"integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1",
+				"load-bmfont": "^1.4.0"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5",
+				"@jimp/plugin-blit": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-resize": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
+			"integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-rotate": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
+			"integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5",
+				"@jimp/plugin-blit": ">=0.3.5",
+				"@jimp/plugin-crop": ">=0.3.5",
+				"@jimp/plugin-resize": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-scale": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
+			"integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5",
+				"@jimp/plugin-resize": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-shadow": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
+			"integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5",
+				"@jimp/plugin-blur": ">=0.3.5",
+				"@jimp/plugin-resize": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugin-threshold": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
+			"integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5",
+				"@jimp/plugin-color": ">=0.8.0",
+				"@jimp/plugin-resize": ">=0.8.0"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/plugins": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
+			"integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/plugin-blit": "^0.16.1",
+				"@jimp/plugin-blur": "^0.16.1",
+				"@jimp/plugin-circle": "^0.16.1",
+				"@jimp/plugin-color": "^0.16.1",
+				"@jimp/plugin-contain": "^0.16.1",
+				"@jimp/plugin-cover": "^0.16.1",
+				"@jimp/plugin-crop": "^0.16.1",
+				"@jimp/plugin-displace": "^0.16.1",
+				"@jimp/plugin-dither": "^0.16.1",
+				"@jimp/plugin-fisheye": "^0.16.1",
+				"@jimp/plugin-flip": "^0.16.1",
+				"@jimp/plugin-gaussian": "^0.16.1",
+				"@jimp/plugin-invert": "^0.16.1",
+				"@jimp/plugin-mask": "^0.16.1",
+				"@jimp/plugin-normalize": "^0.16.1",
+				"@jimp/plugin-print": "^0.16.1",
+				"@jimp/plugin-resize": "^0.16.1",
+				"@jimp/plugin-rotate": "^0.16.1",
+				"@jimp/plugin-scale": "^0.16.1",
+				"@jimp/plugin-shadow": "^0.16.1",
+				"@jimp/plugin-threshold": "^0.16.1",
+				"timm": "^1.6.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/png": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
+			"integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/utils": "^0.16.1",
+				"pngjs": "^3.3.3"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/tiff": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
+			"integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"utif": "^2.0.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/types": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
+			"integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/bmp": "^0.16.1",
+				"@jimp/gif": "^0.16.1",
+				"@jimp/jpeg": "^0.16.1",
+				"@jimp/png": "^0.16.1",
+				"@jimp/tiff": "^0.16.1",
+				"timm": "^1.6.1"
+			},
+			"peerDependencies": {
+				"@jimp/custom": ">=0.3.5"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/@jimp/utils": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
+			"integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"regenerator-runtime": "^0.13.3"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/file-type": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
+			"integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/gatsby-remark-twitter-cards/node_modules/jimp": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.1.tgz",
+			"integrity": "sha512-+EKVxbR36Td7Hfd23wKGIeEyHbxShZDX6L8uJkgVW3ESA9GiTEPK08tG1XI2r/0w5Ch0HyJF5kPqF9K7EmGjaw==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"@jimp/custom": "^0.16.1",
+				"@jimp/plugins": "^0.16.1",
+				"@jimp/types": "^0.16.1",
+				"regenerator-runtime": "^0.13.3"
 			}
 		},
 		"node_modules/gatsby-source-filesystem": {
@@ -18797,6 +19253,15 @@
 				"cross-spawn": "^6.0.5"
 			}
 		},
+		"node_modules/path": {
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+			"integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+			"dependencies": {
+				"process": "^0.11.1",
+				"util": "^0.10.3"
+			}
+		},
 		"node_modules/path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -19592,24 +20057,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
 			}
-		},
-		"node_modules/preact-render-to-string": {
-			"version": "5.1.19",
-			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.1.19.tgz",
-			"integrity": "sha512-bj8sn/oytIKO6RtOGSS/1+5CrQyRSC99eLUnEVbqUa6MzJX5dYh7wu9bmT0d6lm/Vea21k9KhCQwvr2sYN3rrQ==",
-			"peer": true,
-			"dependencies": {
-				"pretty-format": "^3.8.0"
-			},
-			"peerDependencies": {
-				"preact": ">=10"
-			}
-		},
-		"node_modules/preact-render-to-string/node_modules/pretty-format": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-			"integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=",
-			"peer": true
 		},
 		"node_modules/prebuild-install": {
 			"version": "7.0.0",
@@ -23493,19 +23940,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/type-fest": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -23534,19 +23968,6 @@
 			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
 			"dependencies": {
 				"is-typedarray": "^1.0.0"
-			}
-		},
-		"node_modules/typescript": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-			"peer": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -24182,6 +24603,14 @@
 				"pako": "^1.0.5"
 			}
 		},
+		"node_modules/util": {
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"dependencies": {
+				"inherits": "2.0.3"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -24200,6 +24629,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/util/node_modules/inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
 		},
 		"node_modules/utila": {
 			"version": "0.4.0",
@@ -24342,6 +24776,11 @@
 			"dependencies": {
 				"makeerror": "1.0.12"
 			}
+		},
+		"node_modules/wasm-twitter-card": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/wasm-twitter-card/-/wasm-twitter-card-0.3.0.tgz",
+			"integrity": "sha512-S5wPvSJclw/JOqw3XQyP1S7a+KMjL6O42jy0wBIzKZ7x/Yz9/Ou4Itd2TgExGkZ90dd7MhzYsMNC/UxoctVLUw=="
 		},
 		"node_modules/watchpack": {
 			"version": "2.3.1",
@@ -26897,8 +27336,7 @@
 				"ws": {
 					"version": "7.4.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-					"integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
-					"requires": {}
+					"integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
 				}
 			}
 		},
@@ -28026,8 +28464,7 @@
 		"@prefresh/core": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/@prefresh/core/-/core-1.3.2.tgz",
-			"integrity": "sha512-Iv+uI698KDgWsrKpLvOgN3hmAMyvhVgn09mcnhZ98BUNdg/qrxE7tcUf5yFCImkgqED5/Dcn8G5hFy4IikEDvg==",
-			"requires": {}
+			"integrity": "sha512-Iv+uI698KDgWsrKpLvOgN3hmAMyvhVgn09mcnhZ98BUNdg/qrxE7tcUf5yFCImkgqED5/Dcn8G5hFy4IikEDvg=="
 		},
 		"@prefresh/utils": {
 			"version": "1.1.1",
@@ -28835,14 +29272,12 @@
 		"acorn-import-assertions": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-			"requires": {}
+			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"requires": {}
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
 		},
 		"acorn-walk": {
 			"version": "7.2.0",
@@ -28919,8 +29354,7 @@
 		"ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"requires": {}
+			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -29258,13 +29692,13 @@
 			"version": "7.0.0-bridge.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
 			"integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"babel-eslint": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
 			"integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.7.0",
@@ -31049,8 +31483,7 @@
 		"cssnano-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-			"integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-			"requires": {}
+			"integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ=="
 		},
 		"csso": {
 			"version": "4.2.0",
@@ -32262,8 +32695,7 @@
 		"eslint-plugin-react-hooks": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
-			"integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-			"requires": {}
+			"integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA=="
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -34059,6 +34491,356 @@
 				"unist-util-visit": "^2.0.3"
 			}
 		},
+		"gatsby-remark-twitter-cards": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-twitter-cards/-/gatsby-remark-twitter-cards-0.6.1.tgz",
+			"integrity": "sha512-oSz78mJMmVqm4WWGaJrg6OTakP/W34BdWzUB/MlQglRebzMngHX8sCU3Ny2r9GE5Udjyry6wRt6vKSP7AK7wUA==",
+			"requires": {
+				"jimp": "^0.16.1",
+				"path": "^0.12.7",
+				"wasm-twitter-card": "^0.3.0"
+			},
+			"dependencies": {
+				"@jimp/bmp": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
+					"integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1",
+						"bmp-js": "^0.1.0"
+					}
+				},
+				"@jimp/core": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
+					"integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1",
+						"any-base": "^1.1.0",
+						"buffer": "^5.2.0",
+						"exif-parser": "^0.1.12",
+						"file-type": "^9.0.0",
+						"load-bmfont": "^1.3.1",
+						"mkdirp": "^0.5.1",
+						"phin": "^2.9.1",
+						"pixelmatch": "^4.0.2",
+						"tinycolor2": "^1.4.1"
+					}
+				},
+				"@jimp/custom": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
+					"integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/core": "^0.16.1"
+					}
+				},
+				"@jimp/gif": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
+					"integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1",
+						"gifwrap": "^0.9.2",
+						"omggif": "^1.0.9"
+					}
+				},
+				"@jimp/jpeg": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
+					"integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1",
+						"jpeg-js": "0.4.2"
+					}
+				},
+				"@jimp/plugin-blit": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
+					"integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-blur": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
+					"integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-circle": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
+					"integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-color": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
+					"integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1",
+						"tinycolor2": "^1.4.1"
+					}
+				},
+				"@jimp/plugin-contain": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
+					"integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-cover": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
+					"integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-crop": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
+					"integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-displace": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
+					"integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-dither": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
+					"integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-fisheye": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
+					"integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-flip": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
+					"integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-gaussian": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
+					"integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-invert": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
+					"integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-mask": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
+					"integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-normalize": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
+					"integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-print": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
+					"integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1",
+						"load-bmfont": "^1.4.0"
+					}
+				},
+				"@jimp/plugin-resize": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
+					"integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-rotate": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
+					"integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-scale": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
+					"integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-shadow": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
+					"integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugin-threshold": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
+					"integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1"
+					}
+				},
+				"@jimp/plugins": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
+					"integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/plugin-blit": "^0.16.1",
+						"@jimp/plugin-blur": "^0.16.1",
+						"@jimp/plugin-circle": "^0.16.1",
+						"@jimp/plugin-color": "^0.16.1",
+						"@jimp/plugin-contain": "^0.16.1",
+						"@jimp/plugin-cover": "^0.16.1",
+						"@jimp/plugin-crop": "^0.16.1",
+						"@jimp/plugin-displace": "^0.16.1",
+						"@jimp/plugin-dither": "^0.16.1",
+						"@jimp/plugin-fisheye": "^0.16.1",
+						"@jimp/plugin-flip": "^0.16.1",
+						"@jimp/plugin-gaussian": "^0.16.1",
+						"@jimp/plugin-invert": "^0.16.1",
+						"@jimp/plugin-mask": "^0.16.1",
+						"@jimp/plugin-normalize": "^0.16.1",
+						"@jimp/plugin-print": "^0.16.1",
+						"@jimp/plugin-resize": "^0.16.1",
+						"@jimp/plugin-rotate": "^0.16.1",
+						"@jimp/plugin-scale": "^0.16.1",
+						"@jimp/plugin-shadow": "^0.16.1",
+						"@jimp/plugin-threshold": "^0.16.1",
+						"timm": "^1.6.1"
+					}
+				},
+				"@jimp/png": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
+					"integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/utils": "^0.16.1",
+						"pngjs": "^3.3.3"
+					}
+				},
+				"@jimp/tiff": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
+					"integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"utif": "^2.0.1"
+					}
+				},
+				"@jimp/types": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
+					"integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/bmp": "^0.16.1",
+						"@jimp/gif": "^0.16.1",
+						"@jimp/jpeg": "^0.16.1",
+						"@jimp/png": "^0.16.1",
+						"@jimp/tiff": "^0.16.1",
+						"timm": "^1.6.1"
+					}
+				},
+				"@jimp/utils": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
+					"integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"regenerator-runtime": "^0.13.3"
+					}
+				},
+				"file-type": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
+					"integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="
+				},
+				"jimp": {
+					"version": "0.16.1",
+					"resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.1.tgz",
+					"integrity": "sha512-+EKVxbR36Td7Hfd23wKGIeEyHbxShZDX6L8uJkgVW3ESA9GiTEPK08tG1XI2r/0w5Ch0HyJF5kPqF9K7EmGjaw==",
+					"requires": {
+						"@babel/runtime": "^7.7.2",
+						"@jimp/custom": "^0.16.1",
+						"@jimp/plugins": "^0.16.1",
+						"@jimp/types": "^0.16.1",
+						"regenerator-runtime": "^0.13.3"
+					}
+				}
+			}
+		},
 		"gatsby-source-filesystem": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.4.0.tgz",
@@ -34820,8 +35602,7 @@
 		"graphql-type-json": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-			"integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
-			"requires": {}
+			"integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
 		},
 		"graphql-upload": {
 			"version": "11.0.0",
@@ -34845,8 +35626,7 @@
 		"graphql-ws": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.1.5.tgz",
-			"integrity": "sha512-yUQ1AjegD1Y9jDS699kyw7Mw+9H+rILm2HoS8N5a5B5YTH93xy3yifFhAJpKGc2wb/8yGdlVy8gTcud0TPqi6Q==",
-			"requires": {}
+			"integrity": "sha512-yUQ1AjegD1Y9jDS699kyw7Mw+9H+rILm2HoS8N5a5B5YTH93xy3yifFhAJpKGc2wb/8yGdlVy8gTcud0TPqi6Q=="
 		},
 		"gray-matter": {
 			"version": "4.0.3",
@@ -35240,8 +36020,7 @@
 		"icss-utils": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-			"requires": {}
+			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
 		},
 		"idb-keyval": {
 			"version": "3.2.0",
@@ -35893,8 +36672,7 @@
 		"isomorphic-ws": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-			"integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-			"requires": {}
+			"integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -37082,8 +37860,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "27.4.0",
@@ -39640,6 +40417,15 @@
 				"cross-spawn": "^6.0.5"
 			}
 		},
+		"path": {
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+			"integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+			"requires": {
+				"process": "^0.11.1",
+				"util": "^0.10.3"
+			}
+		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -39831,32 +40617,27 @@
 		"postcss-discard-comments": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-			"integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-			"requires": {}
+			"integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg=="
 		},
 		"postcss-discard-duplicates": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-			"integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-			"requires": {}
+			"integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA=="
 		},
 		"postcss-discard-empty": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-			"integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-			"requires": {}
+			"integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw=="
 		},
 		"postcss-discard-overridden": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-			"integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-			"requires": {}
+			"integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q=="
 		},
 		"postcss-flexbugs-fixes": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-			"integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-			"requires": {}
+			"integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
 		},
 		"postcss-loader": {
 			"version": "5.3.0",
@@ -39943,8 +40724,7 @@
 		"postcss-modules-extract-imports": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-			"requires": {}
+			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -39975,8 +40755,7 @@
 		"postcss-normalize-charset": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-			"integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-			"requires": {}
+			"integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg=="
 		},
 		"postcss-normalize-display-values": {
 			"version": "5.0.1",
@@ -40158,23 +40937,6 @@
 			"version": "10.6.4",
 			"resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
 			"integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ=="
-		},
-		"preact-render-to-string": {
-			"version": "5.1.19",
-			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.1.19.tgz",
-			"integrity": "sha512-bj8sn/oytIKO6RtOGSS/1+5CrQyRSC99eLUnEVbqUa6MzJX5dYh7wu9bmT0d6lm/Vea21k9KhCQwvr2sYN3rrQ==",
-			"peer": true,
-			"requires": {
-				"pretty-format": "^3.8.0"
-			},
-			"dependencies": {
-				"pretty-format": {
-					"version": "3.8.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-					"integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=",
-					"peer": true
-				}
-			}
 		},
 		"prebuild-install": {
 			"version": "7.0.0",
@@ -40713,8 +41475,7 @@
 		"react-side-effect": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-			"integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
-			"requires": {}
+			"integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
 		},
 		"read": {
 			"version": "1.0.7",
@@ -40785,8 +41546,7 @@
 		"redux-thunk": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-			"integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-			"requires": {}
+			"integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
 		},
 		"regenerate": {
 			"version": "1.4.2",
@@ -43076,13 +43836,6 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
-		"type-fest": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-			"optional": true,
-			"peer": true
-		},
 		"type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -43109,12 +43862,6 @@
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
-		},
-		"typescript": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-			"peer": true
 		},
 		"unbox-primitive": {
 			"version": "1.0.1",
@@ -43572,6 +44319,21 @@
 				"pako": "^1.0.5"
 			}
 		},
+		"util": {
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"requires": {
+				"inherits": "2.0.3"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+				}
+			}
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -43687,6 +44449,11 @@
 			"requires": {
 				"makeerror": "1.0.12"
 			}
+		},
+		"wasm-twitter-card": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/wasm-twitter-card/-/wasm-twitter-card-0.3.0.tgz",
+			"integrity": "sha512-S5wPvSJclw/JOqw3XQyP1S7a+KMjL6O42jy0wBIzKZ7x/Yz9/Ou4Itd2TgExGkZ90dd7MhzYsMNC/UxoctVLUw=="
 		},
 		"watchpack": {
 			"version": "2.3.1",
@@ -44192,8 +44959,7 @@
 		"ws": {
 			"version": "7.4.6",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-			"requires": {}
+			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
 		},
 		"xdg-basedir": {
 			"version": "4.0.0",

--- a/services/personal-website/package.json
+++ b/services/personal-website/package.json
@@ -43,6 +43,7 @@
     "gatsby-remark-embed-gist": "^1.1.9",
     "gatsby-remark-embed-video": "^3.1.1",
     "gatsby-remark-prismjs": "^6.4.0",
+    "gatsby-remark-twitter-cards": "^0.6.1",
     "gatsby-source-filesystem": "^4.4.0",
     "gatsby-source-git": "^1.1.0",
     "gatsby-transformer-remark": "^5.4.0",

--- a/services/personal-website/src/templates/article.js
+++ b/services/personal-website/src/templates/article.js
@@ -141,6 +141,11 @@ const ArticleTemplate = ({ data, location }) => {
 
       </div>
       <SEO title={post.title} description={post.excerpt}>
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:image"
+          content={`${url}/twitter-card.jpg`}
+        />
         <script type="application/ld+json">{JSON.stringify(Article({
           url: url,
           title: post.title,


### PR DESCRIPTION
# Why?
Currently all pages on the site have the default twitter summary card information which leads to lower engagement.

# What?
Add Twitter summary cards, generating an image with the name of the post - and me!

# Anything else?
For compatability with Gatsby plugins, including the one enabling this funcitonality, this PR also adds back the slug field to MarkdownRemark nodes.  They use this to write files to a location available to posts.