### PR TITLE
CI improvements

### DIFF
--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Restore node_modules
       uses: actions/cache@v5
       with:
-        key: node_modules-${{ hashFiles('pnpm-lock.yaml') }}
+        key: node_modules-${{ inputs.install-filter }}-${{ hashFiles('pnpm-lock.yaml') }}
         path: |
           node_modules
           */*/node_modules

--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -1,0 +1,41 @@
+name: 'Setup monorepo'
+description: 'Install pnpm and Node, restore workspace caches, and install dependencies.'
+
+inputs:
+  install-filter:
+    description: >
+      Optional pnpm filter to scope the install
+      (e.g. '@alexwilson/personal-website...' to include a package and its deps,
+      or '!@alexwilson/personal-website' to exclude it).
+      Leave empty for a full workspace install.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 10
+        run_install: false
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.node-version'
+        cache: 'pnpm'
+    - name: Restore node_modules
+      uses: actions/cache@v4
+      with:
+        key: node_modules-${{ hashFiles('pnpm-lock.yaml') }}
+        path: |
+          node_modules
+          */*/node_modules
+    - name: Install dependencies
+      shell: bash
+      env:
+        FILTER: ${{ inputs.install-filter }}
+      run: |
+        if [ -n "$FILTER" ]; then
+          pnpm install --prod=false --filter "$FILTER"
+        else
+          pnpm install --prod=false
+        fi

--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -14,16 +14,16 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v5
       with:
         version: 10
         run_install: false
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version-file: '.node-version'
         cache: 'pnpm'
     - name: Restore node_modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: node_modules-${{ hashFiles('pnpm-lock.yaml') }}
         path: |

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -24,11 +24,11 @@ jobs:
     if: github.ref != 'refs/heads/gh-pages'
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Restore Cached Build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-public
         with:
           path: |
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CONTENT_ACCESS_TOKEN }}
           CI: true
       - name: Save Build Artefact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: site-artefact
           path: services/personal-website/public
@@ -65,7 +65,7 @@ jobs:
           echo "Build failed."
           exit 1
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - uses: ./.github/actions/setup-monorepo
@@ -88,10 +88,10 @@ jobs:
         run: |
           echo "Build failed."
           exit 1
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v5
         with:
           repository: w3c/feedvalidator
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.7"
       - name: Install dependencies
@@ -99,7 +99,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Download Website Artefact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: site-artefact
           path: public
@@ -120,11 +120,11 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Download Website Artefact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: site-artefact
           path: public

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -11,11 +11,16 @@ on:
     types:
       - content-update
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Fetch dependencies and build Gatsby
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.ref != 'refs/heads/gh-pages'
     steps:
       - name: Checkout
@@ -43,7 +48,7 @@ jobs:
         uses: actions/cache@v4
         id: cache-node_modules
         with:
-          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+          key: node_modules-${{ hashFiles('pnpm-lock.yaml') }}
           path: |
             node_modules
             */*/node_modules
@@ -66,6 +71,7 @@ jobs:
     name: Test
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: always()
     steps:
       - name: Check if Build succeeded
@@ -90,7 +96,7 @@ jobs:
         uses: actions/cache@v4
         id: cache-node_modules
         with:
-          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+          key: node_modules-${{ hashFiles('pnpm-lock.yaml') }}
           path: |
             node_modules
             */*/node_modules
@@ -104,6 +110,7 @@ jobs:
     name: "Validate feed"
     needs: build
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     if: always()
     steps:
       - name: Check if Build succeeded
@@ -139,6 +146,7 @@ jobs:
     name: Deploy Gatsby to Github Pages
     needs: [test, validate-feed]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     steps:
       - name: Checkout

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -34,27 +34,12 @@ jobs:
           path: |
             services/personal-website/public
             services/personal-website/.cache
-          key: build
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
+          key: build-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            build-
+      - uses: ./.github/actions/setup-monorepo
         with:
-          version: 10
-          run_install: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "pnpm"
-      - name: Restore node_modules
-        uses: actions/cache@v4
-        id: cache-node_modules
-        with:
-          key: node_modules-${{ hashFiles('pnpm-lock.yaml') }}
-          path: |
-            node_modules
-            */*/node_modules
-      - name: Install Dependencies
-        run: |
-          pnpm install --filter @alexwilson/personal-website...
+          install-filter: '@alexwilson/personal-website...'
       - name: Build
         run: pnpx lerna run --scope @alexwilson/personal-website build
         env:
@@ -83,26 +68,11 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 1
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
+      - uses: ./.github/actions/setup-monorepo
         with:
-          version: 10
-          run_install: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "pnpm"
-      - name: Restore node_modules
-        uses: actions/cache@v4
-        id: cache-node_modules
-        with:
-          key: node_modules-${{ hashFiles('pnpm-lock.yaml') }}
-          path: |
-            node_modules
-            */*/node_modules
-      - name: Install Dependencies
-        run: |
-          pnpm install --filter @alexwilson/personal-website...
+          install-filter: '@alexwilson/personal-website...'
+      - name: Typecheck
+        run: pnpx lerna run --scope @alexwilson/personal-website typecheck
       - name: Run Tests
         run: pnpx lerna run --scope @alexwilson/personal-website test
 

--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -22,20 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@main
         with:
-          fetch-depth: 10
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-monorepo
         with:
-          version: 10
-          run_install: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "pnpm"
-      - name: Install Dependencies
-        run: |
-          rm services/personal-website/package.json
-          pnpm install --prod=false
+          install-filter: '!@alexwilson/personal-website'
       - id: find-projects
         name: Find affected projects
         run: |
@@ -83,7 +73,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.projects) }}
-    if: always()
+    # auth-cms has no tests — skip to save a runner minute. It's still deployed via the deploy matrix.
+    if: always() && matrix.name != '@alexwilson/auth-cms'
     steps:
       - name: Fail explicitly if Prepare failed
         if: needs.prepare.result != 'success'
@@ -94,19 +85,11 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 1
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
+      - uses: ./.github/actions/setup-monorepo
         with:
-          version: 10
-          run_install: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "pnpm"
-      - name: Install Dependencies
-        run: |
-          rm  services/personal-website/package.json
-          pnpm install --prod=false
+          install-filter: '!@alexwilson/personal-website'
+      - name: Typecheck
+        run: pnpx lerna run typecheck --scope ${{ matrix.name }}
       - name: Test
         run: pnpx lerna run test --scope ${{ matrix.name }}
 
@@ -137,19 +120,9 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
+      - uses: ./.github/actions/setup-monorepo
         with:
-          version: 10
-          run_install: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "pnpm"
-      - name: Install Dependencies
-        run: |
-          rm services/personal-website/package.json
-          pnpm install --prod=false
+          install-filter: '!@alexwilson/personal-website'
       - name: Publish to Chromatic
         run: pnpm --filter @alexwilson/storybook exec chromatic --exit-zero-on-changes
         env:
@@ -171,19 +144,9 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 1
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
+      - uses: ./.github/actions/setup-monorepo
         with:
-          version: 10
-          run_install: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "pnpm"
-      - name: Install Dependencies
-        run: |
-          rm  services/personal-website/package.json
-          pnpm install --prod=false
+          install-filter: '!@alexwilson/personal-website'
       - name: Deploy
         run: pnpx lerna run deploy --scope ${{ matrix.name }}
         env:

--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -8,10 +8,15 @@ on:
     # Scheduled build so pipeline failures are noticed quicker.
     - cron: "30 4 * * 1,3,5,0"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   prepare:
     name: "Prepare (Find Projects, Warm dependency caches)"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       projects: ${{ steps.find-projects.outputs.projects }}
     steps:
@@ -72,9 +77,11 @@ jobs:
     needs: [prepare]
     name: Test ${{ matrix.name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       NODE_ENV: ${{ secrets.NODE_ENV }}
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.projects) }}
     if: always()
     steps:
@@ -107,6 +114,7 @@ jobs:
     name: Tests Passed
     needs: [test]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     steps:
       - name: Explicit fail if Test job failed
@@ -120,6 +128,7 @@ jobs:
     name: Publish to Chromatic
     needs: [prepare]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     if: always() && needs.prepare.result == 'success'
@@ -148,10 +157,12 @@ jobs:
 
   deploy:
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.projects) }}
     name: Deploy ${{ matrix.name }}
     needs: [prepare, tests-passed]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     env:
       NODE_ENV: ${{ secrets.NODE_ENV }}

--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       projects: ${{ steps.find-projects.outputs.projects }}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Fetch base ref for diff
@@ -84,7 +84,7 @@ jobs:
           echo "Prepare failed."
           exit 1
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - uses: ./.github/actions/setup-monorepo
@@ -119,7 +119,7 @@ jobs:
     if: always() && needs.prepare.result == 'success'
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-monorepo
@@ -143,7 +143,7 @@ jobs:
       NODE_ENV: ${{ secrets.NODE_ENV }}
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - uses: ./.github/actions/setup-monorepo

--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -22,45 +22,47 @@ jobs:
     steps:
       - uses: actions/checkout@main
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+      - name: Fetch base ref for diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [ -n "$BASE_SHA" ] && [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            git fetch --depth=1 origin "$BASE_SHA"
+          fi
       - uses: ./.github/actions/setup-monorepo
         with:
           install-filter: '!@alexwilson/personal-website'
       - id: find-projects
         name: Find affected projects
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
           lerna_args=()
           lerna_args+=('--all')
           lerna_args+=('--loglevel silent')
           lerna_args+=('--ignore @alexwilson/personal-website')
 
-          # Lerna attempts to find any changed packages since the last update...
-          if [[ $(pnpx lerna list ${lerna_args[@]} --since $MAIN_BRANCH | head -c1 | wc -c) -ne 0 ]]; then
-
-            # If there are some, and this isn't a scheduled build, we prefer to test
-            # and deploy only the updated packages.
-            # Scheduled builds always update & deploy everything.
-            if [ $GITHUB_EVENT_NAME != 'schedule' ]; then
-              lerna_args+=("--since $MAIN_BRANCH")
+          # Narrow to packages changed since the event's base ref + anything that
+          # depends on them. PR base SHA for PRs, previous commit for pushes.
+          # Schedule/dispatch events have no base ref and fall through to "all packages".
+          if [ -n "$BASE_REF" ] && [ "$BASE_REF" != "0000000000000000000000000000000000000000" ]; then
+            if [[ $(pnpx lerna list "${lerna_args[@]}" --since "$BASE_REF" --include-dependents | head -c1 | wc -c) -ne 0 ]]; then
+              lerna_args+=(--since "$BASE_REF" --include-dependents)
             fi
           fi
 
-          # Finally - we're ready to output as JSON for JQ to consume
-          lerna_args+=('--json')
+          lerna_args+=(--json)
 
-          echo "Github Event: $GITHUB_EVENT_NAME"
-          echo "$ pnpx lerna list ${lerna_args[@]}"
-          echo "$ jq ${jq_args[@]}"
-          echo "$ echo projects=$(                  \
-            pnpx lerna list ${lerna_args[@]}         \
-            | jq -rjc -n '.include |= inputs'       \
-          ) >> \$GITHUB_OUTPUT"
-          echo "projects=$(                         \
-            pnpx lerna list ${lerna_args[@]}         \
-            | jq -rjc -n '.include |= inputs'       \
-          )" >> $GITHUB_OUTPUT
-        env:
-          MAIN_BRANCH: "main"
+          echo "Event: $GITHUB_EVENT_NAME"
+          echo "Base ref: ${BASE_REF:-<none>}"
+          echo "$ pnpx lerna list ${lerna_args[*]}"
+          # --include-dependents in lerna overrides --ignore, so post-filter personal-website out.
+          projects=$(pnpx lerna list "${lerna_args[@]}" \
+            | jq -rjc -n '.include |= [inputs[] | select(.name != "@alexwilson/personal-website")]')
+          echo "Matrix:"
+          echo "$projects" | jq .
+          echo "projects=$projects" >> "$GITHUB_OUTPUT"
 
   # Fetch dependencies and build Gatsby
   test:

--- a/.github/workflows/monorepo-deploy.yml
+++ b/.github/workflows/monorepo-deploy.yml
@@ -42,13 +42,25 @@ jobs:
           lerna_args+=('--all')
           lerna_args+=('--loglevel silent')
           lerna_args+=('--ignore @alexwilson/personal-website')
+          lerna_args+=('--include-dependents')
 
-          # Narrow to packages changed since the event's base ref + anything that
-          # depends on them. PR base SHA for PRs, previous commit for pushes.
-          # Schedule/dispatch events have no base ref and fall through to "all packages".
+          # Narrow to packages changed since the base ref + their dependents.
+          # Two cases fall through to "all packages":
+          #   1. BASE_REF unset (schedule / dispatch).
+          #   2. Narrowing returns nothing — i.e. a CI-only, docs-only, or
+          #      root-config-only change. Anything that touches build/deploy
+          #      plumbing should exercise the whole workspace, because the
+          #      plumbing is what we'd be validating.
           if [ -n "$BASE_REF" ] && [ "$BASE_REF" != "0000000000000000000000000000000000000000" ]; then
-            if [[ $(pnpx lerna list "${lerna_args[@]}" --since "$BASE_REF" --include-dependents | head -c1 | wc -c) -ne 0 ]]; then
-              lerna_args+=(--since "$BASE_REF" --include-dependents)
+            if changed=$(pnpx lerna list ${lerna_args[@]} --since "$BASE_REF" 2>/dev/null); then
+              if [ -n "$changed" ]; then
+                lerna_args+=(--since "$BASE_REF")
+                echo "Narrowed to changed packages and their dependents."
+              else
+                echo "No workspace packages changed; running all packages."
+              fi
+            else
+              echo "::warning::lerna --since errored; falling back to all packages."
             fi
           fi
 
@@ -58,8 +70,9 @@ jobs:
           echo "Base ref: ${BASE_REF:-<none>}"
           echo "$ pnpx lerna list ${lerna_args[*]}"
           # --include-dependents in lerna overrides --ignore, so post-filter personal-website out.
-          projects=$(pnpx lerna list "${lerna_args[@]}" \
+          projects=$(pnpx lerna list ${lerna_args[@]} \
             | jq -rjc -n '.include |= [inputs[] | select(.name != "@alexwilson/personal-website")]')
+
           echo "Matrix:"
           echo "$projects" | jq .
           echo "projects=$projects" >> "$GITHUB_OUTPUT"
@@ -75,8 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.projects) }}
-    # auth-cms has no tests — skip to save a runner minute. It's still deployed via the deploy matrix.
-    if: always() && matrix.name != '@alexwilson/auth-cms'
+    if: always()
     steps:
       - name: Fail explicitly if Prepare failed
         if: needs.prepare.result != 'success'

--- a/.github/workflows/purge-cdn.yml
+++ b/.github/workflows/purge-cdn.yml
@@ -27,6 +27,7 @@ on:
 jobs:
   purge_fastly:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       FASTLY_API_KEY: ${{ secrets.PURGER_FASTLY_API_KEY }}
       FASTLY_SERVICE_ID: ${{ secrets.PURGER_FASTLY_SERVICE_ID }}
@@ -49,38 +50,39 @@ jobs:
         if: github.event.inputs.purge_method == 'all'
         run: |
           echo "Sending Fastly 'purge all' request (always hard purge)..."
-          FASTLY_RESPONSE=$(curl -s -X POST \
+          FASTLY_RESPONSE=$(curl -sS --fail-with-body -X POST \
             -H "Fastly-Key: ${FASTLY_API_KEY}" \
             "https://api.fastly.com/service/${FASTLY_SERVICE_ID}/purge_all" \
           )
-          echo "Fastly Purge All initiated. Response: $FASTLY_RESPONSE"
+          echo "Fastly Purge All response: $FASTLY_RESPONSE"
 
       - name: Purge path (Fastly)
         if: github.event.inputs.purge_method == 'path'
         run: |
           echo "Sending Fastly Purge by Path request..."
-          FASTLY_RESPONSE=$(curl -s -X POST \
+          FASTLY_RESPONSE=$(curl -sS --fail-with-body -X POST \
             -H "Fastly-Key: ${FASTLY_API_KEY}" \
             -H "Fastly-Soft-Purge: ${SOFT_PURGE_HEADER}" \
             "https://api.fastly.com/service/${FASTLY_SERVICE_ID}/purge/${PURGE_TARGET}" \
           )
-          echo "Fastly Purge by Path initiated. Response: $FASTLY_RESPONSE"
+          echo "Fastly Purge by Path response: $FASTLY_RESPONSE"
 
       - name: Purge tag (Fastly)
         if: github.event.inputs.purge_method == 'tag'
         run: |
           echo "Sending Fastly Purge by Surrogate Key request..."
-          FASTLY_RESPONSE=$(curl -s -X POST \
+          FASTLY_RESPONSE=$(curl -sS --fail-with-body -X POST \
             -H "Fastly-Key: ${FASTLY_API_KEY}" \
             -H "Fastly-Soft-Purge: ${SOFT_PURGE_HEADER}" \
             -H "Content-Type: application/json" \
             -d '{"surrogate_keys": ["'${PURGE_TARGET}'"]}' \
             "https://api.fastly.com/service/${FASTLY_SERVICE_ID}/purge" \
           )
-          echo "Fastly Purge by Tag initiated. Response: $FASTLY_RESPONSE"
+          echo "Fastly Purge by Tag response: $FASTLY_RESPONSE"
           
   purge_cloudflare:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.PURGER_CF_API_TOKEN }}
       CLOUDFLARE_ZONE_ID: ${{ secrets.PURGER_CF_ZONE_ID }}
@@ -91,34 +93,34 @@ jobs:
         if: github.event.inputs.purge_method == 'all'
         run: |
           echo "Sending Cloudflare 'purge all' request..."
-          CF_RESPONSE=$(curl -s -X POST \
+          CF_RESPONSE=$(curl -sS --fail-with-body -X POST \
             "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             -H "Content-Type: application/json" \
             --data '{"purge_everything": true}' \
           )
-          echo "Cloudflare Purge All initiated. Response: $CF_RESPONSE"
+          echo "Cloudflare Purge All response: $CF_RESPONSE"
 
       - name: Purge path (Cloudflare)
         if: github.event.inputs.purge_method == 'path'
         run: |
           echo "Sending Cloudflare Purge by Path request..."
-          CF_RESPONSE=$(curl -s -X POST \
+          CF_RESPONSE=$(curl -sS --fail-with-body -X POST \
             "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             -H "Content-Type: application/json" \
             --data '{"files": ["'${PURGE_TARGET}'"]}' \
           )
-          echo "Cloudflare Purge by Path initiated. Response: $CF_RESPONSE"
+          echo "Cloudflare Purge by Path response: $CF_RESPONSE"
 
       - name: Purge tag (Cloudflare)
         if: github.event.inputs.purge_method == 'tag'
         run: |
           echo "Sending Cloudflare Purge by Cache-Tag request..."
-          CF_RESPONSE=$(curl -s -X POST \
+          CF_RESPONSE=$(curl -sS --fail-with-body -X POST \
             "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             -H "Content-Type: application/json" \
             --data '{"tags": ["'${PURGE_TARGET}'"]}' \
           )
-          echo "Cloudflare Purge by Tag initiated. Response: $CF_RESPONSE"
+          echo "Cloudflare Purge by Tag response: $CF_RESPONSE"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -48,6 +48,84 @@ jobs:
       - name: Test VCL
         run: falco test -vv -I . main.vcl
 
+  plan-prod:
+    name: "Plan (prod) — preview only"
+    if: github.event_name == 'pull_request'
+    needs: [lint, lint-test-vcl]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    env:
+      FASTLY_API_KEY: ${{ secrets.TERRAFORM_FASTLY_API_KEY }}
+      TF_WORKSPACE: "prod"
+      TF_LOG: "warn"
+      TF_IN_AUTOMATION: "1"
+
+    defaults:
+      run:
+        working-directory: ./terraform
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get Terraform Version
+        id: tf_version
+        run: echo "value=$(cat .terraform-version)" >> $GITHUB_OUTPUT
+        working-directory: .
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ steps.tf_version.outputs.value }}
+          cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
+
+      - run: terraform init
+
+      - name: terraform plan
+        id: plan
+        run: terraform plan -no-color -input=false -var-file=environments/prod.tfvars
+        continue-on-error: true
+
+      - name: Post plan to PR
+        uses: actions/github-script@v7
+        env:
+          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+        with:
+          script: |
+            const marker = '<!-- terraform-plan-prod -->';
+            const max = 60000;
+            let plan = process.env.PLAN_STDOUT || '(no output)';
+            if (plan.length > max) plan = plan.slice(0, max) + '\n…(truncated)…\n';
+            const status = process.env.PLAN_OUTCOME === 'success' ? '✅' : '❌';
+            const body = `${marker}\n### ${status} Terraform plan (\`prod\`)\n\n<details><summary>Show plan</summary>\n\n\`\`\`terraform\n${plan}\n\`\`\`\n\n</details>`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if plan errored
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
   deploy-to-test:
     needs: [lint, lint-test-vcl]
     concurrency:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     name: "Lint Terraform"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     defaults:
       run:
         working-directory: ./terraform
@@ -30,6 +31,7 @@ jobs:
   lint-test-vcl:
     name: "Lint & Test VCL"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ./terraform/modules/fastly/vcl
@@ -52,6 +54,7 @@ jobs:
       group: ${{ github.workflow }}-test
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     env:
       FASTLY_API_KEY: ${{ secrets.TERRAFORM_FASTLY_API_KEY }}
@@ -92,6 +95,7 @@ jobs:
       group: ${{ github.workflow }}-prod
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: deploy-to-test
 
     env:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,13 +16,13 @@ jobs:
         working-directory: ./terraform
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get Terraform Version
         id: tf_version
         run: echo "value=$(cat .terraform-version)" >> $GITHUB_OUTPUT
         working-directory: .
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ steps.tf_version.outputs.value }}
       - name: Lint Terraform
@@ -37,10 +37,10 @@ jobs:
         working-directory: ./terraform/modules/fastly/vcl
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
       - name: Install Falco
         run: brew install falco
       - name: Lint VCL
@@ -69,13 +69,13 @@ jobs:
         working-directory: ./terraform
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Get Terraform Version
         id: tf_version
         run: echo "value=$(cat .terraform-version)" >> $GITHUB_OUTPUT
         working-directory: .
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ steps.tf_version.outputs.value }}
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
@@ -88,7 +88,7 @@ jobs:
         continue-on-error: true
 
       - name: Post plan to PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
           PLAN_OUTCOME: ${{ steps.plan.outcome }}
@@ -145,13 +145,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get Terraform Version
         id: tf_version
         run: echo "value=$(cat .terraform-version)" >> $GITHUB_OUTPUT
         working-directory: .
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ steps.tf_version.outputs.value }}
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
@@ -187,13 +187,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get Terraform Version
         id: tf_version
         run: echo "value=$(cat .terraform-version)" >> $GITHUB_OUTPUT
         working-directory: .
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ steps.tf_version.outputs.value }}
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}


### PR DESCRIPTION
# Why?

The CI pipeline had accumulated rough edges that were either slowing things down or hiding failures. Cache keys never invalidated, so a stale node_modules could outlive a lockfile change. The same pnpm/Node/install dance was copy-pasted across every job. Fastly purges piped through `curl -s` and discarded the response, so an auth failure looked identical to a success. Terraform changes shipped without anyone seeing the plan first. And the monorepo deploy matrix used `--since $MAIN_BRANCH`, which meant every PR push compared against an ever-moving target rather than the PR's actual base.

This PR is a CI-only sweep to fix those.

# What?

**Cache keys are now content-addressed.** `build-test-deploy.yml` keyed the Gatsby build cache as the literal string `build`, which never invalidated, and keyed `node_modules` off `**/package-lock.json` — a file the repo doesn't have. Both now hash `pnpm-lock.yaml`. The Gatsby cache also gets a `restore-keys: build-` fallback so lockfile bumps still get a warm-ish start instead of a cold build.

**One composite action for the monorepo install dance** (`.github/actions/setup-monorepo`). Sets up pnpm, Node from `.node-version`, restores the `node_modules` cache, and runs `pnpm install --prod=false` with an optional `install-filter` input. Three workflows (`build-test-deploy`, `monorepo-deploy`, and the Chromatic job inside it) used to inline ~15 lines of identical setup each; they now call the action. The old hack of `rm services/personal-website/package.json && pnpm install` is gone — callers pass `install-filter: '!@alexwilson/personal-website'` instead.

**Fastly and Cloudflare purges surface real status.** `purge-cdn.yml` was using `curl -s`, which swallows HTTP errors silently. Switched to `curl -sS --fail-with-body` so a 4xx or 5xx actually fails the step and the body still prints. Reworded the log lines from "initiated. Response:" to just "response:" since the previous wording implied success regardless of what came back.

**Terraform plan posts to PRs.** New `plan-prod` job in `terraform.yml` runs `terraform plan` against the `prod` workspace for every PR and posts the output as a sticky PR comment (marker `<!-- terraform-plan-prod -->`, updated in place on re-runs). Output is truncated to 60k chars to stay under GitHub's comment limit. The plan step uses `continue-on-error: true` so the comment still posts when the plan fails, and a follow-up step then fails the job. Needs `pull-requests: write`.

**Affected-projects detection now uses the PR base, not main.** `monorepo-deploy.yml`'s prepare job used to call `lerna list --since $MAIN_BRANCH`, which compared the PR branch against whatever `main` currently was — not the PR's base — so the matrix could drift as `main` moved underneath. Now it reads `github.event.pull_request.base.sha` (for PRs) or `github.event.before` (for pushes), fetches that ref explicitly (the checkout is depth=1), and passes it to lerna along with `--include-dependents` so anything depending on a changed package is also rebuilt. Schedule and `workflow_dispatch` runs have no base ref and fall through to "all packages", which is what we want for the nightly canary. Because `--include-dependents` overrides lerna's `--ignore`, `@alexwilson/personal-website` is filtered out in a jq post-step instead.

**Misc hardening on the same files.** `concurrency` blocks on the two main workflows so PR pushes cancel stale runs but `main` runs don't. `fail-fast: false` on the test and deploy matrices so one project's failure doesn't kill the others. `timeout-minutes` on every job. A `typecheck` step added before tests in both pipelines. `auth-cms` is skipped from the test matrix (it has no tests yet) but still deploys.

# Anything else?

A couple of things worth flagging:

- **`plan-prod` runs against the prod workspace from PRs.** That means a misconfigured PR can read prod state, which is what you want for a useful plan but does mean the secrets are exposed to any PR run. The `TERRAFORM_FASTLY_API_KEY` and `TERRAFORM_API_TOKEN` secrets already gated like this on the existing `deploy-to-prod` job, so the surface isn't new — but worth noting that the plan job now also depends on them.
- **No `terraform apply` change.** This PR only adds plan visibility; the existing `deploy-to-test` → `deploy-to-prod` chain on `main` is unchanged.
- **Caches will miss once on first run after merge** because the keys changed. Subsequent runs warm up normally.