### PR TITLE
explicitly fail CI when important steps fail

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -64,7 +64,13 @@ jobs:
     name: Test
     needs: build
     runs-on: ubuntu-latest
+    if: always()
     steps:
+      - name: Check if Build succeeded
+        if: needs.build.result != 'success'
+        run: |
+          echo "Build failed."
+          exit 1
       - name: Checkout
         uses: actions/checkout@main
         with:
@@ -96,7 +102,13 @@ jobs:
     name: "Validate feed"
     needs: build
     runs-on: ubuntu-22.04
+    if: always()
     steps:
+      - name: Check if Build succeeded
+        if: needs.build.result != 'success'
+        run: |
+          echo "Build failed."
+          exit 1
       - uses: actions/checkout@main
         with:
           repository: w3c/feedvalidator

--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -76,7 +76,13 @@ jobs:
       NODE_ENV: ${{ secrets.NODE_ENV }}
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.projects) }}
+    if: always()
     steps:
+      - name: Fail explicitly if Prepare failed
+        if: needs.prepare.result != 'success'
+        run: |
+          echo "Prepare failed."
+          exit 1
       - name: Checkout
         uses: actions/checkout@main
         with:
@@ -101,7 +107,13 @@ jobs:
     name: Tests Passed
     needs: [test]
     runs-on: ubuntu-latest
+    if: always()
     steps:
+      - name: Explicit fail if Test job failed
+        if: needs.test.result != 'success'
+        run: |
+          echo "Tests failed."
+          exit 1
       - run: echo "👍"
 
   deploy:


### PR DESCRIPTION
# Why?
For all new merges, this repository has two required status checks: Test & Tests Passed.
Some pull-requests are merged even when these status checks have not passed, leading to breakages and problems.

# What?
To see if this makes any difference, we now always run the required steps up to the required status-checks, and fail them *explicitly* if a prior step has not succeeded.