### PR TITLE
Revert "chore(deps): bump react from 18.3.1 to 19.0.0"

### DIFF
--- a/components/legacy-components/package.json
+++ b/components/legacy-components/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "prop-types": "^15.8.1",
-    "react": "^19.0.0",
+    "react": "^18.3.1",
     "sass": "^1.77.2"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
     dependencies:
       '@reach/router':
         specifier: ^1.3.4
-        version: 1.3.4(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+        version: 1.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       date-fns:
         specifier: ^4.0.0
         version: 4.0.0
@@ -38,8 +38,8 @@ importers:
         specifier: ^15.8.1
         version: 15.8.1
       react:
-        specifier: ^19.0.0
-        version: 19.0.0
+        specifier: ^18.3.1
+        version: 18.3.1
       sass:
         specifier: ^1.77.2
         version: 1.77.6
@@ -48,7 +48,7 @@ importers:
     dependencies:
       gatsby:
         specifier: '>2.0.0-alpha'
-        version: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
+        version: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
       unist-util-visit:
         specifier: ^2.0.3
         version: 2.0.3
@@ -72,16 +72,16 @@ importers:
         version: 3.3.2(@types/hoist-non-react-statics@3.3.5)(@types/node@22.10.1)(@types/react@18.3.4)(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(graphql@15.9.0)(webpack@5.92.1(esbuild@0.24.0)(webpack-cli@5.1.4))
       decap-cms-app:
         specifier: ^3.3.2
-        version: 3.3.2(@types/hoist-non-react-statics@3.3.5)(@types/node@22.10.1)(@types/react@18.3.4)(graphql@15.9.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+        version: 3.3.2(@types/hoist-non-react-statics@3.3.5)(@types/node@22.10.1)(@types/react@18.3.4)(graphql@15.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       decap-cms-backend-proxy:
         specifier: ^3.1.4
-        version: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0)
+        version: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(prop-types@15.8.1)(react@18.3.1)
       react:
-        specifier: ^19.0.0
-        version: 19.0.0
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
         specifier: ^18.3.1
-        version: 18.3.1(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
       uuid:
         specifier: ^11.0.1
         version: 11.0.1
@@ -151,70 +151,70 @@ importers:
         version: link:../../components/legacy-components
       '@loadable/component':
         specifier: ^5.16.4
-        version: 5.16.4(react@19.0.0)
+        version: 5.16.4(react@18.3.1)
       date-fns:
         specifier: ^4.0.0
         version: 4.0.0
       gatsby:
         specifier: ^5.13.5
-        version: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+        version: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-image:
         specifier: ^3.11.0
         version: 3.11.0
       gatsby-plugin-feed:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-google-analytics:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-manifest:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
       gatsby-plugin-offline:
         specifier: ^6.13.2
-        version: 6.13.2(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+        version: 6.13.2(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-preact:
         specifier: ^7.13.1
-        version: 7.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(preact-render-to-string@5.2.6(preact@10.22.1))(preact@10.22.1)(webpack@5.97.0(esbuild@0.24.0))
+        version: 7.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(preact-render-to-string@5.2.6(preact@10.22.1))(preact@10.22.1)(webpack@5.97.0(esbuild@0.24.0))
       gatsby-plugin-react-helmet:
         specifier: ^6.13.1
-        version: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-helmet@6.1.0(react@19.0.0))
+        version: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-helmet@6.1.0(react@18.3.1))
       gatsby-plugin-sass:
         specifier: ^6.13.1
-        version: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(sass@1.77.6)(webpack@5.97.0(esbuild@0.24.0))
+        version: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(sass@1.77.6)(webpack@5.97.0(esbuild@0.24.0))
       gatsby-plugin-sharp:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
       gatsby-plugin-sitemap:
         specifier: ^6.13.1
-        version: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+        version: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-web-font-loader:
         specifier: ^1.0.4
         version: 1.0.4
       gatsby-remark-embed-gist:
         specifier: ^1.2.1
-        version: 1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))))(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react@19.0.0)
+        version: 1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))))(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react@18.3.1)
       gatsby-remark-embed-video:
         specifier: ^3.2.1
         version: 3.2.1
       gatsby-remark-prismjs:
         specifier: ^7.13.1
-        version: 7.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(prismjs@1.29.0)
+        version: 7.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(prismjs@1.29.0)
       gatsby-remark-twitter-cards:
         specifier: ^0.6.1
-        version: 0.6.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
+        version: 0.6.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
       gatsby-source-filesystem:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
+        version: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
       gatsby-source-git:
         specifier: ^1.1.0
-        version: 1.1.0(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
+        version: 1.1.0(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
       gatsby-transformer-remark:
         specifier: ^6.13.1
-        version: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
+        version: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
       gatsby-transformer-sharp:
         specifier: ^5.13.1
-        version: 5.13.1(gatsby-plugin-sharp@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0))(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+        version: 5.13.1(gatsby-plugin-sharp@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0))(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
       isomorphic-fetch:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
@@ -231,14 +231,14 @@ importers:
         specifier: ^15.8.1
         version: 15.8.1
       react:
-        specifier: ^19.0.0
-        version: 19.0.0
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
         specifier: ^18.3.1
-        version: 18.3.1(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
       react-helmet:
         specifier: ^6.1.0
-        version: 6.1.0(react@19.0.0)
+        version: 6.1.0(react@18.3.1)
       sass:
         specifier: ^1.77.2
         version: 1.77.6
@@ -9631,10 +9631,6 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.0.0:
-    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
-    engines: {node: '>=0.10.0'}
-
   reactcss@1.2.3:
     resolution: {integrity: sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==}
     peerDependencies:
@@ -13692,25 +13688,12 @@ snapshots:
       react: 18.3.1
       tslib: 2.7.0
 
-  '@dnd-kit/accessibility@3.1.0(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
-      tslib: 2.7.0
-
   '@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/accessibility': 3.1.0(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.7.0
-
-  '@dnd-kit/core@6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@dnd-kit/accessibility': 3.1.0(react@19.0.0)
-      '@dnd-kit/utilities': 3.2.2(react@19.0.0)
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
       tslib: 2.7.0
 
   '@dnd-kit/modifiers@6.0.1(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
@@ -13720,13 +13703,6 @@ snapshots:
       react: 18.3.1
       tslib: 2.7.0
 
-  '@dnd-kit/modifiers@6.0.1(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      '@dnd-kit/utilities': 3.2.2(react@19.0.0)
-      react: 19.0.0
-      tslib: 2.7.0
-
   '@dnd-kit/sortable@7.0.2(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -13734,21 +13710,9 @@ snapshots:
       react: 18.3.1
       tslib: 2.7.0
 
-  '@dnd-kit/sortable@7.0.2(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      '@dnd-kit/utilities': 3.2.2(react@19.0.0)
-      react: 19.0.0
-      tslib: 2.7.0
-
   '@dnd-kit/utilities@3.2.2(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      tslib: 2.7.0
-
-  '@dnd-kit/utilities@3.2.2(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
       tslib: 2.7.0
 
   '@emotion/babel-plugin@11.12.0':
@@ -13799,22 +13763,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0)':
-    dependencies:
-      '@babel/runtime': 7.25.6
-      '@emotion/babel-plugin': 11.12.0
-      '@emotion/cache': 11.13.1
-      '@emotion/serialize': 1.3.1
-      '@emotion/use-insertion-effect-with-fallbacks': 1.1.0(react@19.0.0)
-      '@emotion/utils': 1.4.0
-      '@emotion/weak-memoize': 0.4.0
-      hoist-non-react-statics: 3.3.2
-      react: 19.0.0
-    optionalDependencies:
-      '@types/react': 18.3.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@emotion/serialize@1.3.1':
     dependencies:
       '@emotion/hash': 0.9.2
@@ -13840,30 +13788,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)':
-    dependencies:
-      '@babel/runtime': 7.25.6
-      '@emotion/babel-plugin': 11.12.0
-      '@emotion/is-prop-valid': 1.3.0
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/serialize': 1.3.1
-      '@emotion/use-insertion-effect-with-fallbacks': 1.1.0(react@19.0.0)
-      '@emotion/utils': 1.4.0
-      react: 19.0.0
-    optionalDependencies:
-      '@types/react': 18.3.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@emotion/unitless@0.10.0': {}
 
   '@emotion/use-insertion-effect-with-fallbacks@1.1.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
-
-  '@emotion/use-insertion-effect-with-fallbacks@1.1.0(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
 
   '@emotion/utils@1.4.0': {}
 
@@ -14080,12 +14009,12 @@ snapshots:
     transitivePeerDependencies:
       - '@parcel/core'
 
-  '@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)':
+  '@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       invariant: 2.2.4
       prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@gatsbyjs/webpack-hot-middleware@2.25.3':
     dependencies:
@@ -14296,10 +14225,6 @@ snapshots:
   '@icons/material@0.2.4(react@18.3.1)':
     dependencies:
       react: 18.3.1
-
-  '@icons/material@0.2.4(react@19.0.0)':
-    dependencies:
-      react: 19.0.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -14932,11 +14857,11 @@ snapshots:
   '@lmdb/lmdb-win32-x64@2.5.3':
     optional: true
 
-  '@loadable/component@5.16.4(react@19.0.0)':
+  '@loadable/component@5.16.4(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.24.7
       hoist-non-react-statics: 3.3.2
-      react: 19.0.0
+      react: 18.3.1
       react-is: 16.13.1
 
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
@@ -15629,13 +15554,13 @@ snapshots:
       preact: 10.22.1
       webpack: 5.97.0(esbuild@0.24.0)
 
-  '@reach/router@1.3.4(react-dom@18.3.1(react@19.0.0))(react@19.0.0)':
+  '@reach/router@1.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      create-react-context: 0.3.0(prop-types@15.8.1)(react@19.0.0)
+      create-react-context: 0.3.0(prop-types@15.8.1)(react@18.3.1)
       invariant: 2.2.4
       prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       react-lifecycles-compat: 3.0.4
 
   '@react-dnd/asap@4.0.1': {}
@@ -15653,16 +15578,6 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
       react-redux: 7.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-
-  '@reduxjs/toolkit@1.9.7(react-redux@7.2.9(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      immer: 9.0.21
-      redux: 4.2.1
-      redux-thunk: 2.4.2(redux@4.2.1)
-      reselect: 4.1.8
-    optionalDependencies:
-      react: 19.0.0
-      react-redux: 7.2.9(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
 
   '@serverless/event-mocks@1.1.1':
     dependencies:
@@ -16979,20 +16894,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-remove-graphql-queries@5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))):
+  babel-plugin-remove-graphql-queries@5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/runtime': 7.25.6
       '@babel/types': 7.26.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
 
-  babel-plugin-remove-graphql-queries@5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
+  babel-plugin-remove-graphql-queries@5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/runtime': 7.25.6
       '@babel/types': 7.26.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
 
   babel-plugin-syntax-object-rest-spread@6.13.0: {}
@@ -17995,11 +17910,11 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
 
-  create-react-context@0.3.0(prop-types@15.8.1)(react@19.0.0):
+  create-react-context@0.3.0(prop-types@15.8.1)(react@18.3.1):
     dependencies:
       gud: 1.0.0
       prop-types: 15.8.1
-      react: 19.0.0
+      react: 18.3.1
       warning: 4.0.3
 
   create-require@1.1.1: {}
@@ -18273,78 +18188,6 @@ snapshots:
       - react-native
       - supports-color
 
-  decap-cms-app@3.3.2(@types/hoist-non-react-statics@3.3.5)(@types/node@22.10.1)(@types/react@18.3.4)(graphql@15.9.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      codemirror: 5.65.17
-      dayjs: 1.11.13
-      decap-cms-backend-aws-cognito-github-proxy: 3.2.2(hc2hzsmr2eeotqohatbfxvo2ky)
-      decap-cms-backend-azure: 3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-backend-bitbucket: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-backend-git-gateway: 3.2.2(cm6n5qxmv7tmi7wxztql2q3xeu)
-      decap-cms-backend-github: 3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-backend-gitlab: 3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(graphql@15.9.0)(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-backend-proxy: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-backend-test: 3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)(uuid@8.3.2)
-      decap-cms-core: 3.4.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(@types/hoist-non-react-statics@3.3.5)(@types/node@22.10.1)(@types/react@18.3.4)(decap-cms-editor-component-image@3.1.3(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-lib-widgets@3.0.2(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)
-      decap-cms-editor-component-image: 3.1.3(react@19.0.0)
-      decap-cms-lib-auth: 3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-lib-widgets: 3.0.2(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-locales: 3.2.0
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      decap-cms-widget-boolean: 3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)
-      decap-cms-widget-code: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(codemirror@5.65.17)(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      decap-cms-widget-colorstring: 3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-widget-datetime: 3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(react@19.0.0)
-      decap-cms-widget-file: 3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)(uuid@11.0.1)
-      decap-cms-widget-image: 3.1.3(3rwgcguzcp7qxggw6ff2xxrwqa)
-      decap-cms-widget-list: 3.2.2(oekhr6mtxr2yv5je4527w4euoe)
-      decap-cms-widget-map: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)
-      decap-cms-widget-markdown: 3.1.6(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)
-      decap-cms-widget-number: 3.1.3(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-widget-object: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)
-      decap-cms-widget-relation: 3.3.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(decap-cms-lib-widgets@3.0.2(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(uuid@8.3.2)
-      decap-cms-widget-select: 3.2.2(@types/react@18.3.4)(decap-cms-lib-widgets@3.0.2(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)
-      decap-cms-widget-string: 3.1.3(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-widget-text: 3.1.3(@types/react@18.3.4)(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0)
-      immutable: 3.8.2
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-      react-immutable-proptypes: 2.2.0(immutable@3.8.2)
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - graphql
-      - react-native
-      - supports-color
-
-  decap-cms-backend-aws-cognito-github-proxy@3.2.2(hc2hzsmr2eeotqohatbfxvo2ky):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      apollo-cache-inmemory: 1.6.6(graphql@15.9.0)
-      apollo-client: 2.6.10(graphql@15.9.0)
-      apollo-link-context: 1.0.20(graphql@15.9.0)
-      apollo-link-http: 1.5.17(graphql@15.9.0)
-      common-tags: 1.8.2
-      decap-cms-backend-github: 3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-lib-auth: 3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      graphql: 15.9.0
-      graphql-tag: 2.12.6(graphql@15.9.0)
-      js-base64: 3.7.7
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
-      semaphore: 1.1.0
-
   decap-cms-backend-aws-cognito-github-proxy@3.2.2(qzes6unp5p2agjvs2b7fhfh4ia):
     dependencies:
       '@emotion/react': 11.13.3(@types/react@18.3.4)(react@18.3.1)
@@ -18380,20 +18223,6 @@ snapshots:
       react: 18.3.1
       semaphore: 1.1.0
 
-  decap-cms-backend-azure@3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-lib-auth: 3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      immutable: 3.8.2
-      js-base64: 3.7.7
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
-      semaphore: 1.1.0
-
   decap-cms-backend-bitbucket@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@18.3.1):
     dependencies:
       '@emotion/react': 11.13.3(@types/react@18.3.4)(react@18.3.1)
@@ -18407,22 +18236,6 @@ snapshots:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.3.1
-      semaphore: 1.1.0
-      what-the-diff: 0.6.0
-
-  decap-cms-backend-bitbucket@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      common-tags: 1.8.2
-      decap-cms-lib-auth: 3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      immutable: 3.8.2
-      js-base64: 3.7.7
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
       semaphore: 1.1.0
       what-the-diff: 0.6.0
 
@@ -18444,24 +18257,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
 
-  decap-cms-backend-git-gateway@3.2.2(cm6n5qxmv7tmi7wxztql2q3xeu):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-backend-bitbucket: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-backend-github: 3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-backend-gitlab: 3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(graphql@15.9.0)(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)
-      decap-cms-lib-auth: 3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      gotrue-js: 0.9.29
-      ini: 2.0.0
-      jwt-decode: 3.1.2
-      lodash: 4.17.21
-      minimatch: 3.1.2
-      prop-types: 15.8.1
-      react: 19.0.0
-
   decap-cms-backend-github@3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react@18.3.1):
     dependencies:
       '@emotion/react': 11.13.3(@types/react@18.3.4)(react@18.3.1)
@@ -18480,26 +18275,6 @@ snapshots:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.3.1
-      semaphore: 1.1.0
-
-  decap-cms-backend-github@3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      apollo-cache-inmemory: 1.6.6(graphql@15.9.0)
-      apollo-client: 2.6.10(graphql@15.9.0)
-      apollo-link-context: 1.0.20(graphql@15.9.0)
-      apollo-link-http: 1.5.17(graphql@15.9.0)
-      common-tags: 1.8.2
-      decap-cms-lib-auth: 3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      graphql: 15.9.0
-      graphql-tag: 2.12.6(graphql@15.9.0)
-      js-base64: 3.7.7
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
       semaphore: 1.1.0
 
   decap-cms-backend-gitlab@3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(graphql@15.9.0)(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@18.3.1):
@@ -18522,26 +18297,6 @@ snapshots:
     transitivePeerDependencies:
       - graphql
 
-  decap-cms-backend-gitlab@3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@11.0.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(graphql@15.9.0)(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      apollo-cache-inmemory: 1.6.6(graphql@15.9.0)
-      apollo-client: 2.6.10(graphql@15.9.0)
-      apollo-link-context: 1.0.20(graphql@15.9.0)
-      apollo-link-http: 1.5.17(graphql@15.9.0)
-      decap-cms-lib-auth: 3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      immutable: 3.8.2
-      js-base64: 3.7.7
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
-      semaphore: 1.1.0
-    transitivePeerDependencies:
-      - graphql
-
   decap-cms-backend-proxy@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(prop-types@15.8.1)(react@18.3.1):
     dependencies:
       '@emotion/react': 11.13.3(@types/react@18.3.4)(react@18.3.1)
@@ -18550,15 +18305,6 @@ snapshots:
       decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
-
-  decap-cms-backend-proxy@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      prop-types: 15.8.1
-      react: 19.0.0
 
   decap-cms-backend-test@3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react@18.3.1)(uuid@8.3.2):
     dependencies:
@@ -18569,17 +18315,6 @@ snapshots:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.3.1
-      uuid: 8.3.2
-
-  decap-cms-backend-test@3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react@19.0.0)(uuid@8.3.2):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
       uuid: 8.3.2
 
   decap-cms-core@3.4.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(@types/hoist-non-react-statics@3.3.5)(@types/node@22.10.1)(@types/react@18.3.4)(decap-cms-editor-component-image@3.1.3(react@18.3.1))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-lib-widgets@3.0.2(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@18.3.1):
@@ -18650,81 +18385,9 @@ snapshots:
       - react-native
       - supports-color
 
-  decap-cms-core@3.4.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(@types/hoist-non-react-statics@3.3.5)(@types/node@22.10.1)(@types/react@18.3.4)(decap-cms-editor-component-image@3.1.3(react@19.0.0))(decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2))(decap-cms-lib-util@3.1.0(immutable@3.8.2)(lodash@4.17.21))(decap-cms-lib-widgets@3.0.2(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      '@iarna/toml': 2.2.5
-      '@reduxjs/toolkit': 1.9.7(react-redux@7.2.9(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      ajv: 8.12.0
-      ajv-errors: 3.0.0(ajv@8.12.0)
-      ajv-keywords: 5.1.0(ajv@8.12.0)
-      clean-stack: 4.2.0
-      copy-text-to-clipboard: 3.2.0
-      dayjs: 1.11.13
-      decap-cms-editor-component-image: 3.1.3(react@19.0.0)
-      decap-cms-lib-auth: 3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2)
-      decap-cms-lib-util: 3.1.0(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-lib-widgets: 3.0.2(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      deepmerge: 4.3.1
-      diacritics: 1.3.0
-      fuzzy: 0.1.3
-      gotrue-js: 0.9.29
-      gray-matter: 4.0.3
-      history: 4.10.1
-      immer: 9.0.21
-      immutable: 3.8.2
-      js-base64: 3.7.7
-      jwt-decode: 3.1.2
-      lodash: 4.17.21
-      node-polyglot: 2.6.0
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dnd: 14.0.5(@types/hoist-non-react-statics@3.3.5)(@types/node@22.10.1)(@types/react@18.3.4)(react@19.0.0)
-      react-dnd-html5-backend: 14.1.0
-      react-dom: 18.3.1(react@19.0.0)
-      react-frame-component: 5.2.7(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      react-immutable-proptypes: 2.2.0(immutable@3.8.2)
-      react-is: 16.13.1
-      react-markdown: 6.0.3(@types/react@18.3.4)(react@19.0.0)
-      react-modal: 3.16.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      react-polyglot: 0.7.2(node-polyglot@2.6.0)(react@19.0.0)
-      react-redux: 7.2.9(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      react-router-dom: 5.3.4(react@19.0.0)
-      react-scroll-sync: 0.9.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      react-split-pane: 0.1.92(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      react-toastify: 9.1.3(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      react-topbar-progress-indicator: 4.1.1(react@19.0.0)
-      react-virtualized-auto-sizer: 1.0.24(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      react-waypoint: 10.3.0(react@19.0.0)
-      react-window: 1.8.10(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      redux: 4.2.1
-      redux-devtools-extension: 2.13.9(redux@4.2.1)
-      redux-notifications: 4.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(redux@4.2.1)
-      redux-thunk: 2.4.2(redux@4.2.1)
-      remark-gfm: 1.0.0
-      sanitize-filename: 1.6.3
-      semaphore: 1.1.0
-      tomlify-j0.4: 3.0.0
-      url: 0.11.4
-      url-join: 4.0.1
-      what-input: 5.2.12
-      yaml: 1.10.2
-    transitivePeerDependencies:
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - react-native
-      - supports-color
-
   decap-cms-editor-component-image@3.1.3(react@18.3.1):
     dependencies:
       react: 18.3.1
-
-  decap-cms-editor-component-image@3.1.3(react@19.0.0):
-    dependencies:
-      react: 19.0.0
 
   decap-cms-lib-auth@3.0.5(immutable@3.8.2)(lodash@4.17.21)(uuid@8.3.2):
     dependencies:
@@ -18769,18 +18432,6 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-aria-menubutton: 7.0.3(react@19.0.0)
-      react-transition-group: 4.4.5(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - react-dom
-
   decap-cms-widget-boolean@3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@18.3.1):
     dependencies:
       '@emotion/react': 11.13.3(@types/react@18.3.4)(react@18.3.1)
@@ -18788,15 +18439,6 @@ snapshots:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.3.1
-      react-immutable-proptypes: 2.2.0(immutable@3.8.2)
-
-  decap-cms-widget-boolean@3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
       react-immutable-proptypes: 2.2.0(immutable@3.8.2)
 
   decap-cms-widget-code@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(codemirror@5.65.17)(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(lodash@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -18813,20 +18455,6 @@ snapshots:
       - react-dom
       - supports-color
 
-  decap-cms-widget-code@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(codemirror@5.65.17)(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      codemirror: 5.65.17
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      lodash: 4.17.21
-      react: 19.0.0
-      react-codemirror2: 7.3.0(codemirror@5.65.17)(react@19.0.0)
-      react-select: 4.3.1(@types/react@18.3.4)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
   decap-cms-widget-colorstring@3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(prop-types@15.8.1)(react@18.3.1):
     dependencies:
       '@emotion/react': 11.13.3(@types/react@18.3.4)(react@18.3.1)
@@ -18837,27 +18465,11 @@ snapshots:
       react-color: 2.19.3(react@18.3.1)
       tinycolor2: 1.6.0
 
-  decap-cms-widget-colorstring@3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-color: 2.19.3(react@19.0.0)
-      tinycolor2: 1.6.0
-
   decap-cms-widget-datetime@3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(react@18.3.1):
     dependencies:
       '@emotion/react': 11.13.3(@types/react@18.3.4)(react@18.3.1)
       dayjs: 1.11.13
       react: 18.3.1
-
-  decap-cms-widget-datetime@3.2.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      dayjs: 1.11.13
-      react: 19.0.0
 
   decap-cms-widget-file@3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(immutable@3.8.2)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@18.3.1)(uuid@8.3.2):
     dependencies:
@@ -18877,24 +18489,6 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  decap-cms-widget-file@3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)(uuid@11.0.1):
-    dependencies:
-      '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      array-move: 4.0.0
-      common-tags: 1.8.2
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      immutable: 3.8.2
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-immutable-proptypes: 2.2.0(immutable@3.8.2)
-      uuid: 11.0.1
-    transitivePeerDependencies:
-      - react-dom
-
   decap-cms-widget-image@3.1.3(3mn2uxuvsm6qi5pwble4snq65e):
     dependencies:
       '@emotion/react': 11.13.3(@types/react@18.3.4)(react@18.3.1)
@@ -18904,34 +18498,6 @@ snapshots:
       immutable: 3.8.2
       prop-types: 15.8.1
       react: 18.3.1
-
-  decap-cms-widget-image@3.1.3(3rwgcguzcp7qxggw6ff2xxrwqa):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      decap-cms-widget-file: 3.1.3(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)(uuid@11.0.1)
-      immutable: 3.8.2
-      prop-types: 15.8.1
-      react: 19.0.0
-
-  decap-cms-widget-list@3.2.2(oekhr6mtxr2yv5je4527w4euoe):
-    dependencies:
-      '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-lib-widgets: 3.0.2(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      decap-cms-widget-object: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0)
-      immutable: 3.8.2
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-immutable-proptypes: 2.2.0(immutable@3.8.2)
-    transitivePeerDependencies:
-      - react-dom
 
   decap-cms-widget-list@3.2.2(sl37yvskw3peblmevswzpqxiky):
     dependencies:
@@ -18959,16 +18525,6 @@ snapshots:
       ol: 6.15.1
       prop-types: 15.8.1
       react: 18.3.1
-      react-immutable-proptypes: 2.2.0(immutable@3.8.2)
-
-  decap-cms-widget-map@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      lodash: 4.17.21
-      ol: 6.15.1
-      prop-types: 15.8.1
-      react: 19.0.0
       react-immutable-proptypes: 2.2.0(immutable@3.8.2)
 
   decap-cms-widget-markdown@3.1.6(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@18.3.1):
@@ -19005,51 +18561,11 @@ snapshots:
       unist-builder: 1.0.4
       unist-util-visit-parents: 2.1.2
 
-  decap-cms-widget-markdown@3.1.6(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      dompurify: 2.5.6
-      immutable: 3.8.2
-      is-hotkey: 0.2.0
-      is-url: 1.2.4
-      lodash: 4.17.21
-      mdast-util-definitions: 1.2.5
-      mdast-util-to-string: 1.1.0
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-      react-immutable-proptypes: 2.2.0(immutable@3.8.2)
-      rehype-parse: 6.0.2
-      rehype-remark: 8.1.1
-      rehype-stringify: 7.0.0
-      remark-parse: 6.0.3
-      remark-rehype: 4.0.1
-      remark-slate: 1.8.6
-      remark-slate-transformer: 0.7.5(unified@9.2.2)
-      remark-stringify: 6.0.4
-      slate: 0.91.4
-      slate-base64-serializer: 0.2.115(slate@0.91.4)
-      slate-history: 0.93.0(slate@0.91.4)
-      slate-plain-serializer: 0.7.13(immutable@3.8.2)(slate@0.91.4)
-      slate-react: 0.91.11(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(slate@0.91.4)
-      slate-soft-break: 0.9.0(slate-react@0.91.11(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(slate@0.91.4))(slate@0.91.4)
-      unified: 9.2.2
-      unist-builder: 1.0.4
-      unist-util-visit-parents: 2.1.2
-
   decap-cms-widget-number@3.1.3(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(prop-types@15.8.1)(react@18.3.1):
     dependencies:
       decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
-
-  decap-cms-widget-number@3.1.3(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0):
-    dependencies:
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      prop-types: 15.8.1
-      react: 19.0.0
 
   decap-cms-widget-object@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@18.3.1):
     dependencies:
@@ -19060,17 +18576,6 @@ snapshots:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.3.1
-      react-immutable-proptypes: 2.2.0(immutable@3.8.2)
-
-  decap-cms-widget-object@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0):
-    dependencies:
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      immutable: 3.8.2
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
       react-immutable-proptypes: 2.2.0(immutable@3.8.2)
 
   decap-cms-widget-relation@3.3.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(decap-cms-lib-widgets@3.0.2(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(uuid@8.3.2):
@@ -19094,27 +18599,6 @@ snapshots:
       - react-dom
       - supports-color
 
-  decap-cms-widget-relation@3.3.2(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(decap-cms-lib-widgets@3.0.2(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(uuid@8.3.2):
-    dependencies:
-      '@dnd-kit/core': 6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react@19.0.0)
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0)
-      decap-cms-lib-widgets: 3.0.2(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      immutable: 3.8.2
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-select: 4.3.1(@types/react@18.3.4)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      react-window: 1.8.10(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
   decap-cms-widget-select@3.2.2(@types/react@18.3.4)(decap-cms-lib-widgets@3.0.2(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(immutable@3.8.2)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@18.3.1):
     dependencies:
       decap-cms-lib-widgets: 3.0.2(immutable@3.8.2)(lodash@4.17.21)
@@ -19129,31 +18613,11 @@ snapshots:
       - react-dom
       - supports-color
 
-  decap-cms-widget-select@3.2.2(@types/react@18.3.4)(decap-cms-lib-widgets@3.0.2(immutable@3.8.2)(lodash@4.17.21))(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(immutable@3.8.2)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react-immutable-proptypes@2.2.0(immutable@3.8.2))(react@19.0.0):
-    dependencies:
-      decap-cms-lib-widgets: 3.0.2(immutable@3.8.2)(lodash@4.17.21)
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      immutable: 3.8.2
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-immutable-proptypes: 2.2.0(immutable@3.8.2)
-      react-select: 4.3.1(@types/react@18.3.4)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
   decap-cms-widget-string@3.1.3(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(prop-types@15.8.1)(react@18.3.1):
     dependencies:
       decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
-
-  decap-cms-widget-string@3.1.3(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0):
-    dependencies:
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      prop-types: 15.8.1
-      react: 19.0.0
 
   decap-cms-widget-text@3.1.3(@types/react@18.3.4)(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(prop-types@15.8.1)(react@18.3.1):
     dependencies:
@@ -19161,15 +18625,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
       react-textarea-autosize: 8.5.3(@types/react@18.3.4)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  decap-cms-widget-text@3.1.3(@types/react@18.3.4)(decap-cms-ui-default@3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(prop-types@15.8.1)(react@19.0.0):
-    dependencies:
-      decap-cms-ui-default: 3.1.4(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@19.0.0))(@types/react@18.3.4)(react@19.0.0))(lodash@4.17.21)(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-textarea-autosize: 8.5.3(@types/react@18.3.4)(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -20604,14 +20059,14 @@ snapshots:
       '@babel/runtime': 7.25.6
       core-js-compat: 3.31.0
 
-  gatsby-link@5.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
+  gatsby-link@5.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/reach__router': 1.3.15
       gatsby-page-utils: 3.13.1
       prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   gatsby-page-utils@3.13.1:
     dependencies:
@@ -20640,54 +20095,54 @@ snapshots:
       '@parcel/transformer-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-json': 2.8.3(@parcel/core@2.8.3)
 
-  gatsby-plugin-feed@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
+  gatsby-plugin-feed@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.7
       common-tags: 1.8.2
       fs-extra: 11.2.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
       lodash.merge: 4.6.2
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       rss: 1.2.2
     transitivePeerDependencies:
       - graphql
 
-  gatsby-plugin-google-analytics@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
+  gatsby-plugin-google-analytics@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.7
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       minimatch: 3.1.2
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       web-vitals: 1.1.2
 
-  gatsby-plugin-manifest@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
+  gatsby-plugin-manifest@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.24.7
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
       semver: 7.6.2
       sharp: 0.32.6
     transitivePeerDependencies:
       - graphql
 
-  gatsby-plugin-offline@6.13.2(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
+  gatsby-plugin-offline@6.13.2(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.7
       cheerio: 1.0.0-rc.12
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
       glob: 7.2.3
       idb-keyval: 3.2.0
       lodash: 4.17.21
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       workbox-build: 4.3.1
 
-  gatsby-plugin-page-creator@5.13.1(encoding@0.1.13)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0):
+  gatsby-plugin-page-creator@5.13.1(encoding@0.1.13)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.25.6
       '@babel/traverse': 7.25.9
@@ -20695,10 +20150,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.2.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
       gatsby-page-utils: 3.13.1
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0)
       gatsby-telemetry: 4.13.1(encoding@0.1.13)
       globby: 11.1.0
       lodash: 4.17.21
@@ -20707,7 +20162,7 @@ snapshots:
       - graphql
       - supports-color
 
-  gatsby-plugin-page-creator@5.13.1(encoding@0.1.13)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
+  gatsby-plugin-page-creator@5.13.1(encoding@0.1.13)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.25.6
       '@babel/traverse': 7.25.9
@@ -20715,10 +20170,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.2.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
       gatsby-page-utils: 3.13.1
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
       gatsby-telemetry: 4.13.1(encoding@0.1.13)
       globby: 11.1.0
       lodash: 4.17.21
@@ -20727,28 +20182,28 @@ snapshots:
       - graphql
       - supports-color
 
-  gatsby-plugin-preact@7.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(preact-render-to-string@5.2.6(preact@10.22.1))(preact@10.22.1)(webpack@5.97.0(esbuild@0.24.0)):
+  gatsby-plugin-preact@7.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(preact-render-to-string@5.2.6(preact@10.22.1))(preact@10.22.1)(webpack@5.97.0(esbuild@0.24.0)):
     dependencies:
       '@babel/runtime': 7.24.7
       '@gatsbyjs/webpack-hot-middleware': 2.25.3
       '@prefresh/babel-plugin': 0.4.4
       '@prefresh/webpack': 3.3.4(@prefresh/babel-plugin@0.4.4)(preact@10.22.1)(webpack@5.97.0(esbuild@0.24.0))
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       preact: 10.22.1
       preact-render-to-string: 5.2.6(preact@10.22.1)
     transitivePeerDependencies:
       - webpack
 
-  gatsby-plugin-react-helmet@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-helmet@6.1.0(react@19.0.0)):
+  gatsby-plugin-react-helmet@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-helmet@6.1.0(react@18.3.1)):
     dependencies:
       '@babel/runtime': 7.24.7
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
-      react-helmet: 6.1.0(react@19.0.0)
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      react-helmet: 6.1.0(react@18.3.1)
 
-  gatsby-plugin-sass@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(sass@1.77.6)(webpack@5.97.0(esbuild@0.24.0)):
+  gatsby-plugin-sass@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(sass@1.77.6)(webpack@5.97.0(esbuild@0.24.0)):
     dependencies:
       '@babel/runtime': 7.24.7
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       resolve-url-loader: 3.1.5
       sass: 1.77.6
       sass-loader: 10.5.2(sass@1.77.6)(webpack@5.97.0(esbuild@0.24.0))
@@ -20757,7 +20212,7 @@ snapshots:
       - node-sass
       - webpack
 
-  gatsby-plugin-sharp@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
+  gatsby-plugin-sharp@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.24.7
       async: 3.2.5
@@ -20765,9 +20220,9 @@ snapshots:
       debug: 4.3.5
       filenamify: 4.3.0
       fs-extra: 11.2.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
       lodash: 4.17.21
       probe-image-size: 7.2.3
       semver: 7.6.2
@@ -20776,17 +20231,17 @@ snapshots:
       - graphql
       - supports-color
 
-  gatsby-plugin-sitemap@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
+  gatsby-plugin-sitemap@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.7
       common-tags: 1.8.2
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       minimatch: 3.1.2
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       sitemap: 7.1.2
 
-  gatsby-plugin-typescript@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))):
+  gatsby-plugin-typescript@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.26.0)
@@ -20794,12 +20249,12 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.26.0)
       '@babel/runtime': 7.25.6
-      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
+      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-typescript@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
+  gatsby-plugin-typescript@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.26.0)
@@ -20807,17 +20262,17 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.26.0)
       '@babel/runtime': 7.25.6
-      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-utils@4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0):
+  gatsby-plugin-utils@4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.25.6
       fastq: 1.17.1
       fs-extra: 11.2.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
       gatsby-sharp: 1.13.0
       graphql: 16.9.0
@@ -20826,12 +20281,12 @@ snapshots:
       joi: 17.13.3
       mime: 3.0.0
 
-  gatsby-plugin-utils@4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
+  gatsby-plugin-utils@4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.25.6
       fastq: 1.17.1
       fs-extra: 11.2.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
       gatsby-sharp: 1.13.0
       graphql: 16.9.0
@@ -20845,24 +20300,24 @@ snapshots:
       babel-runtime: 6.26.0
       webfontloader: 1.6.28
 
-  gatsby-react-router-scroll@6.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
+  gatsby-react-router-scroll@6.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.6
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  gatsby-remark-embed-gist@1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))))(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react@19.0.0):
+  gatsby-remark-embed-gist@1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))))(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.7
       async-unist-util-visit: 1.0.0
       cheerio: 1.0.0-rc.12
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
-      gatsby-transformer-remark: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby-transformer-remark: 6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
       node-fetch: 2.7.0(encoding@0.1.13)
       parse-numeric-range: 1.3.0
-      react: 19.0.0
+      react: 18.3.1
     transitivePeerDependencies:
       - encoding
 
@@ -20872,39 +20327,39 @@ snapshots:
       remark-burger: 1.0.1
       unist-util-visit: 2.0.3
 
-  gatsby-remark-prismjs@7.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(prismjs@1.29.0):
+  gatsby-remark-prismjs@7.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(prismjs@1.29.0):
     dependencies:
       '@babel/runtime': 7.24.7
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       parse-numeric-range: 1.3.0
       prismjs: 1.29.0
       unist-util-visit: 2.0.3
 
-  gatsby-remark-twitter-cards@0.6.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
+  gatsby-remark-twitter-cards@0.6.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
     dependencies:
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       jimp: 0.16.13
       path: 0.12.7
       wasm-twitter-card: 0.3.0
 
-  gatsby-script@2.13.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
+  gatsby-script@2.13.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   gatsby-sharp@1.13.0:
     dependencies:
       sharp: 0.32.6
 
-  gatsby-source-filesystem@2.11.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
+  gatsby-source-filesystem@2.11.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
     dependencies:
       '@babel/runtime': 7.25.6
       better-queue: 3.8.12
       chokidar: 3.6.0
       file-type: 16.5.4
       fs-extra: 8.1.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-core-utils: 1.10.1
       got: 9.6.0
       md5-file: 5.0.0
@@ -20914,25 +20369,25 @@ snapshots:
       valid-url: 1.0.9
       xstate: 4.38.3
 
-  gatsby-source-filesystem@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
+  gatsby-source-filesystem@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
     dependencies:
       '@babel/runtime': 7.24.7
       chokidar: 3.6.0
       file-type: 16.5.4
       fs-extra: 11.2.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
       mime: 3.0.0
       pretty-bytes: 5.6.0
       valid-url: 1.0.9
       xstate: 4.38.3
 
-  gatsby-source-git@1.1.0(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
+  gatsby-source-git@1.1.0(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
     dependencies:
       fast-glob: 2.2.7
       fs-extra: 5.0.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
-      gatsby-source-filesystem: 2.11.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby-source-filesystem: 2.11.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
       git-url-parse: 11.6.0
       rimraf: 2.7.1
       simple-git: 1.132.0
@@ -20956,10 +20411,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  gatsby-transformer-remark@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
+  gatsby-transformer-remark@6.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))):
     dependencies:
       '@babel/runtime': 7.24.7
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
       gatsby-core-utils: 4.13.1
       gray-matter: 4.0.3
       hast-util-raw: 6.1.0
@@ -20984,15 +20439,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-transformer-sharp@5.13.1(gatsby-plugin-sharp@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0))(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
+  gatsby-transformer-sharp@5.13.1(gatsby-plugin-sharp@5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0))(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0):
     dependencies:
       '@babel/runtime': 7.24.7
       bluebird: 3.7.2
       common-tags: 1.8.2
       fs-extra: 11.2.0
-      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
-      gatsby-plugin-sharp: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby: 5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0)))
+      gatsby-plugin-sharp: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
       probe-image-size: 7.2.3
       semver: 7.6.2
       sharp: 0.32.6
@@ -21009,7 +20464,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))):
+  gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/core': 7.26.0
@@ -21020,7 +20475,7 @@ snapshots:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
       '@builder.io/partytown': 0.7.6
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@gatsbyjs/webpack-hot-middleware': 2.25.3
       '@graphql-codegen/add': 3.2.3(graphql@16.9.0)
       '@graphql-codegen/core': 2.6.8(graphql@16.9.0)
@@ -21049,7 +20504,7 @@ snapshots:
       babel-loader: 8.3.0(@babel/core@7.26.0)(webpack@5.96.1(esbuild@0.24.0))
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))
+      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))
       babel-preset-gatsby: 3.13.2(@babel/core@7.26.0)(core-js@3.37.1)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -21096,14 +20551,14 @@ snapshots:
       gatsby-core-utils: 4.13.1
       gatsby-graphiql-explorer: 3.13.1
       gatsby-legacy-polyfills: 3.13.1
-      gatsby-link: 5.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      gatsby-link: 5.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-page-utils: 3.13.1
       gatsby-parcel-config: 1.13.1(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.13.1(encoding@0.1.13)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0)
-      gatsby-plugin-typescript: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0)
-      gatsby-react-router-scroll: 6.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      gatsby-script: 2.13.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      gatsby-plugin-page-creator: 5.13.1(encoding@0.1.13)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby-plugin-typescript: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.96.1(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby-react-router-scroll: 6.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gatsby-script: 2.13.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-telemetry: 4.13.1(encoding@0.1.13)
       gatsby-worker: 2.13.1
       glob: 7.2.3
@@ -21148,11 +20603,11 @@ snapshots:
       prop-types: 15.8.1
       query-string: 6.14.1
       raw-loader: 4.0.2(webpack@5.96.1(esbuild@0.24.0))
-      react: 19.0.0
+      react: 18.3.1
       react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@5.7.2)(webpack@5.96.1(esbuild@0.24.0))
-      react-dom: 18.3.1(react@19.0.0)
+      react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
-      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@19.0.0)(webpack@5.96.1(esbuild@0.24.0))
+      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@18.3.1)(webpack@5.96.1(esbuild@0.24.0))
       redux: 4.2.1
       redux-thunk: 2.4.2(redux@4.2.1)
       resolve-from: 5.0.0
@@ -21207,7 +20662,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))):
+  gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/core': 7.26.0
@@ -21218,7 +20673,7 @@ snapshots:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
       '@builder.io/partytown': 0.7.6
-      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@gatsbyjs/webpack-hot-middleware': 2.25.3
       '@graphql-codegen/add': 3.2.3(graphql@16.9.0)
       '@graphql-codegen/core': 2.6.8(graphql@16.9.0)
@@ -21247,7 +20702,7 @@ snapshots:
       babel-loader: 8.3.0(@babel/core@7.26.0)(webpack@5.96.1(esbuild@0.24.0))
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
+      babel-plugin-remove-graphql-queries: 5.13.1(@babel/core@7.26.0)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
       babel-preset-gatsby: 3.13.2(@babel/core@7.26.0)(core-js@3.37.1)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -21294,14 +20749,14 @@ snapshots:
       gatsby-core-utils: 4.13.1
       gatsby-graphiql-explorer: 3.13.1
       gatsby-legacy-polyfills: 3.13.1
-      gatsby-link: 5.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      gatsby-link: 5.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-page-utils: 3.13.1
       gatsby-parcel-config: 1.13.1(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.13.1(encoding@0.1.13)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
-      gatsby-plugin-typescript: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
-      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
-      gatsby-react-router-scroll: 6.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-      gatsby-script: 2.13.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0))(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      gatsby-plugin-page-creator: 5.13.1(encoding@0.1.13)(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby-plugin-typescript: 5.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))
+      gatsby-plugin-utils: 4.13.1(gatsby@5.13.6(babel-eslint@10.1.0(eslint@9.6.0))(encoding@0.1.13)(esbuild@0.24.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@5.7.2)(webpack-dev-server@5.1.0(webpack@5.97.0(esbuild@0.24.0))))(graphql@16.9.0)
+      gatsby-react-router-scroll: 6.13.1(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gatsby-script: 2.13.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-telemetry: 4.13.1(encoding@0.1.13)
       gatsby-worker: 2.13.1
       glob: 7.2.3
@@ -21346,11 +20801,11 @@ snapshots:
       prop-types: 15.8.1
       query-string: 6.14.1
       raw-loader: 4.0.2(webpack@5.96.1(esbuild@0.24.0))
-      react: 19.0.0
+      react: 18.3.1
       react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@5.7.2)(webpack@5.96.1(esbuild@0.24.0))
-      react-dom: 18.3.1(react@19.0.0)
+      react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
-      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@19.0.0)(webpack@5.96.1(esbuild@0.24.0))
+      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@18.3.1)(webpack@5.96.1(esbuild@0.24.0))
       redux: 4.2.1
       redux-thunk: 2.4.2(redux@4.2.1)
       resolve-from: 5.0.0
@@ -25306,22 +24761,10 @@ snapshots:
       react: 18.3.1
       teeny-tap: 0.2.0
 
-  react-aria-menubutton@7.0.3(react@19.0.0):
-    dependencies:
-      focus-group: 0.3.1
-      prop-types: 15.8.1
-      react: 19.0.0
-      teeny-tap: 0.2.0
-
   react-codemirror2@7.3.0(codemirror@5.65.17)(react@18.3.1):
     dependencies:
       codemirror: 5.65.17
       react: 18.3.1
-
-  react-codemirror2@7.3.0(codemirror@5.65.17)(react@19.0.0):
-    dependencies:
-      codemirror: 5.65.17
-      react: 19.0.0
 
   react-color@2.19.3(react@18.3.1):
     dependencies:
@@ -25332,17 +24775,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
       reactcss: 1.2.3(react@18.3.1)
-      tinycolor2: 1.6.0
-
-  react-color@2.19.3(react@19.0.0):
-    dependencies:
-      '@icons/material': 0.2.4(react@19.0.0)
-      lodash: 4.17.21
-      lodash-es: 4.17.21
-      material-colors: 1.2.6
-      prop-types: 15.8.1
-      react: 19.0.0
-      reactcss: 1.2.3(react@19.0.0)
       tinycolor2: 1.6.0
 
   react-dev-utils@12.0.1(eslint@7.32.0)(typescript@5.7.2)(webpack@5.96.1(esbuild@0.24.0)):
@@ -25396,29 +24828,10 @@ snapshots:
       '@types/node': 22.10.1
       '@types/react': 18.3.4
 
-  react-dnd@14.0.5(@types/hoist-non-react-statics@3.3.5)(@types/node@22.10.1)(@types/react@18.3.4)(react@19.0.0):
-    dependencies:
-      '@react-dnd/invariant': 2.0.0
-      '@react-dnd/shallowequal': 2.0.0
-      dnd-core: 14.0.1
-      fast-deep-equal: 3.1.3
-      hoist-non-react-statics: 3.3.2
-      react: 19.0.0
-    optionalDependencies:
-      '@types/hoist-non-react-statics': 3.3.5
-      '@types/node': 22.10.1
-      '@types/react': 18.3.4
-
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
-      scheduler: 0.23.2
-
-  react-dom@18.3.1(react@19.0.0):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 19.0.0
       scheduler: 0.23.2
 
   react-error-overlay@6.0.11: {}
@@ -25431,19 +24844,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-frame-component@5.2.7(prop-types@15.8.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-
-  react-helmet@6.1.0(react@19.0.0):
+  react-helmet@6.1.0(react@18.3.1):
     dependencies:
       object-assign: 4.1.1
       prop-types: 15.8.1
-      react: 19.0.0
+      react: 18.3.1
       react-fast-compare: 3.2.2
-      react-side-effect: 2.1.2(react@19.0.0)
+      react-side-effect: 2.1.2(react@18.3.1)
 
   react-immutable-proptypes@2.2.0(immutable@3.8.2):
     dependencies:
@@ -25454,11 +24861,6 @@ snapshots:
     dependencies:
       prop-types: 15.8.1
       react: 18.3.1
-
-  react-input-autosize@3.0.0(react@19.0.0):
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.0.0
 
   react-is@16.13.1: {}
 
@@ -25488,41 +24890,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-markdown@6.0.3(@types/react@18.3.4)(react@19.0.0):
-    dependencies:
-      '@types/hast': 2.3.10
-      '@types/react': 18.3.4
-      '@types/unist': 2.0.11
-      comma-separated-tokens: 1.0.8
-      prop-types: 15.8.1
-      property-information: 5.6.0
-      react: 19.0.0
-      react-is: 17.0.2
-      remark-parse: 9.0.0
-      remark-rehype: 8.1.0
-      space-separated-tokens: 1.1.5
-      style-to-object: 0.3.0
-      unified: 9.2.2
-      unist-util-visit: 2.0.3
-      vfile: 4.2.1
-    transitivePeerDependencies:
-      - supports-color
-
   react-modal@3.16.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       exenv: 1.2.2
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-lifecycles-compat: 3.0.4
-      warning: 4.0.3
-
-  react-modal@3.16.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      exenv: 1.2.2
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
       react-lifecycles-compat: 3.0.4
       warning: 4.0.3
 
@@ -25533,13 +24906,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
 
-  react-polyglot@0.7.2(node-polyglot@2.6.0)(react@19.0.0):
-    dependencies:
-      hoist-non-react-statics: 3.3.2
-      node-polyglot: 2.6.0
-      prop-types: 15.8.1
-      react: 19.0.0
-
   react-redux@4.4.10(react@18.3.1)(redux@4.2.1):
     dependencies:
       create-react-class: 15.7.0
@@ -25549,17 +24915,6 @@ snapshots:
       loose-envify: 1.4.0
       prop-types: 15.8.1
       react: 18.3.1
-      redux: 4.2.1
-
-  react-redux@4.4.10(react@19.0.0)(redux@4.2.1):
-    dependencies:
-      create-react-class: 15.7.0
-      hoist-non-react-statics: 3.3.2
-      invariant: 2.2.4
-      lodash: 4.17.21
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.0.0
       redux: 4.2.1
 
   react-redux@7.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -25574,18 +24929,6 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
-  react-redux@7.2.9(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@babel/runtime': 7.25.6
-      '@types/react-redux': 7.1.33
-      hoist-non-react-statics: 3.3.2
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-is: 17.0.2
-    optionalDependencies:
-      react-dom: 18.3.1(react@19.0.0)
-
   react-refresh@0.14.2: {}
 
   react-router-dom@5.3.4(react@18.3.1):
@@ -25596,17 +24939,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
       react-router: 5.3.4(react@18.3.1)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
-  react-router-dom@5.3.4(react@19.0.0):
-    dependencies:
-      '@babel/runtime': 7.25.6
-      history: 4.10.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-router: 5.3.4(react@19.0.0)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
@@ -25623,30 +24955,11 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router@5.3.4(react@19.0.0):
-    dependencies:
-      '@babel/runtime': 7.25.6
-      history: 4.10.1
-      hoist-non-react-statics: 3.3.2
-      loose-envify: 1.4.0
-      path-to-regexp: 1.8.0
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-is: 16.13.1
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
   react-scroll-sync@0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  react-scroll-sync@0.9.0(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
 
   react-select@4.3.1(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -25663,46 +24976,23 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  react-select@4.3.1(@types/react@18.3.4)(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@babel/runtime': 7.25.6
-      '@emotion/cache': 11.13.1
-      '@emotion/react': 11.13.3(@types/react@18.3.4)(react@19.0.0)
-      memoize-one: 5.2.1
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-      react-input-autosize: 3.0.0(react@19.0.0)
-      react-transition-group: 4.4.5(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-
-  react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825(react@19.0.0)(webpack@5.96.1(esbuild@0.24.0)):
+  react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825(react@18.3.1)(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
       acorn: 6.4.2
       loose-envify: 1.4.0
       neo-async: 2.6.2
-      react: 19.0.0
+      react: 18.3.1
       webpack: 5.96.1(esbuild@0.24.0)
 
-  react-side-effect@2.1.2(react@19.0.0):
+  react-side-effect@2.1.2(react@18.3.1):
     dependencies:
-      react: 19.0.0
+      react: 18.3.1
 
   react-split-pane@0.1.92(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-lifecycles-compat: 3.0.4
-      react-style-proptype: 3.2.2
-
-  react-split-pane@0.1.92(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
       react-lifecycles-compat: 3.0.4
       react-style-proptype: 3.2.2
 
@@ -25719,35 +25009,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  react-textarea-autosize@8.5.3(@types/react@18.3.4)(react@19.0.0):
-    dependencies:
-      '@babel/runtime': 7.25.6
-      react: 19.0.0
-      use-composed-ref: 1.3.0(react@19.0.0)
-      use-latest: 1.2.1(@types/react@18.3.4)(react@19.0.0)
-    transitivePeerDependencies:
-      - '@types/react'
-
   react-toastify@9.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       clsx: 1.2.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-toastify@9.1.3(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      clsx: 1.2.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-
   react-topbar-progress-indicator@4.1.1(react@18.3.1):
     dependencies:
       react: 18.3.1
-      topbar: 0.1.4
-
-  react-topbar-progress-indicator@4.1.1(react@19.0.0):
-    dependencies:
-      react: 19.0.0
       topbar: 0.1.4
 
   react-transition-group@1.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -25760,16 +25030,6 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       warning: 3.0.0
 
-  react-transition-group@1.2.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      chain-function: 1.0.1
-      dom-helpers: 3.4.0
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-      warning: 3.0.0
-
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.6
@@ -25779,24 +25039,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-transition-group@4.4.5(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@babel/runtime': 7.25.6
-      dom-helpers: 5.2.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-
   react-virtualized-auto-sizer@1.0.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  react-virtualized-auto-sizer@1.0.24(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
 
   react-waypoint@10.3.0(react@18.3.1):
     dependencies:
@@ -25806,14 +25052,6 @@ snapshots:
       react: 18.3.1
       react-is: 18.3.1
 
-  react-waypoint@10.3.0(react@19.0.0):
-    dependencies:
-      '@babel/runtime': 7.25.6
-      consolidated-events: 2.0.2
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-is: 18.3.1
-
   react-window@1.8.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.6
@@ -25821,28 +25059,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-window@1.8.10(react-dom@18.3.1(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@babel/runtime': 7.25.6
-      memoize-one: 5.2.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  react@19.0.0: {}
 
   reactcss@1.2.3(react@18.3.1):
     dependencies:
       lodash: 4.17.21
       react: 18.3.1
-
-  reactcss@1.2.3(react@19.0.0):
-    dependencies:
-      lodash: 4.17.21
-      react: 19.0.0
 
   read-cmd-shim@4.0.0: {}
 
@@ -25935,17 +25159,6 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-redux: 4.4.10(react@18.3.1)(redux@4.2.1)
       react-transition-group: 1.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - redux
-
-  redux-notifications@4.0.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(redux@4.2.1):
-    dependencies:
-      object-assign: 4.1.1
-      prop-types: 15.8.1
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-      react-redux: 4.4.10(react@19.0.0)(redux@4.2.1)
-      react-transition-group: 1.2.1(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - redux
 
@@ -26661,30 +25874,10 @@ snapshots:
       slate: 0.91.4
       tiny-invariant: 1.0.6
 
-  slate-react@0.91.11(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(slate@0.91.4):
-    dependencies:
-      '@juggle/resize-observer': 3.4.0
-      '@types/is-hotkey': 0.1.10
-      '@types/lodash': 4.17.7
-      direction: 1.0.4
-      is-hotkey: 0.1.8
-      is-plain-object: 5.0.0
-      lodash: 4.17.21
-      react: 19.0.0
-      react-dom: 18.3.1(react@19.0.0)
-      scroll-into-view-if-needed: 2.2.31
-      slate: 0.91.4
-      tiny-invariant: 1.0.6
-
   slate-soft-break@0.9.0(slate-react@0.91.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.91.4))(slate@0.91.4):
     dependencies:
       slate: 0.91.4
       slate-react: 0.91.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.91.4)
-
-  slate-soft-break@0.9.0(slate-react@0.91.11(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(slate@0.91.4))(slate@0.91.4):
-    dependencies:
-      slate: 0.91.4
-      slate-react: 0.91.11(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(slate@0.91.4)
 
   slate@0.91.4:
     dependencies:
@@ -27815,19 +27008,9 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  use-composed-ref@1.3.0(react@19.0.0):
-    dependencies:
-      react: 19.0.0
-
   use-isomorphic-layout-effect@1.1.2(@types/react@18.3.4)(react@18.3.1):
     dependencies:
       react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.4
-
-  use-isomorphic-layout-effect@1.1.2(@types/react@18.3.4)(react@19.0.0):
-    dependencies:
-      react: 19.0.0
     optionalDependencies:
       '@types/react': 18.3.4
 
@@ -27835,13 +27018,6 @@ snapshots:
     dependencies:
       react: 18.3.1
       use-isomorphic-layout-effect: 1.1.2(@types/react@18.3.4)(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.4
-
-  use-latest@1.2.1(@types/react@18.3.4)(react@19.0.0):
-    dependencies:
-      react: 19.0.0
-      use-isomorphic-layout-effect: 1.1.2(@types/react@18.3.4)(react@19.0.0)
     optionalDependencies:
       '@types/react': 18.3.4
 

--- a/services/cms/package.json
+++ b/services/cms/package.json
@@ -41,7 +41,7 @@
     "decap-cms": "^3.3.2",
     "decap-cms-app": "^3.3.2",
     "decap-cms-backend-proxy": "^3.1.4",
-    "react": "^19.0.0",
+    "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "uuid": "^11.0.1"
   },

--- a/services/personal-website/package.json
+++ b/services/personal-website/package.json
@@ -53,7 +53,7 @@
     "prismjs": "^1.29.0",
     "promise-image-loader": "^0.1.2",
     "prop-types": "^15.8.1",
-    "react": "^19.0.0",
+    "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",
     "sass": "^1.77.2",


### PR DESCRIPTION
# Why?
New major release of React has broken builds.  I have not yet looked into why!

# What?
Reverts alexwilson/frontend#3077

