### PR TITLE
Migrate to Decap CMS

### DIFF
--- a/components/legacy-components/src/util-typography/type/_mixins.scss
+++ b/components/legacy-components/src/util-typography/type/_mixins.scss
@@ -20,7 +20,7 @@ $max-widths: map-values($maxwidths);
 
   // Loop through breakpoints.
   @for $i from 2 through $breakpoints-limit {
-    @media screen and (min-width: math.div(nth($points, $i), 16px) * 1em ) {
+    @media screen and (min-width: #{math.div(nth($points, $i), 16)}em ) {
       font-size: math.div(nth($sizes, $i), 16) * 100%;
     }
   }
@@ -71,7 +71,7 @@ $max-widths: map-values($maxwidths);
 
       // Loop through breakpoints.
       @for $i from 2 through $breakpoints-limit {
-        @media screen and (min-width: math.div(nth($points, $i), 16px) * 1em ) {
+        @media screen and (min-width: #{math.div(nth($points, $i), 16)}em ) {
           font-size: #{math.div($fontsize, nth($sizes, $i))}rem;
         }
       }
@@ -87,7 +87,7 @@ $max-widths: map-values($maxwidths);
         $get-scale: map-get($modular-scale, scale-#{$i - 1});
         $get-size: map-get($get-scale, $fontsize);
 
-        @media screen and (min-width: math.div(nth($points, $i), 16px) * 1em ) {
+        @media screen and (min-width: #{math.div(nth($points, $i), 16)}em ) {
           font-size: #{math.div($get-size, nth($sizes, $i))}rem;
         }
       }
@@ -166,7 +166,7 @@ $max-widths: map-values($maxwidths);
         $baseline-shift: #{math.div($fontsize * 0.5 * (math.div($lineheight * $rootsize, $fontsize) - $cap-height), $rootsize) + 0.00001};
         $baseline-push: #{$below - (math.div($fontsize * 0.5 * (math.div($lineheight * $rootsize, $fontsize) - $cap-height), $rootsize) + 0.00001)};
 
-        @media screen and (min-width: math.div(nth($points, $i), 16px) * 1em ) {
+        @media screen and (min-width: #{math.div(nth($points, $i), 16)}em ) {
           margin-bottom: #{$baseline-push}rem;
           padding-top: #{$baseline-shift}rem;
         }
@@ -193,7 +193,7 @@ $max-widths: map-values($maxwidths);
         $baseline-shift: #{math.div($get-size * 0.5 * (math.div($lineheight * $rootsize, $get-size) - $cap-height), $rootsize) + 0.00001};
         $baseline-push: #{$below - (math.div($get-size * 0.5 * (math.div($lineheight * $rootsize, $get-size) - $cap-height), $rootsize) + 0.00001)};
 
-        @media screen and (min-width: math.div(nth($points, $i), 16px) * 1em ) {
+        @media screen and (min-width: #{math.div(nth($points, $i), 16)}em ) {
           margin-bottom: #{$baseline-push}rem;
           padding-top: #{$baseline-shift}rem;
         }
@@ -255,7 +255,7 @@ $max-widths: map-values($maxwidths);
         $rootsize: nth($sizes, $i);
         $baseline-shift: #{math.div($fontsize * 0.5 * (math.div($lineheight * $rootsize, $fontsize) - $cap-height), $rootsize) + 0.00001};
         $baseline-push: #{$below - (math.div($fontsize * 0.5 * (math.div($lineheight * $rootsize, $fontsize) - $cap-height), $rootsize) + 0.00001)};
-        @media screen and (min-width: math.div(nth($points, $i), 16px) * 1em ) {
+        @media screen and (min-width: #{math.div(nth($points, $i), 16)}em ) {
           font-size: #{math.div($fontsize, nth($sizes, $i))}rem;
           margin-bottom: #{$baseline-push}rem;
           padding-top: #{$baseline-shift}rem;
@@ -278,7 +278,7 @@ $max-widths: map-values($maxwidths);
         $rootsize: nth($sizes, $i);
         $baseline-shift: #{math.div($get-size * 0.5 * (math.div($lineheight * $rootsize, $get-size) - $cap-height), $rootsize) + 0.00001};
         $baseline-push: #{$below - (math.div($get-size * 0.5 * (math.div($lineheight * $rootsize, $get-size) - $cap-height), $rootsize) + 0.00001)};
-        @media screen and (min-width: math.div(nth($points, $i), 16px) * 1em ) {
+        @media screen and (min-width: #{math.div(nth($points, $i), 16)}em ) {
           font-size: #{math.div($get-size, nth($sizes, $i))}rem;
           margin-bottom: #{$baseline-push}rem;
           padding-top: #{$baseline-shift}rem;

--- a/components/legacy-components/src/util-typography/typography.scss
+++ b/components/legacy-components/src/util-typography/typography.scss
@@ -1,4 +1,5 @@
 @import "../util-palette/palette";
+@import "../util-viewports/viewports";
 @import "./type/main";
 
 * {
@@ -7,7 +8,7 @@
 
 @mixin heading {
     .wf-active & {
-        font-family: 'Overpass', sans-serif;
+        font-family: "Overpass", sans-serif;
     }
 }
 
@@ -16,7 +17,8 @@
         @extend .typeset;
 
         // Override to add spacing between bullet-points.
-        ul, ol {
+        ul,
+        ol {
             li:not(:last-child) {
                 padding-bottom: 1em;
             }
@@ -31,10 +33,11 @@
 .heading {
     @include heading;
 
-    a, a:visited {
+    a,
+    a:visited {
         color: $grey-5;
     }
- }
+}
 
 // Helpers for text-alignment
 .align-left {
@@ -47,18 +50,29 @@
     text-align: center;
 }
 
-h1, h2, h3, h4, ul.pager, ul.pagination {
+h1,
+h2,
+h3,
+h4,
+ul.pager,
+ul.pagination {
     @include heading;
     // font-weight: 800 !important;
     color: $grey-5;
 }
 
-h1,h2 {
+h1,
+h2 {
     text-transform: uppercase;
 }
 
-a, a:visited, a:hover, a:focus {
-    transition: color .4s ease-out, background .2s ease-in;
+a,
+a:visited,
+a:hover,
+a:focus {
+    transition:
+        color 0.4s ease-out,
+        background 0.2s ease-in;
     text-decoration: underline;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2333,6 +2333,68 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
+      "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-6.0.1.tgz",
+      "integrity": "sha512-rbxcsg3HhzlcMHVHWDuh9LCjpOVAgqbV78wLGI8tziXY3+qcMQ61qVXIvNKQFuhj75dSfD+o+PYZQ/NUk2A23A==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.1",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.6",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
+      "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.7",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
@@ -2406,61 +2468,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/@emotion/cache": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-      "dependencies": {
-        "@emotion/sheet": "0.9.4",
-        "@emotion/stylis": "0.8.5",
-        "@emotion/utils": "0.11.3",
-        "@emotion/weak-memoize": "0.2.5"
-      }
-    },
-    "node_modules/@emotion/core": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
-      "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/cache": "^10.0.27",
-        "@emotion/css": "^10.0.27",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/sheet": "0.9.4",
-        "@emotion/utils": "0.11.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@emotion/css": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-      "dependencies": {
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3",
-        "babel-plugin-emotion": "^10.0.27"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "node_modules/@emotion/react": {
       "version": "11.11.4",
@@ -2539,66 +2546,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
-    "node_modules/@emotion/serialize": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-      "dependencies": {
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/unitless": "0.7.5",
-        "@emotion/utils": "0.11.3",
-        "csstype": "^2.5.7"
-      }
-    },
-    "node_modules/@emotion/serialize/node_modules/csstype": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
-    },
-    "node_modules/@emotion/styled": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.3.0.tgz",
-      "integrity": "sha512-GgcUpXBBEU5ido+/p/mCT2/Xx+Oqmp9JzQRuC+a4lYM4i4LBBn/dWvc0rQ19N9ObA8/T4NWMrPNe79kMBDJqoQ==",
-      "dependencies": {
-        "@emotion/styled-base": "^10.3.0",
-        "babel-plugin-emotion": "^10.0.27"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.27",
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@emotion/styled-base": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.3.0.tgz",
-      "integrity": "sha512-PBRqsVKR7QRNkmfH78hTSSwHWcwDpecH9W6heujWAcyp2wdz/64PP73s7fWS1dIPm8/Exc8JAzYS8dEWXjv60w==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/is-prop-valid": "0.8.8",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.28",
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-    },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
@@ -2606,16 +2553,6 @@
       "peerDependencies": {
         "react": ">=16.8.0"
       }
-    },
-    "node_modules/@emotion/utils": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "node_modules/@esbuild-plugins/node-globals-polyfill": {
       "version": "0.2.3",
@@ -4812,6 +4749,11 @@
         "tslib": "2"
       }
     },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -6944,6 +6886,29 @@
       "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "dependencies": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -7564,6 +7529,11 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
     },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg=="
+    },
     "node_modules/@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -7675,6 +7645,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/is-hotkey": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.10.tgz",
+      "integrity": "sha512-RvC8KMw5BCac1NvRRyaHgMMEtBaZ6wh0pyPTBu7izn4Sj/AX9Y4aXU5c7rX8PnM/knsuUpC1IeoBkANtxBypsQ=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -7933,25 +7908,6 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
-    },
-    "node_modules/@types/vfile": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
-      "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/unist": "*",
-        "@types/vfile-message": "*"
-      }
-    },
-    "node_modules/@types/vfile-message": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
-      "integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
-      "deprecated": "This is a stub types definition. vfile-message provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "vfile-message": "*"
-      }
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -9460,61 +9416,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "node_modules/babel-plugin-emotion": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
-      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/serialize": "^0.11.16",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^1.0.5",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7"
-      }
-    },
-    "node_modules/babel-plugin-emotion/node_modules/babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
-      }
-    },
-    "node_modules/babel-plugin-emotion/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
-    },
-    "node_modules/babel-plugin-emotion/node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-emotion/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -9635,11 +9536,6 @@
         "@babel/core": "^7.0.0",
         "gatsby": "^5.0.0-next"
       }
-    },
-    "node_modules/babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
     "node_modules/babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -11059,6 +10955,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cmd-shim": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-6.0.1.tgz",
@@ -11312,6 +11216,11 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -12238,6 +12147,11 @@
         "node": "*"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -12291,6 +12205,998 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decap-cms": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/decap-cms/-/decap-cms-3.1.10.tgz",
+      "integrity": "sha512-9BdYiadF6DUfSt3M/HUO3ELEaohaRH/3I9JbbDSIRRZdVBtYpHKzEnG8g9eCVFg5X49addU/09d5SK/BgNPbSA==",
+      "dependencies": {
+        "codemirror": "^5.46.0",
+        "create-react-class": "^15.7.0",
+        "decap-cms-app": "^3.1.10",
+        "decap-cms-media-library-cloudinary": "^3.0.3",
+        "decap-cms-media-library-uploadcare": "^3.0.2",
+        "file-loader": "^6.2.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "svgo-loader": "^3.0.3"
+      }
+    },
+    "node_modules/decap-cms-app": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/decap-cms-app/-/decap-cms-app-3.1.10.tgz",
+      "integrity": "sha512-q9+HfnjawRf9nLjzGqglmFQifQr9cVm3c5An/VDDxwiw9h/geCOdKNAd+tBgtqT+7xaCPzfCp2KRsJmTqWRnxg==",
+      "dependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "codemirror": "^5.46.0",
+        "dayjs": "^1.11.10",
+        "decap-cms-backend-aws-cognito-github-proxy": "^3.1.2",
+        "decap-cms-backend-azure": "^3.1.1",
+        "decap-cms-backend-bitbucket": "^3.1.2",
+        "decap-cms-backend-git-gateway": "^3.1.1",
+        "decap-cms-backend-github": "^3.1.2",
+        "decap-cms-backend-gitlab": "^3.1.3",
+        "decap-cms-backend-proxy": "^3.1.1",
+        "decap-cms-backend-test": "^3.1.1",
+        "decap-cms-core": "^3.3.6",
+        "decap-cms-editor-component-image": "^3.1.1",
+        "decap-cms-lib-auth": "^3.0.5",
+        "decap-cms-lib-util": "^3.0.4",
+        "decap-cms-lib-widgets": "^3.0.2",
+        "decap-cms-locales": "^3.1.4",
+        "decap-cms-ui-default": "^3.1.1",
+        "decap-cms-widget-boolean": "^3.1.1",
+        "decap-cms-widget-code": "^3.1.2",
+        "decap-cms-widget-colorstring": "^3.1.1",
+        "decap-cms-widget-datetime": "^3.1.5",
+        "decap-cms-widget-file": "^3.1.1",
+        "decap-cms-widget-image": "^3.1.1",
+        "decap-cms-widget-list": "^3.1.1",
+        "decap-cms-widget-map": "^3.1.1",
+        "decap-cms-widget-markdown": "^3.1.3",
+        "decap-cms-widget-number": "^3.1.1",
+        "decap-cms-widget-object": "^3.1.2",
+        "decap-cms-widget-relation": "^3.3.0",
+        "decap-cms-widget-select": "^3.1.1",
+        "decap-cms-widget-string": "^3.1.1",
+        "decap-cms-widget-text": "^3.1.1",
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react-immutable-proptypes": "^2.1.0",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-app/node_modules/@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
+    "node_modules/decap-cms-app/node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/decap-cms-app/node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/decap-cms-app/node_modules/@emotion/serialize": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.4.tgz",
+      "integrity": "sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/unitless": "^0.8.1",
+        "@emotion/utils": "^1.2.1",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/decap-cms-app/node_modules/@emotion/styled": {
+      "version": "11.11.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
+      "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/is-prop-valid": "^1.2.2",
+        "@emotion/serialize": "^1.1.4",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decap-cms-app/node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
+    "node_modules/decap-cms-app/node_modules/@emotion/utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+    },
+    "node_modules/decap-cms-app/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/decap-cms-backend-aws-cognito-github-proxy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/decap-cms-backend-aws-cognito-github-proxy/-/decap-cms-backend-aws-cognito-github-proxy-3.1.2.tgz",
+      "integrity": "sha512-KInJ10qKayuxI+gbMtlYLJ+eoG6If1GVTqClbcpezbm/XxFtyifrzBr9cSjY1+d3pHxxnLcF4+GuVdLqAnrIYA==",
+      "dependencies": {
+        "apollo-cache-inmemory": "^1.6.2",
+        "apollo-client": "^2.6.3",
+        "apollo-link-context": "^1.0.18",
+        "apollo-link-http": "^1.5.15",
+        "common-tags": "^1.8.0",
+        "graphql": "^15.0.0",
+        "graphql-tag": "^2.10.1",
+        "js-base64": "^3.0.0",
+        "semaphore": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-backend-github": "^3.0.0",
+        "decap-cms-lib-auth": "^3.0.0",
+        "decap-cms-lib-util": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-backend-aws-cognito-github-proxy/node_modules/graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/decap-cms-backend-azure": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-backend-azure/-/decap-cms-backend-azure-3.1.1.tgz",
+      "integrity": "sha512-zzPy8bJkS8Sh+DOdUiF31gbAFeb+xqr1KvyeTP8ul31oCBbzJt6K6sybDEm/1Rt4S20Lq4CbP476qcHA89ZmVg==",
+      "dependencies": {
+        "js-base64": "^3.0.0",
+        "semaphore": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-lib-auth": "^3.0.0",
+        "decap-cms-lib-util": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-backend-bitbucket": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/decap-cms-backend-bitbucket/-/decap-cms-backend-bitbucket-3.1.2.tgz",
+      "integrity": "sha512-YW1AvzKUbeWppcWVK9ZlN+3bYBLjC479ryuPJDV4GyVIxjvgqP7KMtHgULlPT15VPLP11kwdH0qQf8r4AJnPqw==",
+      "dependencies": {
+        "common-tags": "^1.8.0",
+        "js-base64": "^3.0.0",
+        "semaphore": "^1.1.0",
+        "what-the-diff": "^0.6.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-lib-auth": "^3.0.0",
+        "decap-cms-lib-util": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-backend-git-gateway": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-backend-git-gateway/-/decap-cms-backend-git-gateway-3.1.1.tgz",
+      "integrity": "sha512-Do+WU8sFC5rkKDjkbiSjIP5CBYlN8CWRQuOUJ5cwRgUSrmfJAKFB0AlRQmr79JburAk/JdAS8faljeL/L85Byw==",
+      "dependencies": {
+        "gotrue-js": "^0.9.24",
+        "ini": "^2.0.0",
+        "jwt-decode": "^3.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-backend-bitbucket": "^3.0.0",
+        "decap-cms-backend-github": "^3.0.0",
+        "decap-cms-backend-gitlab": "^3.0.0",
+        "decap-cms-lib-auth": "^3.0.0",
+        "decap-cms-lib-util": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-backend-git-gateway/node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/decap-cms-backend-github": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/decap-cms-backend-github/-/decap-cms-backend-github-3.1.2.tgz",
+      "integrity": "sha512-K2WXwdlqMXgMNuEe0JMaDBd7jRayxT6zBLZ5Eqyl2frIDGxV63JXSoBIkhxLpOsP1Z0SC8XeCx9cPmTe26KnGw==",
+      "dependencies": {
+        "apollo-cache-inmemory": "^1.6.2",
+        "apollo-client": "^2.6.3",
+        "apollo-link-context": "^1.0.18",
+        "apollo-link-http": "^1.5.15",
+        "common-tags": "^1.8.0",
+        "graphql": "^15.0.0",
+        "graphql-tag": "^2.10.1",
+        "js-base64": "^3.0.0",
+        "semaphore": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-lib-auth": "^3.0.0",
+        "decap-cms-lib-util": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-backend-github/node_modules/graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/decap-cms-backend-gitlab": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/decap-cms-backend-gitlab/-/decap-cms-backend-gitlab-3.1.3.tgz",
+      "integrity": "sha512-RoyfkL9hPncojB98IjdC8UFZpJajq88hy3ymXSW0oFuZotMG2RZwyZejKltq/unq/YNGpLzdDIk5kVfrm+o64g==",
+      "dependencies": {
+        "apollo-cache-inmemory": "^1.6.2",
+        "apollo-client": "^2.6.3",
+        "apollo-link-context": "^1.0.18",
+        "apollo-link-http": "^1.5.15",
+        "js-base64": "^3.0.0",
+        "semaphore": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-lib-auth": "^3.0.0",
+        "decap-cms-lib-util": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-backend-proxy": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-backend-proxy/-/decap-cms-backend-proxy-3.1.1.tgz",
+      "integrity": "sha512-w1AClt+bScKBehvLOEWCvwaAI7idG6IJ4070zwNkTspsyjnqSQoay8T9VySoo9aDnKQi4iI0mNojlcI0uBY3tA==",
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-lib-util": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-backend-test": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-backend-test/-/decap-cms-backend-test-3.1.1.tgz",
+      "integrity": "sha512-62CbnDfF9EUJNcfNJbX/V40ArbMbF09wQeHEPwtzj8l5byWIhtzZwSMIrmtstuhfBtYVlc/7e5A2E6zSVI9l9w==",
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-lib-util": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/decap-cms-core": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/decap-cms-core/-/decap-cms-core-3.3.6.tgz",
+      "integrity": "sha512-PwLXQj9xt7Pb170VAI9gdrnqxgIos9tmcIFVM90NE0UoBOzHkkestYuvKGKLzPzLk0mQHz9ZjKgIH6E9G+1a4Q==",
+      "dependencies": {
+        "@iarna/toml": "2.2.5",
+        "@reduxjs/toolkit": "^1.9.1",
+        "ajv": "8.12.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.0.0",
+        "clean-stack": "^4.1.0",
+        "copy-text-to-clipboard": "^3.0.0",
+        "dayjs": "^1.11.10",
+        "deepmerge": "^4.2.2",
+        "diacritics": "^1.3.0",
+        "fuzzy": "^0.1.1",
+        "gotrue-js": "^0.9.24",
+        "gray-matter": "^4.0.2",
+        "history": "^4.7.2",
+        "immer": "^9.0.0",
+        "js-base64": "^3.0.0",
+        "jwt-decode": "^3.0.0",
+        "node-polyglot": "^2.3.0",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-dnd": "^14.0.0",
+        "react-dnd-html5-backend": "^14.0.0",
+        "react-dom": "^18.2.0",
+        "react-frame-component": "^5.2.1",
+        "react-immutable-proptypes": "^2.1.0",
+        "react-is": "16.13.1",
+        "react-markdown": "^6.0.2",
+        "react-modal": "^3.8.1",
+        "react-polyglot": "^0.7.0",
+        "react-redux": "^7.2.0",
+        "react-router-dom": "^5.2.0",
+        "react-scroll-sync": "^0.9.0",
+        "react-split-pane": "^0.1.85",
+        "react-toastify": "^9.1.1",
+        "react-topbar-progress-indicator": "^4.0.0",
+        "react-virtualized-auto-sizer": "^1.0.2",
+        "react-waypoint": "^10.0.0",
+        "react-window": "^1.8.5",
+        "redux": "^4.0.5",
+        "redux-devtools-extension": "^2.13.8",
+        "redux-notifications": "^4.0.1",
+        "redux-thunk": "^2.3.0",
+        "remark-gfm": "1.0.0",
+        "sanitize-filename": "^1.6.1",
+        "semaphore": "^1.0.5",
+        "tomlify-j0.4": "^3.0.0-alpha.0",
+        "url": "^0.11.0",
+        "url-join": "^4.0.1",
+        "what-input": "^5.1.4",
+        "yaml": "^1.8.3"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-editor-component-image": "^3.0.0",
+        "decap-cms-lib-auth": "^3.0.0",
+        "decap-cms-lib-util": "^3.0.0",
+        "decap-cms-lib-widgets": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-immutable-proptypes": "^2.1.0"
+      }
+    },
+    "node_modules/decap-cms-core/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/decap-cms-core/node_modules/clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decap-cms-core/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decap-cms-core/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/decap-cms-editor-component-image": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-editor-component-image/-/decap-cms-editor-component-image-3.1.1.tgz",
+      "integrity": "sha512-T2wPaVW0Vp+UAzxwbrkbAgO+cWPinX515C6PxjNh9MbtcHyBL8sYIXtqBcvgvH6sfyUZLsfTCtcHjcV0+qO8vw==",
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-lib-auth": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/decap-cms-lib-auth/-/decap-cms-lib-auth-3.0.5.tgz",
+      "integrity": "sha512-NG+dI1Pg0UBoxRQfuI0zeRLZAtPU23R3qUOA1mDUJ4OpKmX6/lsznmvu0l+e3TzGUhCkOXyz2fl/9HctsMjTXw==",
+      "peerDependencies": {
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/decap-cms-lib-util": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/decap-cms-lib-util/-/decap-cms-lib-util-3.0.4.tgz",
+      "integrity": "sha512-hvawum2GW2N9M4ljPT929s4oLeo0kRPlR0Wlt/CxdD84leROrBAUfwWB1Upfznvuirvme1EBToFiLg9zdrfOqg==",
+      "dependencies": {
+        "js-sha256": "^0.9.0",
+        "localforage": "^1.7.3",
+        "semaphore": "^1.1.0"
+      },
+      "peerDependencies": {
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11"
+      }
+    },
+    "node_modules/decap-cms-lib-widgets": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/decap-cms-lib-widgets/-/decap-cms-lib-widgets-3.0.2.tgz",
+      "integrity": "sha512-bb53ZKh98XnmBWXhvyyc9vXn6Nw4RCcS465V1bhI3AI+ec22feGg0G5dWb61NONj0j9XPbZKaqFxL7dcO9/S8Q==",
+      "dependencies": {
+        "dayjs": "^1.11.10"
+      },
+      "peerDependencies": {
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11"
+      }
+    },
+    "node_modules/decap-cms-locales": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/decap-cms-locales/-/decap-cms-locales-3.1.4.tgz",
+      "integrity": "sha512-JenOninZv4qY1nyLKTShYrQ2zdUNkUmRzhYqWbU1a54OJQT/QUS1T3ekNrcwygDX/RHgzsYPxkyOdmaUV2iR6w=="
+    },
+    "node_modules/decap-cms-media-library-cloudinary": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/decap-cms-media-library-cloudinary/-/decap-cms-media-library-cloudinary-3.0.3.tgz",
+      "integrity": "sha512-2dRmHeEiTpFUZaBOvIdCMvZeWGSdC0SyKcVCyU0YpJ7NXdfZg1LoYt5+2xgsbVO2CWH9HjEWw9uKKgCsMKNf9g==",
+      "peerDependencies": {
+        "decap-cms-lib-util": "^3.0.0"
+      }
+    },
+    "node_modules/decap-cms-media-library-uploadcare": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/decap-cms-media-library-uploadcare/-/decap-cms-media-library-uploadcare-3.0.2.tgz",
+      "integrity": "sha512-nBgA3Mx3z4rEhbuu5XFfOt8/PQ/LXYU/FnwR0bpYcsCXdWQUogp9F+gHrGoYF6UiDrkSPlUUFSTn3Jcfyn0xXQ==",
+      "dependencies": {
+        "uploadcare-widget": "^3.7.0",
+        "uploadcare-widget-tab-effects": "^1.4.0"
+      }
+    },
+    "node_modules/decap-cms-ui-default": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-ui-default/-/decap-cms-ui-default-3.1.1.tgz",
+      "integrity": "sha512-d50DGTYqn9cty6UYf7PZMi7EZ5pOZLpmyf/JapRpuwU+7aWeb22Gj9Zs8nQ4GNd0EFBQXG/KjSoxVx+jqfPw4Q==",
+      "dependencies": {
+        "react-aria-menubutton": "^7.0.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-widget-boolean": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-boolean/-/decap-cms-widget-boolean-3.1.1.tgz",
+      "integrity": "sha512-uUpucKVlWvCHiypmru92BUs1agDAyQ8g9b+XQCcR+T4CVuU+Q/M+fFH5nxKE/qBZv/WAUnsh+t+Jqtby+vy8lA==",
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "decap-cms-ui-default": "^3.0.0",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-immutable-proptypes": "^2.1.0"
+      }
+    },
+    "node_modules/decap-cms-widget-code": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-code/-/decap-cms-widget-code-3.1.2.tgz",
+      "integrity": "sha512-ok9JFEzHID8/H0x5kf4HIGW/933B4VgVPLk7KGFYEu/nXG3fn7c9HsYSZVdCBQs9de9+hhDZyjnOpW/M+LguEA==",
+      "dependencies": {
+        "react-codemirror2": "^7.0.0",
+        "react-select": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "codemirror": "^5.46.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "lodash": "^4.17.11",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-widget-colorstring": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-colorstring/-/decap-cms-widget-colorstring-3.1.1.tgz",
+      "integrity": "sha512-ZAIcTYJjR8K/uvDQlFGFe6PnqDc6dDJzEDggB4EgvAl99ruj9Q+a89+j17dWYyf4PZppByrlSK1A8Tu3MIzlqQ==",
+      "dependencies": {
+        "react-color": "^2.18.1",
+        "tinycolor2": "^1.4.1"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-widget-datetime": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-datetime/-/decap-cms-widget-datetime-3.1.5.tgz",
+      "integrity": "sha512-WOuPn9TpDlptk1YuJDV5SCPHPfQls0naxpwHcGdnKmLm2k7R0vQoAmwEWo6sv52VWr0S4ytgjsZaCjkMPWFlxg==",
+      "dependencies": {
+        "dayjs": "^1.11.10"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-widget-file": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-file/-/decap-cms-widget-file-3.1.1.tgz",
+      "integrity": "sha512-MKZaRF6uyB7j6HnvIpR4N6vYjwi2DJlhtToGhO+adRCkgmJi0IXj78kASk/3rJsCKv/XCShY/pu3pQg671nmaA==",
+      "dependencies": {
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/modifiers": "^6.0.1",
+        "@dnd-kit/sortable": "^7.0.2",
+        "array-move": "4.0.0",
+        "common-tags": "^1.8.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "immutable": "^3.7.6",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-immutable-proptypes": "^2.1.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/decap-cms-widget-image": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-image/-/decap-cms-widget-image-3.1.1.tgz",
+      "integrity": "sha512-yxD+kUD9XXUmiHQnAV1PR28gfpaKCxKT80gm6BIob4S4RO7+HBtZmKz5vnw6w1pnAXNFK+R+gkERBxTxFwrPhQ==",
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "decap-cms-widget-file": "^3.0.0",
+        "immutable": "^3.7.6",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-widget-list": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-list/-/decap-cms-widget-list-3.1.1.tgz",
+      "integrity": "sha512-yzp1VnyOfT9oFFdS38NXFNoVtvLmoYq3DbQvc9hW6gd5U5TZ1FeCblsMIaucJbO2SS7Hhno79cGGXWzvHRHeSg==",
+      "dependencies": {
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/modifiers": "^6.0.1",
+        "@dnd-kit/sortable": "^7.0.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-lib-widgets": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "decap-cms-widget-object": "^3.0.0",
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-immutable-proptypes": "^2.1.0"
+      }
+    },
+    "node_modules/decap-cms-widget-map": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-map/-/decap-cms-widget-map-3.1.1.tgz",
+      "integrity": "sha512-SZ3ydJ4D6o6ptwUk4K0hcGPxYY+XF1060QCaefKRUB43Utd7tu8lB9bD7D/rosPgNpsY/M34846Lzbkmg3pUTA==",
+      "dependencies": {
+        "ol": "^6.9.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "decap-cms-ui-default": "^3.0.0",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-immutable-proptypes": "^2.1.0"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-markdown/-/decap-cms-widget-markdown-3.1.3.tgz",
+      "integrity": "sha512-7e+9OJ4bH2akPFi1gRuhAKAYt1tGW1tWBDa6IEs7lqCdEohQOtT23+weV8CGylslZOBu1sBi6qkrZ7iyHYoGYw==",
+      "dependencies": {
+        "dompurify": "^2.2.6",
+        "is-hotkey": "^0.2.0",
+        "is-url": "^1.2.4",
+        "mdast-util-definitions": "^1.2.3",
+        "mdast-util-to-string": "^1.0.5",
+        "rehype-parse": "^6.0.0",
+        "rehype-remark": "^8.0.0",
+        "rehype-stringify": "^7.0.0",
+        "remark-parse": "^6.0.3",
+        "remark-rehype": "^4.0.0",
+        "remark-slate": "^1.8.6",
+        "remark-slate-transformer": "^0.7.4",
+        "remark-stringify": "^6.0.4",
+        "slate": "^0.91.1",
+        "slate-base64-serializer": "^0.2.107",
+        "slate-history": "^0.93.0",
+        "slate-plain-serializer": "^0.7.1",
+        "slate-react": "^0.91.2",
+        "slate-soft-break": "^0.9.0",
+        "unified": "^9.2.0",
+        "unist-builder": "^1.0.3",
+        "unist-util-visit-parents": "^2.0.1"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-immutable-proptypes": "^2.1.0"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/direction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/markdown-table": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/mdast-util-definitions": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
+      "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
+      "dependencies": {
+        "unist-util-visit": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/mdast-util-to-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
+      "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/remark-parse": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+      "dependencies": {
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/remark-stringify": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+      "integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
+      "dependencies": {
+        "ccount": "^1.0.0",
+        "is-alphanumeric": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "longest-streak": "^2.0.1",
+        "markdown-escapes": "^1.0.0",
+        "markdown-table": "^1.1.0",
+        "mdast-util-compact": "^1.0.0",
+        "parse-entities": "^1.0.2",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "stringify-entities": "^1.0.1",
+        "unherit": "^1.0.4",
+        "xtend": "^4.0.1"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/slate": {
+      "version": "0.91.4",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.91.4.tgz",
+      "integrity": "sha512-aUJ3rpjrdi5SbJ5G1Qjr3arytfRkEStTmHjBfWq2A2Q8MybacIzkScSvGJjQkdTk3djCK9C9SEOt39sSeZFwTw==",
+      "dependencies": {
+        "immer": "^9.0.6",
+        "is-plain-object": "^5.0.0",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/slate-react": {
+      "version": "0.91.11",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.91.11.tgz",
+      "integrity": "sha512-2nS29rc2kuTTJrEUOXGyTkFATmTEw/R9KuUXadUYiz+UVwuFOUMnBKuwJWyuIBOsFipS+06SkIayEf5CKdARRQ==",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "@types/is-hotkey": "^0.1.1",
+        "@types/lodash": "^4.14.149",
+        "direction": "^1.0.3",
+        "is-hotkey": "^0.1.6",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.4",
+        "scroll-into-view-if-needed": "^2.2.20",
+        "tiny-invariant": "1.0.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "slate": ">=0.65.3"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/slate-react/node_modules/is-hotkey": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.8.tgz",
+      "integrity": "sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ=="
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/stringify-entities": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+      "dependencies": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/tiny-invariant": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/unist-builder": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
+      "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
+      "dependencies": {
+        "object-assign": "^4.1.0"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/unist-util-remove-position": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+      "dependencies": {
+        "unist-util-visit": "^1.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/unist-util-visit": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "dependencies": {
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "node_modules/decap-cms-widget-markdown/node_modules/vfile-location": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/decap-cms-widget-number": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-number/-/decap-cms-widget-number-3.1.1.tgz",
+      "integrity": "sha512-rS6bZ+tRrbjSnmWZBXh0MCOJp6ByA5lRDTmGBdKYuTxxfcTSX1Leu6pyUrIL87t+Weuf7crImCqiC2wk/Bs5wQ==",
+      "peerDependencies": {
+        "decap-cms-ui-default": "^3.0.0",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-widget-object": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-object/-/decap-cms-widget-object-3.1.2.tgz",
+      "integrity": "sha512-GoZIulFhyIuRFZAEqz8tyA+vEecX6dzMA5lIyC8YICXA0nHCGP70djZnfj64Bt3p6+2yJ9ZtT65uV31OliNvWg==",
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-immutable-proptypes": "^2.1.0"
+      }
+    },
+    "node_modules/decap-cms-widget-relation": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-relation/-/decap-cms-widget-relation-3.3.0.tgz",
+      "integrity": "sha512-4t9uoA+dxgyfROjs67iD5RCjqJ7FiQyjbqlRlIPX8vp0M25z5PWIsb9OKO3XPD8VCktOQxprNzLNCddfZwMJ5w==",
+      "dependencies": {
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/modifiers": "^6.0.1",
+        "@dnd-kit/sortable": "^7.0.2",
+        "react-select": "^4.0.0",
+        "react-window": "^1.8.5"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "@emotion/styled": "^11.11.0",
+        "decap-cms-lib-widgets": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "immutable": "^3.7.6",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/decap-cms-widget-select": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-select/-/decap-cms-widget-select-3.1.1.tgz",
+      "integrity": "sha512-CMQO/pDUfXp5uZoxggBq+3Ucrsif9WwHA8jjIB9SpgEEqF6a9zukGTqLneaW1jy1rCBTehGdAabeBmw89wjFlA==",
+      "dependencies": {
+        "react-select": "^4.0.0"
+      },
+      "peerDependencies": {
+        "decap-cms-lib-widgets": "^3.0.0",
+        "decap-cms-ui-default": "^3.0.0",
+        "immutable": "^3.7.6",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0",
+        "react-immutable-proptypes": "^2.1.0"
+      }
+    },
+    "node_modules/decap-cms-widget-string": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-string/-/decap-cms-widget-string-3.1.1.tgz",
+      "integrity": "sha512-/sEpZ73WZ1xuDzdbKXJ250N1I0zSJblIvDgoannj8BNKIAV7aNOQUQtb4Gs1uQK7ZzSQQIWzPqTtYng7dEGV6w==",
+      "peerDependencies": {
+        "decap-cms-ui-default": "^3.0.0",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decap-cms-widget-text": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decap-cms-widget-text/-/decap-cms-widget-text-3.1.1.tgz",
+      "integrity": "sha512-qyDZ+pD2aocsKrnuKRo/YzQAajcx/9hzZKxXwXPa1to7TPsfOuXN3jhSopMi7zqVNvzRP5DboMgwnE5oRYZ3sg==",
+      "dependencies": {
+        "react-textarea-autosize": "^8.0.0"
+      },
+      "peerDependencies": {
+        "decap-cms-ui-default": "^3.0.0",
+        "prop-types": "^15.7.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/decode-named-character-reference/node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/decode-uri-component": {
@@ -12754,14 +13660,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/direction": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/direction/-/direction-0.1.5.tgz",
-      "integrity": "sha512-HceXsAluGbXKCz2qCVbXFUH4Vn4eNMWxY5gzydMFMnS1zKSwvDASqLwcrYLIFDpwuZ63FUAqjDLEP1eicHt8DQ==",
-      "bin": {
-        "direction": "cli.js"
       }
     },
     "node_modules/dnd-core": {
@@ -14119,14 +15017,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/esrever": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/esrever/-/esrever-0.2.0.tgz",
-      "integrity": "sha512-1e9YJt6yQkyekt2BUjTky7LZWWVyC2cIpgdnsTAvMcnzXIZvlW/fTMPkxBcZoYhgih4d+EC+iw+yv9GIkz7vrw==",
-      "bin": {
-        "esrever": "bin/esrever"
       }
     },
     "node_modules/estraverse": {
@@ -17304,11 +18194,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-document": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz",
-      "integrity": "sha512-8E7H2Xxibav+/rQTTtm6gFlSQwDoAQg667yheA+vWQr/amxEuswChzGo4MIbOJJoR0SMpDyhbUqWp3FpIfwD9A=="
-    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -17477,14 +18362,6 @@
       "integrity": "sha512-hU5pnODTo87slfs9MUFO3vpJr23AESJHmF20T3ivqQJZ/Wz0W5TxjSrGoyB6X538Shyi6tCCpQSeBoV88F9NYA==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/get-window": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-window/-/get-window-1.1.2.tgz",
-      "integrity": "sha512-yjWpFcy9fjhLQHW1dPtg9ga4pmizLY8y4ZSHdGrAQ1NU277MRhnGnnLPxe19X8W5lWVsCZz++5xEuNozWMVmTw==",
-      "dependencies": {
-        "get-document": "1"
       }
     },
     "node_modules/gifwrap": {
@@ -19538,11 +20415,6 @@
       "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
       "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
     },
-    "node_modules/is-in-browser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
-    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -19695,6 +20567,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19896,6 +20769,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "node_modules/is-valid-domain": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.1.6.tgz",
@@ -19960,11 +20838,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/is-window": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
-      "integrity": "sha512-uj00kdXyZb9t9RcAUAwMZAnkBUwdYGhYlt7djMXhfyhUCzwNba50tIiBKR7q0l7tdoBtFVw/3JmLY6fI3rmZmg=="
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -22093,6 +22966,121 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-2.0.2.tgz",
+      "integrity": "sha512-8gmkKVp9v6+Tgjtq6SYx9kGPpTf6FVYRa53/DLh479aldR9AyP48qeVOgNZ5X7QUK7nOy4yw7vg6mbiGcs9jWQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/mdast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/mdast-util-to-markdown": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-2.0.0.tgz",
@@ -22530,6 +23518,94 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.7",
@@ -23267,944 +24343,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    },
-    "node_modules/netlify-cms": {
-      "version": "2.10.192",
-      "resolved": "https://registry.npmjs.org/netlify-cms/-/netlify-cms-2.10.192.tgz",
-      "integrity": "sha512-Bh0MH4w4rELSswBi+insLfKgHd80Jx43bhyZiMU9j1aCv+WEQqw9ZNu/0cqitCZP72VDyI5OSn8112DaZd5bYQ==",
-      "dependencies": {
-        "codemirror": "^5.46.0",
-        "create-react-class": "^15.7.0",
-        "netlify-cms-app": "^2.15.72",
-        "netlify-cms-media-library-cloudinary": "^1.3.10",
-        "netlify-cms-media-library-uploadcare": "^0.5.10",
-        "react": "^16.8.4",
-        "react-dom": "^16.8.4"
-      }
-    },
-    "node_modules/netlify-cms-app": {
-      "version": "2.15.72",
-      "resolved": "https://registry.npmjs.org/netlify-cms-app/-/netlify-cms-app-2.15.72.tgz",
-      "integrity": "sha512-oUqLegvCa2UdOK42tLByyol6RnLG3mMr55jj9W5DX199ODGZlD6V39S5UlrDD2r183SUAgDYersq5LjeBTTz0Q==",
-      "dependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "codemirror": "^5.46.0",
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "moment": "^2.24.0",
-        "netlify-cms-backend-azure": "^1.3.1",
-        "netlify-cms-backend-bitbucket": "^2.14.0",
-        "netlify-cms-backend-git-gateway": "^2.13.1",
-        "netlify-cms-backend-github": "^2.14.1",
-        "netlify-cms-backend-gitlab": "^2.13.0",
-        "netlify-cms-backend-proxy": "^1.2.3",
-        "netlify-cms-backend-test": "^2.11.3",
-        "netlify-cms-core": "^2.55.2",
-        "netlify-cms-editor-component-image": "^2.7.0",
-        "netlify-cms-lib-auth": "^2.4.2",
-        "netlify-cms-lib-util": "^2.15.1",
-        "netlify-cms-lib-widgets": "^1.8.1",
-        "netlify-cms-locales": "^1.39.0",
-        "netlify-cms-ui-default": "^2.15.5",
-        "netlify-cms-widget-boolean": "^2.4.1",
-        "netlify-cms-widget-code": "^1.3.4",
-        "netlify-cms-widget-colorstring": "^1.1.2",
-        "netlify-cms-widget-date": "^2.6.3",
-        "netlify-cms-widget-datetime": "^2.7.4",
-        "netlify-cms-widget-file": "^2.12.1",
-        "netlify-cms-widget-image": "^2.8.1",
-        "netlify-cms-widget-list": "^2.10.1",
-        "netlify-cms-widget-map": "^1.5.1",
-        "netlify-cms-widget-markdown": "^2.15.1",
-        "netlify-cms-widget-number": "^2.5.0",
-        "netlify-cms-widget-object": "^2.7.2",
-        "netlify-cms-widget-relation": "^2.11.1",
-        "netlify-cms-widget-select": "^2.8.2",
-        "netlify-cms-widget-string": "^2.3.0",
-        "netlify-cms-widget-text": "^2.4.1",
-        "prop-types": "^15.7.2",
-        "react-immutable-proptypes": "^2.1.0",
-        "uuid": "^3.3.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-app/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/netlify-cms-backend-azure": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-azure/-/netlify-cms-backend-azure-1.3.1.tgz",
-      "integrity": "sha512-mD0vYjhZAUjjc6/WeK/ei+uvgwYAMIE8zNxPCNYLBLLGS5s5bk4DdKeqTMwtzonjz+wfvMc1VVBEj8CHGeP8ZA==",
-      "dependencies": {
-        "js-base64": "^3.0.0",
-        "semaphore": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.9",
-        "@emotion/styled": "^10.0.9",
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "netlify-cms-lib-auth": "^2.3.0",
-        "netlify-cms-lib-util": "^2.12.3",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-backend-bitbucket": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-bitbucket/-/netlify-cms-backend-bitbucket-2.14.0.tgz",
-      "integrity": "sha512-8629cRpUaQ4MulD8OjCqwuqtLjj5G12S6SZfM/wZkibx+T9JIetVNV4Fqj7ddMGXX+NLjw+uiig3wtPz3jgM1Q==",
-      "dependencies": {
-        "common-tags": "^1.8.0",
-        "js-base64": "^3.0.0",
-        "semaphore": "^1.1.0",
-        "what-the-diff": "^0.6.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "netlify-cms-lib-auth": "^2.3.0",
-        "netlify-cms-lib-util": "^2.12.3",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-backend-git-gateway": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-git-gateway/-/netlify-cms-backend-git-gateway-2.13.1.tgz",
-      "integrity": "sha512-0prZbfmDd7k2Ww16kS1wayCBH/Er5fj/2OxdLPxoanQSRmCmTF1v9RRsy/52UR4mQdZd1e7Y5zgpIeoHk1aq6g==",
-      "dependencies": {
-        "gotrue-js": "^0.9.24",
-        "ini": "^2.0.0",
-        "jwt-decode": "^3.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "lodash": "^4.17.11",
-        "netlify-cms-backend-bitbucket": "^2.12.8",
-        "netlify-cms-backend-github": "^2.11.9",
-        "netlify-cms-backend-gitlab": "^2.9.9",
-        "netlify-cms-lib-auth": "^2.3.0",
-        "netlify-cms-lib-util": "^2.12.3",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-backend-git-gateway/node_modules/ini": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/netlify-cms-backend-github": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-github/-/netlify-cms-backend-github-2.14.1.tgz",
-      "integrity": "sha512-To7ZxqMUQuV7TBrckhKUT/uwHtVbRcs6RzDPayYkkA5j5SLlrQY2nJYpPQgJjEktCLYMPvcz2HZXTzWMOyvDDA==",
-      "dependencies": {
-        "apollo-cache-inmemory": "^1.6.2",
-        "apollo-client": "^2.6.3",
-        "apollo-link-context": "^1.0.18",
-        "apollo-link-http": "^1.5.15",
-        "common-tags": "^1.8.0",
-        "graphql": "^15.0.0",
-        "graphql-tag": "^2.10.1",
-        "js-base64": "^3.0.0",
-        "semaphore": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "lodash": "^4.17.11",
-        "netlify-cms-lib-auth": "^2.3.0",
-        "netlify-cms-lib-util": "^2.12.3",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-backend-github/node_modules/graphql": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/netlify-cms-backend-gitlab": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-gitlab/-/netlify-cms-backend-gitlab-2.13.0.tgz",
-      "integrity": "sha512-2x837ljDP/u0oBGTTc5D6CKFjZph1aNRlYiS1wzxLVPseXYuheDWpeTaNGroHbDTaZjIU9XS72Ezpeh54YqUlw==",
-      "dependencies": {
-        "apollo-cache-inmemory": "^1.6.2",
-        "apollo-client": "^2.6.3",
-        "apollo-link-context": "^1.0.18",
-        "apollo-link-http": "^1.5.15",
-        "js-base64": "^3.0.0",
-        "semaphore": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "netlify-cms-lib-auth": "^2.3.0",
-        "netlify-cms-lib-util": "^2.12.3",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-backend-proxy": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-proxy/-/netlify-cms-backend-proxy-1.2.3.tgz",
-      "integrity": "sha512-HSbTxER/QaYonr8JC8W2eULKmvCwgH42NHNqKAz4QZNE5qNdbNk7pccfHHa3YjE4JcEcpJEMkb3+GrdDhq2QCw==",
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "netlify-cms-lib-util": "^2.12.3",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-backend-test": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-test/-/netlify-cms-backend-test-2.11.3.tgz",
-      "integrity": "sha512-L7WXjryPcZ8immIkrdDauZjqiOrKS5NIcc6ewP9QI1BrZr2jeqwDpeN2/45fPdg/TRxtRA3ik3MuKXXLJRJ0MQ==",
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "lodash": "^4.17.11",
-        "netlify-cms-lib-util": "^2.12.3",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "uuid": "^3.3.2"
-      }
-    },
-    "node_modules/netlify-cms-core": {
-      "version": "2.55.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms-core/-/netlify-cms-core-2.55.2.tgz",
-      "integrity": "sha512-g7pU53axFQt8n3zzyNt/FI8vPv/lZ+G4cJnh5sfyWSM9/rK4wr7DeDfZTbmjPeonfuUFiD1UrFqzwqAnT7BjTA==",
-      "dependencies": {
-        "@iarna/toml": "2.2.5",
-        "ajv": "8.1.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-keywords": "^5.0.0",
-        "clean-stack": "^4.1.0",
-        "copy-text-to-clipboard": "^3.0.0",
-        "deepmerge": "^4.2.2",
-        "diacritics": "^1.3.0",
-        "fuzzy": "^0.1.1",
-        "gotrue-js": "^0.9.24",
-        "gray-matter": "^4.0.2",
-        "history": "^4.7.2",
-        "immer": "^9.0.0",
-        "js-base64": "^3.0.0",
-        "jwt-decode": "^3.0.0",
-        "node-polyglot": "^2.3.0",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4",
-        "react-dnd": "^14.0.0",
-        "react-dnd-html5-backend": "^14.0.0",
-        "react-dom": "^16.8.4",
-        "react-frame-component": "^5.2.1",
-        "react-hot-loader": "^4.8.0",
-        "react-immutable-proptypes": "^2.1.0",
-        "react-is": "16.13.1",
-        "react-markdown": "^6.0.2",
-        "react-modal": "^3.8.1",
-        "react-polyglot": "^0.7.0",
-        "react-redux": "^7.2.0",
-        "react-router-dom": "^5.2.0",
-        "react-scroll-sync": "^0.9.0",
-        "react-sortable-hoc": "^2.0.0",
-        "react-split-pane": "^0.1.85",
-        "react-topbar-progress-indicator": "^4.0.0",
-        "react-virtualized-auto-sizer": "^1.0.2",
-        "react-waypoint": "^10.0.0",
-        "react-window": "^1.8.5",
-        "redux": "^4.0.5",
-        "redux-devtools-extension": "^2.13.8",
-        "redux-notifications": "^4.0.1",
-        "redux-thunk": "^2.3.0",
-        "remark-gfm": "1.0.0",
-        "sanitize-filename": "^1.6.1",
-        "semaphore": "^1.0.5",
-        "tomlify-j0.4": "^3.0.0-alpha.0",
-        "url": "^0.11.0",
-        "url-join": "^4.0.1",
-        "what-input": "^5.1.4",
-        "yaml": "^1.8.3"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "moment": "^2.24.0",
-        "netlify-cms-editor-component-image": "^2.6.7",
-        "netlify-cms-lib-auth": "^2.3.0",
-        "netlify-cms-lib-util": "^2.12.3",
-        "netlify-cms-lib-widgets": "^1.6.1",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0",
-        "react-immutable-proptypes": "^2.1.0"
-      }
-    },
-    "node_modules/netlify-cms-core/node_modules/ajv": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
-      "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/netlify-cms-core/node_modules/clean-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dependencies": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/netlify-cms-core/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/netlify-cms-core/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/netlify-cms-core/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/netlify-cms-core/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/netlify-cms-core/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/netlify-cms-editor-component-image": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-editor-component-image/-/netlify-cms-editor-component-image-2.7.0.tgz",
-      "integrity": "sha512-pQ7vcviNSHz0tAkW+lpw1zAh2BNplb5R8w58ZeA6svVte+v9Db8n54mZeVwk6y+e7quZoEl4isV1LMVcox5HLQ==",
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-lib-auth": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms-lib-auth/-/netlify-cms-lib-auth-2.4.2.tgz",
-      "integrity": "sha512-Ygq6qhYndgyxIHtWZ09dMGh6FgBnsEpaSUryvTholvAK4smRJMkOjlwZTSoblM82k/hE7hl/PD8EVIozafVcXg==",
-      "peerDependencies": {
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "uuid": "^3.3.2"
-      }
-    },
-    "node_modules/netlify-cms-lib-util": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-lib-util/-/netlify-cms-lib-util-2.15.1.tgz",
-      "integrity": "sha512-Kg9aK40VjNRoD/BQ8MrYqj5K1ac62cjWrH3x+NqFEIyBQkpGtWcKzm6vrAcNe61LirW64YccsVAf+ll+ZDMJGA==",
-      "dependencies": {
-        "js-sha256": "^0.9.0",
-        "localforage": "^1.7.3",
-        "semaphore": "^1.1.0"
-      },
-      "peerDependencies": {
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11"
-      }
-    },
-    "node_modules/netlify-cms-lib-widgets": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-lib-widgets/-/netlify-cms-lib-widgets-1.8.1.tgz",
-      "integrity": "sha512-1tDCQJ90Flv8EcDTbCc395+oB3PpS08B3KnuMX0h1r601Z1/ORw+vSYQOTDlL+TvC13epmtmUwG29O0LjEl0QA==",
-      "peerDependencies": {
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "moment": "^2.24.0"
-      }
-    },
-    "node_modules/netlify-cms-locales": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-locales/-/netlify-cms-locales-1.39.0.tgz",
-      "integrity": "sha512-79MhSw588IEMtd0SLObSIiTC0cv7krYqJOtYnapPwJcUYZ87nFz/le9v/KvJglb5OxmpvlNLRyGvbyK5Er4v4w=="
-    },
-    "node_modules/netlify-cms-media-library-cloudinary": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/netlify-cms-media-library-cloudinary/-/netlify-cms-media-library-cloudinary-1.3.10.tgz",
-      "integrity": "sha512-F9ccWD4+3uEYoGHaO+abqBDfhITw3MA2Tsz1LwtVxdp8ExMCrZxhLrR1VPetUlOLe5BxuZD+WOA3cvRnj3rRwA==",
-      "peerDependencies": {
-        "netlify-cms-lib-util": "^2.12.3"
-      }
-    },
-    "node_modules/netlify-cms-media-library-uploadcare": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/netlify-cms-media-library-uploadcare/-/netlify-cms-media-library-uploadcare-0.5.10.tgz",
-      "integrity": "sha512-jAkxWepjRkQujuLM2z2ix+njSdiQxzzabmVXegpPH6ZLVGNepYVvjAsHMMpFCJAb1EPbdHuEn69ajsJDq+52CQ==",
-      "dependencies": {
-        "uploadcare-widget": "^3.7.0",
-        "uploadcare-widget-tab-effects": "^1.4.0"
-      }
-    },
-    "node_modules/netlify-cms-ui-default": {
-      "version": "2.15.5",
-      "resolved": "https://registry.npmjs.org/netlify-cms-ui-default/-/netlify-cms-ui-default-2.15.5.tgz",
-      "integrity": "sha512-hrdS1zEF/Pb3jpxqHdRrb4cOxsTUBHgSr7doyRfZaa2il6S5s/Pgq49Otu6xr0CHiGNB721U4mXxFn8nCigcYw==",
-      "dependencies": {
-        "react-aria-menubutton": "^7.0.0",
-        "react-toggled": "^1.1.2",
-        "react-transition-group": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "lodash": "^4.17.11",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-boolean": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-boolean/-/netlify-cms-widget-boolean-2.4.1.tgz",
-      "integrity": "sha512-/0S10iXZVivlUKI6smyb+cE6bZQT9W8/Y2JJJYpP6vpoOynH0F78hSDUERv+3C428SPotyHeCLRneHoH44fkfQ==",
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "lodash": "^4.17.11",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "react-immutable-proptypes": "^2.1.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-code": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-code/-/netlify-cms-widget-code-1.3.4.tgz",
-      "integrity": "sha512-WNrL4QIaTE9cIi4ubaLZ9WyFzoVSVLh25nRy+GsrIHJ0ltd0Y8iL/JzGsH7onpmOMX5KgaYeaHkoPGcrpc3MIQ==",
-      "dependencies": {
-        "react-codemirror2": "^7.0.0",
-        "react-select": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "codemirror": "^5.46.0",
-        "lodash": "^4.17.11",
-        "netlify-cms-ui-default": "^2.12.1",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-colorstring": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-colorstring/-/netlify-cms-widget-colorstring-1.1.2.tgz",
-      "integrity": "sha512-KsLSU4XQ6EL4aQYAb4tlTaZoO0FE1pbwe9eCZ8njg4nOc2HUcHyzjOEgwFfdnWdyokQFRTbweZ01/9caknZE8w==",
-      "dependencies": {
-        "react-color": "^2.18.1",
-        "validate-color": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-date": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-date/-/netlify-cms-widget-date-2.6.3.tgz",
-      "integrity": "sha512-ea9muRQZsQtk61s8VhgwtoMfz7FJpPF7xx4xFhQ7UTrGUOat/mtLxhIb+XASIdhzQ8lK+W+BfnH0nZqKpOR/9g==",
-      "dependencies": {
-        "react-datetime": "^3.1.1"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "moment": "^2.24.0",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-datetime": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-datetime/-/netlify-cms-widget-datetime-2.7.4.tgz",
-      "integrity": "sha512-7rMbpQvjEY85ogts3MBcO+JoIny9k2iG7QHozEhsPxn0EGxhTOVQV8PJGQpesEJNIPXm0N4n3/JDyF6y4xWSIg==",
-      "dependencies": {
-        "react-datetime": "^3.1.1"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "netlify-cms-widget-date": "^2.5.7",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-file": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-file/-/netlify-cms-widget-file-2.12.1.tgz",
-      "integrity": "sha512-u80aN3X0xSi+LoxJrvjRR5q1xPjR4daDxiyhtXutiA8qg2/kerYOftdAWhsZ2aMyIpvXMPasNCqpcic+wnknBA==",
-      "dependencies": {
-        "array-move": "4.0.0",
-        "common-tags": "^1.8.0",
-        "react-sortable-hoc": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "immutable": "^3.7.6",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "react-immutable-proptypes": "^2.1.0",
-        "uuid": "^3.3.2"
-      }
-    },
-    "node_modules/netlify-cms-widget-image": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-image/-/netlify-cms-widget-image-2.8.1.tgz",
-      "integrity": "sha512-wuB++G1h3VJJW/EdmEyc7jNMyQtULdcxnAjTdTHnJpwn+WbC0t1m3phxP2gqQF4je9K6+5YppBwtw3xf0hNjCA==",
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "immutable": "^3.7.6",
-        "netlify-cms-ui-default": "^2.12.1",
-        "netlify-cms-widget-file": "^2.9.2",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-list": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-list/-/netlify-cms-widget-list-2.10.1.tgz",
-      "integrity": "sha512-seDpwnxHASkDEQl/+bkWYt0JNr1LLKyjtlmz/JaLEciEa5sSauC6rmYtamHY2y/6mN2QZZdSGP0uw4+qNlaubQ==",
-      "dependencies": {
-        "react-sortable-hoc": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "netlify-cms-lib-widgets": "^1.6.1",
-        "netlify-cms-ui-default": "^2.12.1",
-        "netlify-cms-widget-object": "^2.6.2",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "react-immutable-proptypes": "^2.1.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-map/-/netlify-cms-widget-map-1.5.1.tgz",
-      "integrity": "sha512-zasnqrdTd3HruFjaZi+JvXgwXXxh+TF+aZ9ueFeaIIgvzLLSwYaxDlqX9Bby1iark/4jVhPb9/yuqEM0cLBHxg==",
-      "dependencies": {
-        "ol": "^6.9.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "lodash": "^4.17.11",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "react-immutable-proptypes": "^2.1.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-markdown/-/netlify-cms-widget-markdown-2.15.1.tgz",
-      "integrity": "sha512-hw5neYVKPFJVNiyymQ1TUzChoQmY23BV6K2VxJQvb+WEABhFIv0kJY42q3QKfqN53Wh4sPGv+yFxwaeIVPvQBQ==",
-      "dependencies": {
-        "dompurify": "^2.2.6",
-        "is-hotkey": "^0.2.0",
-        "mdast-util-definitions": "^1.2.3",
-        "mdast-util-to-string": "^1.0.5",
-        "rehype-parse": "^6.0.0",
-        "rehype-remark": "^8.0.0",
-        "rehype-stringify": "^7.0.0",
-        "remark-parse": "^6.0.3",
-        "remark-rehype": "^4.0.0",
-        "remark-stringify": "^6.0.4",
-        "slate": "^0.47.0",
-        "slate-base64-serializer": "^0.2.107",
-        "slate-plain-serializer": "^0.7.1",
-        "slate-react": "^0.22.0",
-        "slate-soft-break": "^0.9.0",
-        "unified": "^7.1.0",
-        "unist-builder": "^1.0.3",
-        "unist-util-visit-parents": "^2.0.1"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0",
-        "react-immutable-proptypes": "^2.1.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/markdown-table": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
-      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/mdast-util-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
-      "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
-      "dependencies": {
-        "unist-util-visit": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/mdast-util-to-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
-      "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/remark-parse": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
-      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
-      "dependencies": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.1.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/remark-stringify": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
-      "integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
-      "dependencies": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/stringify-entities": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
-      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
-      "dependencies": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/unified": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "@types/vfile": "^3.0.0",
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^3.0.0",
-        "x-is-string": "^0.1.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/unist-builder": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
-      "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
-      "dependencies": {
-        "object-assign": "^4.1.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/unist-util-remove-position": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/unist-util-stringify-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/vfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
-      "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
-      "dependencies": {
-        "is-buffer": "^2.0.0",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/vfile-location": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/netlify-cms-widget-markdown/node_modules/vfile-message": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-      "dependencies": {
-        "unist-util-stringify-position": "^1.1.1"
-      }
-    },
-    "node_modules/netlify-cms-widget-number": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-number/-/netlify-cms-widget-number-2.5.0.tgz",
-      "integrity": "sha512-4F7c+xkLba4UQTxhqfO8HTKfzCgQLeyDfdvJJOm/RXJjvcK+tp4MnTPqMI3OHBKi56Ay/oV1Q8OHIQ6grT9bpQ==",
-      "peerDependencies": {
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-object": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-object/-/netlify-cms-widget-object-2.7.2.tgz",
-      "integrity": "sha512-x2jyRHcIBymdEZSFVoJrm6gVlCeySs4n/p8t+wM1n0HB5av9z5hnL/AypiwnNAUC2Bf+0AtrfFnQg2K6gZUcGQ==",
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "react-immutable-proptypes": "^2.1.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-relation": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-relation/-/netlify-cms-widget-relation-2.11.1.tgz",
-      "integrity": "sha512-oHnEgYKSqyU/XOyIHE/jvqLhFAk4YbaU0Xmwv+YBY38F1KuSQ0LUnm0slXlKO5jfl4jdCXnBGzgEcw8XEOviDw==",
-      "dependencies": {
-        "react-select": "^4.0.0",
-        "react-sortable-hoc": "^2.0.0",
-        "react-window": "^1.8.5"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
-        "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
-        "netlify-cms-lib-widgets": "^1.6.1",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "uuid": "^3.3.2"
-      }
-    },
-    "node_modules/netlify-cms-widget-select": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-select/-/netlify-cms-widget-select-2.8.2.tgz",
-      "integrity": "sha512-uBMJPdoH4hEw35HbyE9FSFHj+xSPWhzp8FK8O7XkU3LlcvZarYoOaw59BGs8/7VUE10t4gCgGNqkYSMRiQ5eCg==",
-      "dependencies": {
-        "react-select": "^4.0.0"
-      },
-      "peerDependencies": {
-        "immutable": "^3.7.6",
-        "netlify-cms-lib-widgets": "^1.6.1",
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0",
-        "react-immutable-proptypes": "^2.1.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-string": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-string/-/netlify-cms-widget-string-2.3.0.tgz",
-      "integrity": "sha512-3TeDNob5wj8jyoqsuy7hPTtXNMwSx8yXzUrBPWVSMedvFYccqylQS3TamwMMM63S83zNC0SrqatYMSUiEG5dhw==",
-      "peerDependencies": {
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms-widget-text": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-text/-/netlify-cms-widget-text-2.4.1.tgz",
-      "integrity": "sha512-fFuHtID0GfjFwugEyQmHld2nKFe8p42NnvXsayneldcl1YL2jIOk1oastJV1sRx1FB7BIyj1WzJWoaWXNMWwng==",
-      "dependencies": {
-        "react-textarea-autosize": "^8.0.0"
-      },
-      "peerDependencies": {
-        "netlify-cms-ui-default": "^2.12.1",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/netlify-cms/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/netlify-cms/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/netlify-cms/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "node_modules/next-tick": {
       "version": "1.1.0",
@@ -27963,18 +28101,6 @@
         "react": "*"
       }
     },
-    "node_modules/react-datetime": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-datetime/-/react-datetime-3.2.0.tgz",
-      "integrity": "sha512-w5XdeNIGzBht9CadaZIJhKUhEcDTgH0XokKxGPCxeeJRYL7B3HIKA8CM6Q0xej2JFJt0n5d+zi3maMwaY3262A==",
-      "dependencies": {
-        "prop-types": "^15.5.7"
-      },
-      "peerDependencies": {
-        "moment": "^2.16.0",
-        "react": "^16.5.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -28181,42 +28307,6 @@
       },
       "peerDependencies": {
         "react": ">=16.3.0"
-      }
-    },
-    "node_modules/react-hot-loader": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.1.tgz",
-      "integrity": "sha512-ZlqCfVRqDJmMXTulUGic4lN7Ic1SXgHAFw7y/Jb7t25GBgTR0fYAJ8uY4mrpxjRyWGWmqw77qJQGnYbzCvBU7g==",
-      "dependencies": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^2.0.3",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "@types/react": "^15.0.0 || ^16.0.0 || ^17.0.0",
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-hot-loader/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/react-immutable-proptypes": {
@@ -28524,21 +28614,6 @@
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-sortable-hoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz",
-      "integrity": "sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==",
-      "dependencies": {
-        "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.5.7",
-        "react": "^16.3.0 || ^17.0.0",
-        "react-dom": "^16.3.0 || ^17.0.0"
-      }
-    },
     "node_modules/react-split-pane": {
       "version": "0.1.92",
       "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.92.tgz",
@@ -28577,13 +28652,16 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-toggled": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/react-toggled/-/react-toggled-1.2.7.tgz",
-      "integrity": "sha512-3am1uA5ZzDwUkReEuUkK+fJ0DAYcGiLraWEPqXfL1kKD/NHbbB7fB/t+5FflMGd+FA6n9hih1es4pui1yzKi0w==",
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
       "peerDependencies": {
-        "prop-types": ">=15",
-        "react": ">=15"
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-topbar-progress-indicator": {
@@ -29556,6 +29634,28 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-slate": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/remark-slate/-/remark-slate-1.8.6.tgz",
+      "integrity": "sha512-1Gmt5MGw25MRVP+0xTXqw9JQDWfRNWujD4YFCPg036a9DZYhn7mLFjM6jreHB+9hKa6RCMOm5thiXznAmdn8Ug==",
+      "dependencies": {
+        "@types/escape-html": "^1.0.0",
+        "escape-html": "^1.0.3"
+      }
+    },
+    "node_modules/remark-slate-transformer": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/remark-slate-transformer/-/remark-slate-transformer-0.7.5.tgz",
+      "integrity": "sha512-jyLLjp0wNoQnzy6kwDjUkyjpInCb3NoeJ+sEoNkWVWYpLNSln0toXtsqkYWvM9SH36RpNIxJyNRM/i2nhoJJdw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.10",
+        "mdast-util-math": "^2.0.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "unified": ">=10.1.0"
+      }
+    },
     "node_modules/remark-stringify": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
@@ -29701,14 +29801,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha512-vuNYXC7gG7IeVNBC1xUllqCcZKRbJoSPOBhnTEcAIiKCsbuef6zO3F0Rve3isPMMoNoQRWjQwbAgAjHUHniyEA==",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -29740,6 +29832,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -30449,6 +30546,14 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
+      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
+      "dependencies": {
+        "compute-scroll-into-view": "^1.0.20"
+      }
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -30466,11 +30571,6 @@
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "dev": true
-    },
-    "node_modules/selection-is-backward": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/selection-is-backward/-/selection-is-backward-1.0.0.tgz",
-      "integrity": "sha512-C+6PCOO55NLCfS8uQjUKV/6E5XMuUcfOVsix5m0QqCCCKi495NgeQVNfWtAaD71NKHsdmFCJoXUGfir3qWdr9A=="
     },
     "node_modules/selfsigned": {
       "version": "2.4.1",
@@ -30751,11 +30851,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/shallow-compare/-/shallow-compare-1.2.2.tgz",
       "integrity": "sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg=="
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/sharp": {
       "version": "0.32.6",
@@ -31135,24 +31230,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/slate": {
-      "version": "0.47.9",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.47.9.tgz",
-      "integrity": "sha512-EK4O6b7lGt+g5H9PGw9O5KCM4RrOvOgE9mPi3rzQ0zDRlgAb2ga4TdpS6XNQbrsJWsc8I1fjaSsUeCqCUhhi9A==",
-      "dependencies": {
-        "debug": "^3.1.0",
-        "direction": "^0.1.5",
-        "esrever": "^0.2.0",
-        "is-plain-object": "^2.0.4",
-        "lodash": "^4.17.4",
-        "tiny-invariant": "^1.0.1",
-        "tiny-warning": "^0.0.3",
-        "type-of": "^2.0.1"
-      },
-      "peerDependencies": {
-        "immutable": ">=3.8.1 || >4.0.0-rc"
-      }
-    },
     "node_modules/slate-base64-serializer": {
       "version": "0.2.115",
       "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.2.115.tgz",
@@ -31164,27 +31241,16 @@
         "slate": ">=0.32.0 <0.50.0"
       }
     },
-    "node_modules/slate-dev-environment": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/slate-dev-environment/-/slate-dev-environment-0.2.5.tgz",
-      "integrity": "sha512-oLD8Fclv/RqrDv6RYfN2CRzNcRXsUB99Qgcw5L/njTjxAdDPguV6edQ3DgUG9Q2pLFLhI15DwsKClzVfFzfwGQ==",
+    "node_modules/slate-history": {
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.93.0.tgz",
+      "integrity": "sha512-Gr1GMGPipRuxIz41jD2/rbvzPj8eyar56TVMyJBvBeIpQSSjNISssvGNDYfJlSWM8eaRqf6DAcxMKzsLCYeX6g==",
       "dependencies": {
-        "is-in-browser": "^1.1.3"
+        "is-plain-object": "^5.0.0"
+      },
+      "peerDependencies": {
+        "slate": ">=0.65.3"
       }
-    },
-    "node_modules/slate-hotkeys": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/slate-hotkeys/-/slate-hotkeys-0.2.11.tgz",
-      "integrity": "sha512-xhq/TlI74dRbO57O4ulGsvCcV4eaQ5nEEz9noZjeNLtNzFRd6lSgExRqAJqKGGIeJw+FnJ3OcqGvdb5CEc9/Ew==",
-      "dependencies": {
-        "is-hotkey": "0.1.4",
-        "slate-dev-environment": "^0.2.2"
-      }
-    },
-    "node_modules/slate-hotkeys/node_modules/is-hotkey": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.4.tgz",
-      "integrity": "sha512-Py+aW4r5mBBY18TGzGz286/gKS+fCQ0Hee3qkaiSmEPiD0PqFpe0wuA3l7rTOUKyeXl8Mxf3XzJxIoTlSv+kxA=="
     },
     "node_modules/slate-plain-serializer": {
       "version": "0.7.13",
@@ -31195,72 +31261,6 @@
         "slate": ">=0.46.0 <0.50.0"
       }
     },
-    "node_modules/slate-prop-types": {
-      "version": "0.5.44",
-      "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.5.44.tgz",
-      "integrity": "sha512-JS0iW7uaciE/W3ADuzeN1HOnSjncQhHPXJ65nZNQzB0DF7mXVmbwQKI6cmCo/xKni7XRJT0JbWSpXFhEdPiBUA==",
-      "peerDependencies": {
-        "immutable": ">=3.8.1",
-        "slate": ">=0.32.0 <0.50.0"
-      }
-    },
-    "node_modules/slate-react": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.22.10.tgz",
-      "integrity": "sha512-B2Ms1u/REbdd8yKkOItKgrw/tX8klgz5l5x6PP86+oh/yqmB6EHe0QyrYlQ9fc3WBlJUVTOL+nyAP1KmlKj2/w==",
-      "dependencies": {
-        "debug": "^3.1.0",
-        "get-window": "^1.1.1",
-        "is-window": "^1.0.2",
-        "lodash": "^4.1.1",
-        "memoize-one": "^4.0.0",
-        "prop-types": "^15.5.8",
-        "react-immutable-proptypes": "^2.1.0",
-        "selection-is-backward": "^1.0.0",
-        "slate-base64-serializer": "^0.2.112",
-        "slate-dev-environment": "^0.2.2",
-        "slate-hotkeys": "^0.2.9",
-        "slate-plain-serializer": "^0.7.11",
-        "slate-prop-types": "^0.5.42",
-        "slate-react-placeholder": "^0.2.9",
-        "tiny-invariant": "^1.0.1",
-        "tiny-warning": "^0.0.3"
-      },
-      "peerDependencies": {
-        "immutable": ">=3.8.1 || >4.0.0-rc",
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0",
-        "slate": ">=0.47.0"
-      }
-    },
-    "node_modules/slate-react-placeholder": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/slate-react-placeholder/-/slate-react-placeholder-0.2.9.tgz",
-      "integrity": "sha512-YSJ9Gb4tGpbzPje3eNKtu26hWM8ApxTk9RzjK+6zfD5V/RMTkuWONk24y6c9lZk0OAYNZNUmrnb/QZfU3j9nag==",
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "slate": ">=0.47.0",
-        "slate-react": ">=0.22.0"
-      }
-    },
-    "node_modules/slate-react/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/slate-react/node_modules/memoize-one": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
-      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
-    },
-    "node_modules/slate-react/node_modules/tiny-warning": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-0.0.3.tgz",
-      "integrity": "sha512-r0SSA5Y5IWERF9Xh++tFPx0jITBgGggOsRLDWWew6YRw/C2dr4uNO1fw1vanrBmHsICmPyMLNBZboTlxUmUuaA=="
-    },
     "node_modules/slate-soft-break": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/slate-soft-break/-/slate-soft-break-0.9.0.tgz",
@@ -31269,30 +31269,6 @@
         "slate": ">=0.42.2",
         "slate-react": ">=0.19.3"
       }
-    },
-    "node_modules/slate/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/slate/node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/slate/node_modules/tiny-warning": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-0.0.3.tgz",
-      "integrity": "sha512-r0SSA5Y5IWERF9Xh++tFPx0jITBgGggOsRLDWWew6YRw/C2dr4uNO1fw1vanrBmHsICmPyMLNBZboTlxUmUuaA=="
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
@@ -32465,6 +32441,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/svgo-loader": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/svgo-loader/-/svgo-loader-3.0.3.tgz",
+      "integrity": "sha512-6YdWYge3h0aCb8xHvPhGP4hofIU1OWfZm0I8bteab7hddeRN4fl3aIkN8Z/ZB/ji9QrMOd6C8wT8F1p31GUwuQ==",
+      "dependencies": {
+        "loader-utils": "^2.0.3",
+        "svgo": "^2.8.0"
       }
     },
     "node_modules/svgo/node_modules/commander": {
@@ -34415,11 +34400,6 @@
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
       "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
-    "node_modules/validate-color": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/validate-color/-/validate-color-2.2.4.tgz",
-      "integrity": "sha512-Znolz+b6CwW6eBXYld7MFM3O7funcdyRfjKC/X9hqYV/0VcC5LB/L45mff7m3dIn9wdGdNOAQ/fybNuD5P/HDw=="
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -35733,11 +35713,6 @@
         }
       }
     },
-    "node_modules/x-is-string": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-      "integrity": "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w=="
-    },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
@@ -36209,9 +36184,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "netlify-cms": "^2.10.192",
-        "netlify-cms-app": "^2.15.72",
-        "netlify-cms-backend-proxy": "^1.2.3",
+        "@alexwilson/legacy-components": "^1.0.0",
+        "decap-cms": "^3.1.10",
+        "decap-cms-app": "^3.1.10",
+        "decap-cms-backend-proxy": "^3.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "uuid": "^9.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36198,16 +36198,93 @@
         "@babel/preset-react": "^7.24.6",
         "ajv": "^8.14.0",
         "babel-loader": "^9.1.3",
+        "css-loader": "^7.1.2",
         "html-webpack-plugin": "^5.6.0",
         "js-yaml": "^4.1.0",
         "npm-run-all": "^4.1.5",
         "raw-loader": "^4.0.2",
+        "sass-loader": "^14.2.1",
         "terser-webpack-plugin": "^5.3.10",
         "webpack": "^5.91.0",
         "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4",
         "wrangler": "^3.57.1"
+      }
+    },
+    "services/cms/node_modules/css-loader": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
+      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.33",
+        "postcss-modules-extract-imports": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.5",
+        "postcss-modules-scope": "^3.2.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
+        "webpack": "^5.27.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "services/cms/node_modules/sass-loader": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-14.2.1.tgz",
+      "integrity": "sha512-G0VcnMYU18a4N7VoNDegg2OuMjYtxnqzQWARVWCIVSZwJeiL9kg8QMsuIZOplsJgTzZLF6jGxI3AClj8I9nRdQ==",
+      "dev": true,
+      "dependencies": {
+        "neo-async": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "sass": "^1.3.0",
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "services/personal-website": {

--- a/services/cms/client/main.js
+++ b/services/cms/client/main.js
@@ -1,25 +1,24 @@
-import CMS from 'netlify-cms-app';
-import config from './config.yml';
+import CMS from "decap-cms-app";
+import config from "./config.yml";
 
-import {Uuid} from "./widgets/uuid.jsx";
+import { Uuid } from "./widgets/uuid.jsx";
 // import {YouTube} from "./widgets/editor/youtube.jsx";
 
-
 export default function init() {
-    const useTestBackend = Boolean(process.env.CMS_BACKEND === "test")
+  const useTestBackend = Boolean(process.env.CMS_BACKEND === "test");
 
-    // Remove constants.
-    delete config.__constants;
+  // Remove constants.
+  delete config.__constants;
 
-    if (useTestBackend) {
-        config.backend = {
-            name: 'test-repo'
-        }
-    }
+  if (useTestBackend) {
+    config.backend = {
+      name: "test-repo",
+    };
+  }
 
-    CMS.init({ config });
-    CMS.registerWidget('uuid', Uuid)
-    //CMS.registerEditorComponent(YouTube)
+  CMS.init({ config });
+  CMS.registerWidget("uuid", Uuid);
+  //CMS.registerEditorComponent(YouTube)
 }
 
-document.addEventListener('DOMContentLoaded', init)
+document.addEventListener("DOMContentLoaded", init);

--- a/services/cms/client/main.js
+++ b/services/cms/client/main.js
@@ -3,6 +3,8 @@ import config from "./config.yml";
 
 import { Uuid } from "./widgets/uuid.jsx";
 // import {YouTube} from "./widgets/editor/youtube.jsx";
+//
+import { ArticlePreview, ArticlePreviewStyles } from "./preview/article.jsx";
 
 export default function init() {
   const useTestBackend = Boolean(process.env.CMS_BACKEND === "test");
@@ -19,6 +21,8 @@ export default function init() {
   CMS.init({ config });
   CMS.registerWidget("uuid", Uuid);
   //CMS.registerEditorComponent(YouTube)
+  CMS.registerPreviewTemplate("blog", ArticlePreview);
+  CMS.registerPreviewStyle(ArticlePreviewStyles.toString(), { raw: true });
 }
 
 document.addEventListener("DOMContentLoaded", init);

--- a/services/cms/client/preview/article.jsx
+++ b/services/cms/client/preview/article.jsx
@@ -1,0 +1,60 @@
+import React, { Component } from "react";
+import { format } from "date-fns";
+
+import styles from "!css-loader!sass-loader!@alexwilson/legacy-components/src/util-typography/typography.scss";
+export const ArticlePreviewStyles = styles;
+
+export class ArticlePreview extends Component {
+  render() {
+    const { entry, fieldsMetaData } = this.props;
+    const title = entry.getIn(["data", "title"]);
+    const date = entry.getIn(["data", "date"]);
+    const author = entry.getIn(["data", "author"]);
+
+    return (
+      <div className="alex-article">
+        <h1 class="alex-article__headline" itemProp="name headline">
+          {title}
+        </h1>
+        <div className="alex-article__main">
+          <div className="alex-article__byline">
+            Posted
+            <>
+              {` by `}
+              <span itemProp="author" itemType="http://schema.org/Person">
+                <a href="/">
+                  <span itemProp="name">{author}</span>
+                </a>
+              </span>
+            </>
+            <>
+              {` on `}
+              <time
+                className="alex-article__main__date"
+                dateTime={date}
+                itemProp="datePublished"
+              >
+                {format(new Date(date), "PPPP")}
+              </time>
+              .
+            </>
+          </div>
+          <article
+            className="alex-article__body article-description"
+            itemProp="articleBody"
+          >
+            {this.props.widgetFor("body")}
+          </article>
+        </div>
+
+        <div className="alex-article__aside">
+          <div className="alex-article__aside-start"></div>
+          <div className="alex-article__aside-mid"></div>
+          <div className="alex-article__aside-bottom alex-article__sharing-block"></div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ArticlePreview;

--- a/services/cms/package.json
+++ b/services/cms/package.json
@@ -21,10 +21,12 @@
     "@babel/preset-react": "^7.24.6",
     "ajv": "^8.14.0",
     "babel-loader": "^9.1.3",
+    "css-loader": "^7.1.2",
     "html-webpack-plugin": "^5.6.0",
     "js-yaml": "^4.1.0",
     "npm-run-all": "^4.1.5",
     "raw-loader": "^4.0.2",
+    "sass-loader": "^14.2.1",
     "terser-webpack-plugin": "^5.3.10",
     "webpack": "^5.91.0",
     "webpack-bundle-analyzer": "^4.10.2",
@@ -33,6 +35,7 @@
     "wrangler": "^3.57.1"
   },
   "dependencies": {
+    "@alexwilson/legacy-components": "^1.0.0",
     "decap-cms": "^3.1.10",
     "decap-cms-app": "^3.1.10",
     "decap-cms-backend-proxy": "^3.1.1",

--- a/services/cms/package.json
+++ b/services/cms/package.json
@@ -33,9 +33,9 @@
     "wrangler": "^3.57.1"
   },
   "dependencies": {
-    "netlify-cms": "^2.10.192",
-    "netlify-cms-app": "^2.15.72",
-    "netlify-cms-backend-proxy": "^1.2.3",
+    "decap-cms": "^3.1.10",
+    "decap-cms-app": "^3.1.10",
+    "decap-cms-backend-proxy": "^3.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "uuid": "^9.0.1"


### PR DESCRIPTION
# Why?
Netlify CMS has been abandoned, and the project continues in Decap CMS.

# What?
1. Migrate Netlify CMS to Decap CMS.
2. Implement Article Preview styles.

# Anything else?
This includes some changes to the version of Sassline used in the legacy typography module.  Instead of calculating and casting to EM, we now use a string-literal.