### PR TITLE
Pin OS used for Feed Validation

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -95,7 +95,7 @@ jobs:
   validate-feed:
     name: "Validate feed"
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@main
         with:


### PR DESCRIPTION
# Why?

GitHub have put Ubuntu 24.04 based runners into circulation, and these [do not have a supported/compatible](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json) version of Python 3.7, which is used for feed validation.

# What?

Pin the OS used for the Feed Validation task to Ubuntu 22.04, which is the version previously used, until I can do something more permanent (e.g. extracting this task).
