### PR TITLE
fix: wrangler publish -> wrangler deploy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,6 @@ updates:
         versions: ["^3.5"]
       - dependency-name: "decap-cms-app"
         versions: ["^3.5"]
-
-      # Wrangler has deprecated the publish command.
-      - dependency-name: "wrangler"
-        versions: ["^4.0"]
     reviewers:
       - alexwilson
     versioning-strategy: increase-if-necessary

--- a/services/auth-cms/package.json
+++ b/services/auth-cms/package.json
@@ -4,7 +4,7 @@
   "description": "CMS authentication worker for Netlify CMS",
   "main": "src/index.js",
   "scripts": {
-    "deploy": "wrangler publish"
+    "deploy": "wrangler deploy"
   },
   "author": "Alex Wilson <alex@alexwilson.tech>",
   "type": "module",

--- a/services/cms/package.json
+++ b/services/cms/package.json
@@ -7,7 +7,7 @@
     "build:worker": "webpack --config webpack.worker.cjs",
     "build": "npm-run-all build:*",
     "deploy:client": "aws s3 sync --acl=public-read --delete ./dist/ s3://alex-static-assets/cms/",
-    "deploy:worker": "wrangler publish",
+    "deploy:worker": "wrangler deploy",
     "deploy": "npm-run-all build:* deploy:*",
     "test": "npm-run-all build",
     "start": "webpack serve --config webpack.client.cjs"


### PR DESCRIPTION
# Why?
New versions of Wrangler remove the `wrangler publish` command.

# What?
Change uses of `wrangler publish` to its replacement `wrangler deploy`.