### PR TITLE
Add section prop to header to differentiate Blog and Talks sections.

### DIFF
--- a/components/legacy-components/src/header/header.js
+++ b/components/legacy-components/src/header/header.js
@@ -121,6 +121,7 @@ class Header extends Component {
   }
 
   render() {
+    const { section = null } = this.props
     const { pathname } = this.props.location
     const name = this.props.name ? this.props.name : "Alex Wilson"
     const intro = this.props.intro ? this.props.intro : "On products, engineering & everything in-between."
@@ -155,8 +156,8 @@ class Header extends Component {
             <ul className="alex-header__nav" id="menu" aria-expanded={this.state.navigationExpanded}>
               <this.navItem url="/" active={pathname === "/"}>Home</this.navItem>
               <this.navItem url="/about-me" active={pathname === "/about-me"}>About Me</this.navItem>
-              <this.navItem url="/blog" active={pathname === "/blog" || pathname.startsWith("/content/")}>Writing</this.navItem>
-              <this.navItem url="/talks" active={pathname.startsWith("/talks/")}>Speaking</this.navItem>
+              <this.navItem url="/blog" active={section && section === "blog"}>Writing</this.navItem>
+              <this.navItem url="/talks" active={section && section === "talks"}>Speaking</this.navItem>
               <this.navItem url="/consultancy" active={pathname === "/consultancy"}>Hire Me</this.navItem>
 
               <NavSpacer />
@@ -174,13 +175,20 @@ class Header extends Component {
 }
 
 Header.propTypes = {
-  siteTitle: PropTypes.string,
+  name: PropTypes.string,
+  intro: PropTypes.string,
   image: PropTypes.string,
+  location: PropTypes.object.isRequired,
+  section: PropTypes.oneOf(["blog", "talks"]),
+  linkImplementation: PropTypes.instanceOf(Link)
 }
 
 Header.defaultProps = {
-  siteTitle: `Alex Wilson`,
+  name: "Alex Wilson",
+  intro: "On products, engineering & everything in-between.",
   image: null,
+  section: null,
+  linkImplementation: Link
 }
 
 export default Header

--- a/services/personal-website/src/pages/blog.js
+++ b/services/personal-website/src/pages/blog.js
@@ -1,10 +1,12 @@
 import React from "react"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 import Layout from "../components/layout"
 import ArticleCard from "@alexwilson/legacy-components/src/article-card"
+import Header from "@alexwilson/legacy-components/src/header"
 
  const BlogPage = ({ data, location }) => {
   return (<Layout location={location}>
+    <Header location={location} section="blog" linkImplementation={Link} />
     <div className="alex-stream">
       <h1>My Blog</h1>
       <h4>{data.content.totalCount} Posts</h4>

--- a/services/personal-website/src/pages/talks.js
+++ b/services/personal-website/src/pages/talks.js
@@ -1,10 +1,12 @@
 import React from "react"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 import Layout from "../components/layout"
 import ArticleCard from "@alexwilson/legacy-components/src/article-card"
+import Header from "@alexwilson/legacy-components/src/header"
 
 const TalksPage = ({ data, location }) => {
   return (<Layout location={location}>
+    <Header location={location} section="talks" linkImplementation={Link} />
     <div className="alex-stream">
       <h1>Talks</h1>
       {data.talks.edges.map(({ node }) => (

--- a/services/personal-website/src/templates/article.js
+++ b/services/personal-website/src/templates/article.js
@@ -28,7 +28,7 @@ const ArticleTemplate = ({ data, location }) => {
 
   return (
     <Layout location={location}>
-      <Header location={location} image={post.image.image} linkImplementation={Link} />
+      <Header location={location} section="blog" image={post.image.image} linkImplementation={Link} />
       <div className="alex-article">
         <h1 class="alex-article__headline" itemProp="name headline">{post.title}</h1>
         <div className="alex-article__main">

--- a/services/personal-website/src/templates/talk.js
+++ b/services/personal-website/src/templates/talk.js
@@ -1,5 +1,6 @@
 import React from "react"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
+import Header from "@alexwilson/legacy-components/src/header"
 import ShareWidget from "@alexwilson/legacy-components/src/share-widget"
 import Layout from "../components/layout"
 
@@ -7,6 +8,7 @@ const TalkTemplate = ({ data, location }) => {
   const post = data.content
   return (
     <Layout location={location}>
+      <Header location={location} section="talks" linkImplementation={Link} />
       <div class="alex-article">
         <div class="alex-article__main">
           <h1 itemprop="name headline">{post.title}</h1>

--- a/services/personal-website/src/templates/topic.js
+++ b/services/personal-website/src/templates/topic.js
@@ -1,14 +1,16 @@
 import React from "react"
 import PropTypes from "prop-types"
 import ArticleCard from "@alexwilson/legacy-components/src/article-card"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 import Layout from "../components/layout"
+import Header from "@alexwilson/legacy-components/src/header"
 
 const TopicsTemplate = ({ pageContext, data, location }) => {
   const { topic } = pageContext
   const { totalCount } = data.content
 
   return (<Layout location={location}>
+    <Header location={location} section="blog" linkImplementation={Link} />
     <div class="alex-stream">
       <h1>{`${totalCount} post${totalCount === 1 ? "" : "s"} tagged with "${data.topic.topic}"`}</h1>
       {data.content.edges.map(({ node }) => (


### PR DESCRIPTION
# Why?
Since unifying talks and articles, there has been no differentiation between the two in the navigation. This PR restores that behaviour.

# What?
1. Add a new prop to the Header component called `section`.
2. It is an enum accepting two values atm: `blog` and `talks`.
3. Migrate all content pages to use one or the other.

# Anything else?
* Lots of my PropTypes are incorrect, so it may be better to replace them all with typescript checks???? (jsdoc to avoid adding toolchain complexity before tearing out gatsby?!).
* The LinkImplementation prop probably should be a provider?  I'm not sure what the right pattern is here.
