### PR TITLE
fix: Disable worker-cdn-prod deploys

### DIFF
--- a/services/worker-cdn-prod/package.json
+++ b/services/worker-cdn-prod/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "scripts": {
-    "deploy": "wrangler publish"
+    "deploy": "exit 0"
   },
   "devDependencies": {
     "wrangler": "^3.2.0"


### PR DESCRIPTION
# Why?
Something in the upgrade from Wrangler 1 to 2/3 has broken this particular worker.  I have raised an issue for it [here](https://github.com/alexwilson/frontend/issues/2313).

# What?
Disable deploys for worker-cdn-prod by replacing `wrangler publish` with `exit 0`.  This is a successful error code so it doesn't break other builds.
