### PR TITLE
Fix article widths

### DIFF
--- a/services/personal-website/src/scss/pages/_article.scss
+++ b/services/personal-website/src/scss/pages/_article.scss
@@ -5,7 +5,7 @@
     @include alex-row;
 
     display: grid;
-    grid-template-columns: 100%;
+    grid-template-columns: 1fr;
     grid-template-rows: auto;
     gap: 0 2em;
     grid-template-areas:
@@ -14,13 +14,13 @@
       "Aside";
 
     @include media(">tablet") {
-      grid-template-columns: 80% 20%;
+      grid-template-columns: 8fr 2fr;
       grid-template-areas:
         "Headline Headline"
         "Main Aside";
     }
     @include media(">desktop") {
-      grid-template-columns: 70% 30%;
+      grid-template-columns: 7fr 3fr;
       gap: 0 3em;
       grid-template-areas:
         "Headline Headline"


### PR DESCRIPTION
# Why?
Article layout makes use of CSS grid to separate the side-bar and the content-well.  In many cases it overflows due to the addition of percentages and em units.
(`grid-template-columns: 50% 50%` + `grid-column-gap: 1em` ~= `width: calc(100%+1em)`)

# What?
Replace usage of percentages in grid-template-columns definitions with fr, which take into account free space available after the gap (in em).