### PR TITLE
Remove talks collection

### DIFF
--- a/services/cms/client/config.yml
+++ b/services/cms/client/config.yml
@@ -22,8 +22,8 @@ media_folder: pictures
 display_url: https://alexwilson.tech/
 
 collections:
-  - name: "blog"
-    label: "Blog"
+  - name: "content"
+    label: "Content"
     folder: "/posts/"
     create: true
     slug: "{{id}}"
@@ -37,9 +37,3 @@ collections:
       - {label: Content Type, name: "type", options: ["article", "talk"], default: "article", widget: "select"}
       - {label: "Author(s)", name: "author", widget: "select", options: ["alex"], default: "alex"}
       - {label: Updated Date, name: "last_modified_at", default: "", format: *time_format, required: false, widget: "datetime"}
-  - name: "talks"
-    label: "Talks"
-    folder: "/talks/"
-    create: true
-    slug: "{{id}}"
-    fields: *contentFields

--- a/services/personal-website/gatsby-config.js
+++ b/services/personal-website/gatsby-config.js
@@ -49,7 +49,7 @@ module.exports = {
         name: `posts`,
         remote: `https://alexwilson:${process.env.GITHUB_TOKEN}@github.com/alexwilson/content.git`,
         branch: `main`,
-        patterns: [`posts/**`, `talks/**`],
+        patterns: [`posts/**`],
       }
     },
 


### PR DESCRIPTION
# Why?
This is the final move in the game of 5D chess that has been #1557.  The `/talks/` collection is no longer used or useful, so let's remove it entirely.

# What?
Remove the `/talks/` collection from Personal-Website/Blog and CMS.

# Anything else?
This relied on https://github.com/alexwilson/content/pull/188 merging the collections, which has gone perfectly.
