### PR TITLE
fix: Use dev deps when deploying

### DIFF
--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -119,7 +119,7 @@ jobs:
       run: |
         rm  services/personal-website/package.json
         npm config set legacy-peer-deps true
-        npm ci --ignore-scripts
+        npm ci --ignore-scripts --production=false
     - name: Deploy
       run: npx lerna run deploy --scope ${{ matrix.name }}
       env:


### PR DESCRIPTION
# Why?
Whoops, looks like I broke monorepo deploys that relied on dev tools (i.e. CMS) in https://github.com/alexwilson/frontend/pull/2283!

# What?
Allow production dependencies to be installed in `deploy`.
