### PR TITLE
Add honeycomb logging

### DIFF
--- a/terraform/environments/prod.tfvars
+++ b/terraform/environments/prod.tfvars
@@ -9,3 +9,4 @@ fastly_backends = [
     ssl_cert_hostname = "alexwilson.github.io"
   }
 ]
+fastly_honeycomb_dataset = "fastly:request"

--- a/terraform/environments/test.tfvars
+++ b/terraform/environments/test.tfvars
@@ -9,3 +9,4 @@ fastly_backends = [
     ssl_cert_hostname = "alexwilson.github.io"
   }
 ]
+fastly_honeycomb_dataset = "fastly:request"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,15 +9,17 @@ terraform {
 }
 
 module "fastly" {
-  source      = "./modules/fastly"
-  domains     = var.fastly_domains
-  backends    = var.fastly_backends
-  environment = terraform.workspace
+  source            = "./modules/fastly"
+  domains           = var.fastly_domains
+  backends          = var.fastly_backends
+  environment       = terraform.workspace
+  honeycomb_token   = var.fastly_honeycomb_token
+  honeycomb_dataset = var.fastly_honeycomb_dataset
 }
 
 module "cloudflare_antoligycom" {
   source     = "./modules/cloudflare"
-  account_id = ""
+  account_id = var.cloudflare_account_id
   count      = terraform.workspace == "prod" ? 1 : 0
   zone       = "antoligy.com"
   redirect_rules = [{
@@ -31,7 +33,7 @@ module "cloudflare_antoligycom" {
 
 module "cloudflare_axgy" {
   source     = "./modules/cloudflare"
-  account_id = ""
+  account_id = var.cloudflare_account_id
   count      = terraform.workspace == "prod" ? 1 : 0
   zone       = "ax.gy"
   redirect_rules = [{

--- a/terraform/modules/cloudflare/variables.tf
+++ b/terraform/modules/cloudflare/variables.tf
@@ -1,6 +1,7 @@
 variable "account_id" {
   description = "Account ID"
   type        = string
+  sensitive   = true
 }
 
 variable "zone" {

--- a/terraform/modules/fastly/honeycomb/format.json
+++ b/terraform/modules/fastly/honeycomb/format.json
@@ -1,0 +1,30 @@
+{
+  "time":"%{begin:%Y-%m-%dT%H:%M:%SZ}t",
+  "data":  {
+    "service_id":"%{req.service_id}V",
+    "time_elapsed":%D,
+    "request":"%m",
+    "host":"%{if(req.http.Fastly-Orig-Host, req.http.Fastly-Orig-Host, req.http.Host)}V",
+    "url":"%{cstr_escape(req.url)}V",
+    "protocol":"%H",
+    "is_ipv6":%{if(req.is_ipv6, "true", "false")}V,
+    "is_tls":%{if(req.is_ssl, "true", "false")}V,
+    "is_h2":%{if(fastly_info.is_h2, "true", "false")}V,
+    "client_ip":"%h",
+    "geo_city":"%{client.geo.city.utf8}V",
+    "geo_country_code":"%{client.geo.country_code}V",
+    "server_datacenter":"%{server.datacenter}V",
+    "request_referer":"%{Referer}i",
+    "request_user_agent":"%{User-Agent}i",
+    "request_accept_content":"%{Accept}i",
+    "request_accept_language":"%{Accept-Language}i",
+    "request_accept_charset":"%{Accept-Charset}i",
+    "cache_status":"%{regsub(fastly_info.state, "^(HIT-(SYNTH)|(HITPASS|HIT|MISS|PASS|ERROR|PIPE)).*", "\\2\\3") }V",
+    "status":"%s",
+    "content_type":"%{Content-Type}o",
+    "req_header_size":%{req.header_bytes_read}V,
+    "req_body_size":%{req.body_bytes_read}V,
+    "resp_header_size":%{resp.header_bytes_written}V,
+    "resp_body_size":%{resp.body_bytes_written}V
+  }
+}

--- a/terraform/modules/fastly/main.tf
+++ b/terraform/modules/fastly/main.tf
@@ -45,4 +45,11 @@ resource "fastly_service_vcl" "cdn" {
       })
     }
   }
+
+  logging_honeycomb {
+    dataset = var.honeycomb_dataset
+    name    = "fastly-${var.environment}"
+    token   = var.honeycomb_token
+    format  = file("${path.module}/honeycomb/format.json")
+  }
 }

--- a/terraform/modules/fastly/variables.tf
+++ b/terraform/modules/fastly/variables.tf
@@ -18,3 +18,14 @@ variable "backends" {
 variable "environment" {
   description = "The environment name"
 }
+
+variable "honeycomb_dataset" {
+  description = "Name of dataset to stream to in Honeycomb"
+  type        = string
+}
+
+variable "honeycomb_token" {
+  description = "Name of dataset to stream to in Honeycomb"
+  sensitive   = true
+  type        = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,7 +15,19 @@ variable "fastly_backends" {
   }))
 }
 
+variable "fastly_honeycomb_dataset" {
+  description = "Honeycomb Dataset for streaming Fastly logs to"
+  type        = string
+}
+
+variable "fastly_honeycomb_token" {
+  description = "Write token for Fastly to stream to Honeycomb"
+  type        = string
+  sensitive   = true
+}
+
 variable "cloudflare_account_id" {
   description = "Cloudflare Account ID"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
# Why?
With the move to Fastly, I'm now able to configure logdrains!  I'm also finally able to gain some observability w/o client analytics.

# What?
Add Honeycomb logging to the Fastly module, and configure it for Test and Prod.
