### PR TITLE
feat(terraform): Terraform the Cloudflare things

### DIFF
--- a/terraform/environments/prod.tfvars
+++ b/terraform/environments/prod.tfvars
@@ -1,11 +1,11 @@
-domains        = ["alexwilson.tech"]
-backends = [
+fastly_domains = ["alexwilson.tech"]
+fastly_backends = [
   {
-    address          = "alexwilson.github.io"
-    host             = "alexwilson.tech"
-    name             = "main"
-    port             = 443
-    use_ssl          = true
+    address           = "alexwilson.github.io"
+    host              = "alexwilson.tech"
+    name              = "main"
+    port              = 443
+    use_ssl           = true
     ssl_cert_hostname = "alexwilson.github.io"
   }
 ]

--- a/terraform/environments/test.tfvars
+++ b/terraform/environments/test.tfvars
@@ -1,11 +1,11 @@
-domains        = ["test.alexwilson.tech"]
-backends = [
+fastly_domains = ["test.alexwilson.tech"]
+fastly_backends = [
   {
-    address          = "alexwilson.github.io"
-    host             = "alexwilson.tech"
-    name             = "main"
-    port             = 443
-    use_ssl          = true
+    address           = "alexwilson.github.io"
+    host              = "alexwilson.tech"
+    name              = "main"
+    port              = 443
+    use_ssl           = true
     ssl_cert_hostname = "alexwilson.github.io"
   }
 ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,35 @@ terraform {
 
 module "fastly" {
   source      = "./modules/fastly"
-  domains     = var.domains
-  backends    = var.backends
+  domains     = var.fastly_domains
+  backends    = var.fastly_backends
   environment = terraform.workspace
+}
+
+module "cloudflare_antoligycom" {
+  source     = "./modules/cloudflare"
+  account_id = ""
+  count      = terraform.workspace == "prod" ? 1 : 0
+  zone       = "antoligy.com"
+  redirect_rules = [{
+    target     = "www.antoligy.com/*"
+    forward_to = "https://ax.gy/$1"
+    }, {
+    target     = "antoligy.com/*"
+    forward_to = "https://ax.gy/$1"
+  }]
+}
+
+module "cloudflare_axgy" {
+  source     = "./modules/cloudflare"
+  account_id = ""
+  count      = terraform.workspace == "prod" ? 1 : 0
+  zone       = "ax.gy"
+  redirect_rules = [{
+    target     = "www.ax.gy/*"
+    forward_to = "https://alexwilson.tech/$1"
+    }, {
+    target     = "ax.gy/*"
+    forward_to = "https://alexwilson.tech/$1"
+  }]
 }

--- a/terraform/modules/cloudflare/main.tf
+++ b/terraform/modules/cloudflare/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+resource "cloudflare_zone" "zone" {
+  account_id = var.account_id
+  zone       = var.zone
+}
+
+resource "cloudflare_page_rule" "rules" {
+  for_each = { for rule in var.redirect_rules : rule.target => rule }
+  zone_id  = cloudflare_zone.zone.id
+  target   = each.value.target
+  actions {
+    forwarding_url {
+      url         = each.value.forward_to
+      status_code = 301
+    }
+  }
+}

--- a/terraform/modules/cloudflare/outputs.tf
+++ b/terraform/modules/cloudflare/outputs.tf
@@ -1,0 +1,9 @@
+output "zone_id" {
+  description = "The ID of the Cloudflare zone"
+  value       = cloudflare_zone.zone.id
+}
+
+output "page_rules" {
+  description = "The page rules created"
+  value       = cloudflare_page_rule.rules
+}

--- a/terraform/modules/cloudflare/variables.tf
+++ b/terraform/modules/cloudflare/variables.tf
@@ -1,0 +1,17 @@
+variable "account_id" {
+  description = "Account ID"
+  type        = string
+}
+
+variable "zone" {
+  description = "The domain zone to manage"
+  type        = string
+}
+
+variable "redirect_rules" {
+  description = "List of redirect rules to create"
+  type = list(object({
+    target     = string
+    forward_to = string
+  }))
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,9 +1,9 @@
-variable "domains" {
+variable "fastly_domains" {
   description = "A list of domain names to be used"
   type        = list(string)
 }
 
-variable "backends" {
+variable "fastly_backends" {
   description = "A list of backends"
   type = list(object({
     address           = string
@@ -13,4 +13,9 @@ variable "backends" {
     use_ssl           = bool
     ssl_cert_hostname = string
   }))
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare Account ID"
+  type        = string
 }


### PR DESCRIPTION
# Why?
Cloudflare is the next on my list of things to Terraform.

# What?
Move Page Rules for antoligy.com and ax.gy Cloudflare Zones into Terraform.

# Anything else?
There's no way to run this in a test environment, so we set `count` to 0 in test and 1 in prod.
