### PR TITLE
chore(robots): Block /cdn-cgi/

### DIFF
--- a/services/personal-website/static/robots.txt
+++ b/services/personal-website/static/robots.txt
@@ -2,6 +2,7 @@
 
 User-agent: *
 Disallow: /cms/
+Disallow: /cdn-cgi/
 Crawl-Delay: 1
 
 User-agent: GPTBot


### PR DESCRIPTION
# Why?
Cloudflare have a few endpoints on the `/cdn-cgi/` prefix, which in their markup specify `noindex`. This behaviour confuzzles Google, who prefer this is specified in the robots file.

# What?
Add a disallow directive for `/cdn-cgi/` in the robots.txt file.
