### PR TITLE
CI: Migrate from `set-output` to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -53,10 +53,14 @@ jobs:
         echo "Github Event: $GITHUB_EVENT_NAME"
         echo "$ npx lerna list ${lerna_args[@]}"
         echo "$ jq ${jq_args[@]}"
-        echo "##[set-output name=projects;]$(     \
+        echo "$ echo projects=$(                  \
           npx lerna list ${lerna_args[@]}         \
           | jq -rjc -n '.include |= inputs'       \
-        )"
+        ) >> \$GITHUB_OUTPUT"
+        echo "projects=$(                         \
+          npx lerna list ${lerna_args[@]}         \
+          | jq -rjc -n '.include |= inputs'       \
+        )" >> $GITHUB_OUTPUT
       env:
         MAIN_BRANCH: "main"
 


### PR DESCRIPTION
# Why?
Github are deprecated the `::set-output` directive which the CI workflow uses to discover repositories.  [More here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

# What?
Start migrating to `GITHUB_OUTPUT ` state.