### PR TITLE
Migrate discriminator logic to the type field, and remove other legacy fields

### DIFF
--- a/services/cms/client/config.yml
+++ b/services/cms/client/config.yml
@@ -37,10 +37,6 @@ collections:
       - {label: Content Type, name: "type", options: ["article", "talk"], default: "article", widget: "select"}
       - {label: "Author(s)", name: "author", widget: "select", options: ["alex"], default: "alex"}
       - {label: Updated Date, name: "last_modified_at", default: "", format: *time_format, required: false, widget: "datetime"}
-
-      # Deprecated/un-used fields.
-      - {label: "Legacy Slug (deprecated)", name: "_legacy_slug", widget: "hidden", required: false, default: null}
-      - {label: Layout, name: "layout", widget: "hidden", default: "blog"}
   - name: "talks"
     label: "Talks"
     folder: "/talks/"

--- a/services/personal-website/gatsby-config.js
+++ b/services/personal-website/gatsby-config.js
@@ -49,17 +49,7 @@ module.exports = {
         name: `posts`,
         remote: `https://alexwilson:${process.env.GITHUB_TOKEN}@github.com/alexwilson/content.git`,
         branch: `main`,
-        patterns: `posts/**`,
-      }
-    },
-
-    {
-      resolve: `gatsby-source-git`,
-      options: {
-        name: `talks`,
-        remote: `https://alexwilson:${process.env.GITHUB_TOKEN}@github.com/alexwilson/content.git`,
-        branch: `main`,
-        patterns: `talks/**`,
+        patterns: [`posts/**`, `talks/**`],
       }
     },
 

--- a/services/personal-website/gatsby-node.js
+++ b/services/personal-website/gatsby-node.js
@@ -88,7 +88,7 @@ exports.createResolvers = ({ createResolvers }) => {
 }
 
 exports.createPages = async ({ graphql, actions }) => {
-  const { createPage, createRedirect } = actions
+  const { createPage } = actions
   const {data} = await graphql(`
     query {
       content: allContent {
@@ -112,7 +112,7 @@ exports.createPages = async ({ graphql, actions }) => {
     // Create a page
     createPage({
       path: node.slug,
-      component: node.type === "talks" ? path.resolve(`./src/templates/talk.js`) : path.resolve(`./src/templates/article.js`),
+      component: node.type === "talk" ? path.resolve(`./src/templates/talk.js`) : path.resolve(`./src/templates/article.js`),
       context: {
         contentId: node.contentId
       }

--- a/services/personal-website/gatsby-node.js
+++ b/services/personal-website/gatsby-node.js
@@ -41,7 +41,6 @@ exports.createSchemaCustomization = ({actions}) => {
       topics: [Topic] @link(by: "topicId")
 
       image: ContentImageFields!
-      deprecatedFields: ContentDeprecatedFields!
     }
 
     type ContentImageFields @dontInfer {
@@ -49,10 +48,6 @@ exports.createSchemaCustomization = ({actions}) => {
       thumbnail: String
       credit: String
       altText: String
-    }
-
-    type ContentDeprecatedFields @dontInfer {
-      legacySlugs: [String]
     }
 
     type Topic implements Node @dontInfer {
@@ -101,9 +96,6 @@ exports.createPages = async ({ graphql, actions }) => {
           contentId
           slug
           type
-          deprecatedFields {
-            legacySlugs
-          }
         }
       }
       topics: allTopic {
@@ -124,14 +116,6 @@ exports.createPages = async ({ graphql, actions }) => {
       context: {
         contentId: node.contentId
       }
-    })
-
-    // Redirect from legacy slugs
-    node.deprecatedFields.legacySlugs.forEach(legacySlug => {
-      createRedirect({
-        fromPath: legacySlug,
-        toPath: node.slug,
-      })
     })
   })
   data.topics.nodes.forEach((node) => {

--- a/services/personal-website/src/components/related-articles.js
+++ b/services/personal-website/src/components/related-articles.js
@@ -8,7 +8,7 @@ export default ({article: currentArticle}) => {
       posts: allContent(
         sort: { order: DESC, fields: [date] }
         filter: {
-          type: {eq: "posts"}
+          type: {eq: "article"}
         }
         limit: 1000
       ) {

--- a/services/personal-website/src/pages/blog.js
+++ b/services/personal-website/src/pages/blog.js
@@ -24,7 +24,7 @@ export const query = graphql`
   query {
     content: allContent(
       filter: {
-        type: {eq: "posts"}
+        type: {eq: "article"}
       }
       sort: {
         fields: [date],

--- a/services/personal-website/src/pages/talks.js
+++ b/services/personal-website/src/pages/talks.js
@@ -23,7 +23,7 @@ export const query = graphql`
   query {
     talks: allContent(
       filter: {
-        type: {eq: "talks"}
+        type: {eq: "talk"}
       }
       sort: {
         fields: [date],

--- a/services/personal-website/src/schema/on-create-node.js
+++ b/services/personal-website/src/schema/on-create-node.js
@@ -25,11 +25,6 @@ const contentFromMarkdownRemark = ({node, getNode}) => {
   let author
   if (node.frontmatter.author) author = node.frontmatter.author
 
-  const legacySlugs = []
-  if (node.frontmatter['_legacy_slug']) {
-    legacySlugs.push(node.frontmatter['_legacy_slug'])
-  }
-
   // Content schema
   const content = {
     contentId,
@@ -38,9 +33,6 @@ const contentFromMarkdownRemark = ({node, getNode}) => {
     type,
     date,
     image: {},
-    deprecatedFields: {
-      legacySlugs
-    },
     topics: []
   }
   if (author) {

--- a/services/personal-website/src/schema/on-create-node.js
+++ b/services/personal-website/src/schema/on-create-node.js
@@ -5,10 +5,7 @@ const contentFromMarkdownRemark = ({node, getNode}) => {
   const slug = `/content/${contentId}`
   const title = node.frontmatter['title'] || ''
   const date = new Date(node.frontmatter.date)
-
-  // Determine content type by looking at collection (aka parent node)
-  // @todo Move this into directly article schema instead?
-  const { sourceInstanceName: type } = getNode(node.parent)
+  const type = node.frontmatter['type'] || 'article'
 
   let image
   let thumbnail

--- a/services/personal-website/src/templates/article.js
+++ b/services/personal-website/src/templates/article.js
@@ -185,9 +185,6 @@ export const pageQuery = graphql`
         ...ArticleContent
       }
       slug
-      deprecatedFields {
-        legacySlugs
-      }
     }
     site {
       siteMetadata {


### PR DESCRIPTION
# Why?
Currently - as I've written about in #1557 - we include legacy fields, and guess if a post is an article or a talk based on its collection.  

# What?
1. Remove legacy fields like `_legacy_slugs`  and `layout`.  The use-cases for `_legacy_slugs` were for redirects and webmentions, which have been resolved in Fastly (#2678) and Webmentions (#2692) respectively.
2. in Gatsby `onCreateNode` the `type` field now is based on the frontmatter property of the same name, instead of the collection we discovered the content in.
3. We now fetch the content collection once, for both collections.

# Anything else?
After this is live, it is safe to merge `/talks/` and `/posts/` collections - however this should not be done until after this is merged.
