### PR TITLE
Force PrismJS spans to inherit font

### DIFF
--- a/components/legacy-components/src/util-typography/typography.scss
+++ b/components/legacy-components/src/util-typography/typography.scss
@@ -1,14 +1,14 @@
 @import "../util-palette/palette";
 @import "./type/main";
 
- @mixin heading {
+* {
+    font-family: "Avenir Next", Avenir, Arial, sans-serif;
+}
+
+@mixin heading {
     .wf-active & {
         font-family: 'Overpass', sans-serif;
     }
-}
-
-* {
-    font-family: "Avenir Next", Avenir, Arial, sans-serif;
 }
 
 .alex-article {

--- a/services/personal-website/gatsby-browser.js
+++ b/services/personal-website/gatsby-browser.js
@@ -5,5 +5,3 @@
  */
 
 // You can delete this file if you're not using it
-require("prismjs/themes/prism-okaidia.css")
-require("prismjs/plugins/command-line/prism-command-line.css")

--- a/services/personal-website/src/scss/main.scss
+++ b/services/personal-website/src/scss/main.scss
@@ -4,12 +4,20 @@
 @import "~@alexwilson/legacy-components/src/util-palette/palette";
 @import "~@alexwilson/legacy-components/src/util-typography/typography";
 
+@import "~prismjs/themes/prism-okaidia.css";
+@import "~prismjs/plugins/command-line/prism-command-line.css";
+
 // Page-specific styles
 @import "layout";
 @import "pages/home";
 @import "pages/article";
 @import "pages/listing";
 @import "pages/consultancy";
+
+// Force spans inside PrismJS to use parent font-family.
+code[class*="language-"] span, pre[class*="language-"] span {
+    font-family: inherit;
+}
 
 .panel {
 	background: $brand;


### PR DESCRIPTION
# Why?
As reported in #2384, PrismJS fonts don't inherit correctly as they're overridden by the global `font-family` rule.

# What?
Temporarily patch this by forcing PrismJS spans to inherit their `font-family`.