### PR TITLE
Force code blocks to be responsive

### DIFF
--- a/services/personal-website/src/scss/pages/_article.scss
+++ b/services/personal-website/src/scss/pages/_article.scss
@@ -39,6 +39,9 @@
 
 .alex-article__main {
     grid-area: Main;
+
+    /* This is not a permanent solution. It prevents anything escaping the content-well. */
+    overflow-x: auto;
 }
 
 .alex-article__aside {


### PR DESCRIPTION
# Why?
Since https://github.com/alexwilson/frontend/pull/2238, layout is now calculated and not imposed. Unfortunately that means that if you have an element that is particularly wide, you get this...
<img width="844" alt="image" src="https://user-images.githubusercontent.com/440052/229381527-267cb686-3963-4e82-94b2-4691c3fbca11.png">

# What?
Apply `overflow: auto;` to the article content well so that wide elements are either clamped or cropped.
