### PR TITLE
Article: Pass Link implementation to header

### DIFF
--- a/services/personal-website/src/templates/article.js
+++ b/services/personal-website/src/templates/article.js
@@ -29,7 +29,7 @@ const ArticleTemplate = ({ data, location }) => {
 
   return (
     <Layout location={location}>
-      <Header location={location} image={post.image.image} />
+      <Header location={location} image={post.image.image} linkImplementation={Link} />
       <div className="alex-article">
         <h1 class="alex-article__headline" itemProp="name headline">{post.title}</h1>
         <div className="alex-article__main">


### PR DESCRIPTION
# Why?
Header social links on article pages are broken because they lean on the default reach router implementation, which doesn't support external URLs.

# What?
Pass the Gatsby link implementation through.