### PR TITLE
fix: temporarily swap unsplash for a fastly-hosted randomiser

### DIFF
--- a/components/legacy-components/src/header/header.js
+++ b/components/legacy-components/src/header/header.js
@@ -109,7 +109,7 @@ class Header extends Component {
 
   async fetchRandomImage() {
     try {
-      const response = await fetch('https://source.unsplash.com/collection/33719360/0x0')
+      const response = await fetch("https://alexwilson.tech/__service/random-header-image")
       if (response.ok && response.url) {
         const { origin, pathname } = new URL(response.url)
         this.setState({

--- a/terraform/modules/fastly/vcl/main.vcl
+++ b/terraform/modules/fastly/vcl/main.vcl
@@ -4,5 +4,6 @@ include "fastly-boilerplate-begin.vcl";
 include "cloudflare-service-chain.vcl";
 include "security-headers.vcl";
 include "redirects.vcl";
+include "random-header-image.vcl";
 
 include "fastly-boilerplate-end.vcl";

--- a/terraform/modules/fastly/vcl/random-header-image.vcl
+++ b/terraform/modules/fastly/vcl/random-header-image.vcl
@@ -1,0 +1,21 @@
+table potential_header_images {
+  "0": "https://images.unsplash.com/photo-1603186744434-c3884b484291",
+  "1": "https://images.unsplash.com/photo-1603186568789-159c2c62ade1",
+  "2": "https://images.unsplash.com/photo-1603187430252-10c169c59608",
+  "3": "https://images.unsplash.com/photo-1599511971355-6489fdbbfcc0",
+  "4": "https://images.unsplash.com/photo-1599511971455-cc69549b09e8",
+  "5": "https://images.unsplash.com/photo-1599512011173-da8b4bf85101"
+}
+
+sub vcl_recv {
+    declare local var.key STRING;
+    declare local var.table_length INTEGER;
+
+    # Maximum key in potential_header_images.
+    set var.table_length = 5;
+
+    if (req.url.path ~ "^/__service/random-header-image$") {
+        set var.key = std.itoa(randomint(0, var.table_length));
+        error 602 table.lookup(potential_header_images, var.key);
+    }
+}

--- a/terraform/modules/fastly/vcl/redirects.vcl
+++ b/terraform/modules/fastly/vcl/redirects.vcl
@@ -73,4 +73,11 @@ sub vcl_error {
         set obj.http.Location = obj.response;
         set obj.response = "Moved permanently";
     }
+
+    // A 602 error should include the destination in its response.
+    if (obj.status == 602 && obj.response) {
+        set obj.status = 302;
+        set obj.http.Location = obj.response;
+        set obj.response = "Found";
+    }
 }


### PR DESCRIPTION
# Why?
Header images have been powered by Unsplash Source for quite some time, but they (quietly) deprecated it last year and recently decommissioned it.

# What?
1. Introduce a new endpoint (`/__service/random-header-image`) which returns a random image when called.
2. Change the reference to Unsplash to reference this instead.

# Anything else?
This is extremely ugly, and I'm only doing this to buy time to reconsider the header more generally.
