### PR TITLE
feat(rss): Add author tag

### DIFF
--- a/services/personal-website/gatsby-config.js
+++ b/services/personal-website/gatsby-config.js
@@ -142,6 +142,8 @@ module.exports = {
                 rawUrl.searchParams.append('utm_source', 'feed')
                 const url = rawUrl.toString()
 
+                const author = entry?.author?.name ?? site.siteMetadata.title
+
                 const content = `
                   ${entry.content.preview}<br />
                   <a href="${url}">Read the full post here...</a>
@@ -158,6 +160,7 @@ module.exports = {
                   date: entry.date,
                   url,
                   guid,
+                  author,
                   custom_elements: [{
                     "content:encoded": contentEncoded,
                     "atom:link": {
@@ -186,6 +189,9 @@ module.exports = {
                     title
                     date
                     slug
+                    author {
+                      name
+                    }
                     content: parent {
                       ...FeedContent
                     }


### PR DESCRIPTION
# Why?
In some feed readers (looking at you, mailchimp) - not setting an author tag in the RSS feed results in the author appearing as "Anonymous". 

_(I've no idea who this anonymous chap is)_

# What?
Add author tag to feed items, defaulting to site title.
