### PR TITLE
Fix deprecated sort

### DIFF
--- a/components/legacy-components/package.json
+++ b/components/legacy-components/package.json
@@ -25,7 +25,6 @@
     "@reach/router": "1.3.4",
     "date-fns": "4.1.0",
     "include-media": "https://github.com/eduardoboucas/include-media.git#78c6aebae262202dc857dbc08e31504323dcbd04",
-    "isomorphic-fetch": "3.0.0",
     "promise-image-loader": "0.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       include-media:
         specifier: https://github.com/eduardoboucas/include-media.git#78c6aebae262202dc857dbc08e31504323dcbd04
         version: https://codeload.github.com/eduardoboucas/include-media/tar.gz/78c6aebae262202dc857dbc08e31504323dcbd04
-      isomorphic-fetch:
-        specifier: 3.0.0
-        version: 3.0.0(encoding@0.1.13)
       promise-image-loader:
         specifier: 0.1.2
         version: 0.1.2
@@ -274,40 +271,40 @@ importers:
         version: 4.1.0
       gatsby:
         specifier: 5.16.1
-        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-plugin-feed:
         specifier: 5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-sass:
         specifier: 6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0))
       gatsby-plugin-sitemap:
         specifier: 6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-web-font-loader:
         specifier: 1.0.4
         version: 1.0.4
       gatsby-remark-embed-gist:
         specifier: 1.2.1
-        version: 1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(react@18.3.1)
+        version: 1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(react@18.3.1)
       gatsby-remark-embed-video:
         specifier: 3.2.1
         version: 3.2.1
       gatsby-remark-prismjs:
         specifier: 7.16.0
-        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0)
+        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0)
       gatsby-remark-twitter-cards:
         specifier: 0.6.1
-        version: 0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))
+        version: 0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       gatsby-source-filesystem:
         specifier: 5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       gatsby-source-git:
         specifier: 1.1.0
-        version: 1.1.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))
+        version: 1.1.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       gatsby-transformer-remark:
         specifier: 6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       prismjs:
         specifier: 1.30.0
         version: 1.30.0
@@ -9087,9 +9084,6 @@ packages:
   isomorphic-base64@1.0.2:
     resolution: {integrity: sha512-pQFyLwShVPA1Qr0dE1ZPguJkbOsFGDfSq6Wzz6XaO33v74X6/iQjgYPozwkeKGQxOI1/H3Fz7+ROtnV1veyKEg==}
 
-  isomorphic-fetch@3.0.0:
-    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
-
   isurl@1.0.0:
     resolution: {integrity: sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==}
     engines: {node: '>= 4'}
@@ -13674,9 +13668,6 @@ packages:
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
-  whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
-
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
@@ -17702,6 +17693,22 @@ snapshots:
       - scheduler
       - use-sync-external-store
 
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))':
+    dependencies:
+      ansi-html: 0.0.9
+      core-js-pure: 3.49.0
+      error-stack-parser: 2.1.4
+      html-entities: 2.6.0
+      loader-utils: 2.0.4
+      react-refresh: 0.14.2
+      schema-utils: 4.3.3
+      source-map: 0.7.6
+      webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.14)
+    optionalDependencies:
+      type-fest: 4.41.0
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0))
+      webpack-hot-middleware: 2.26.1
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))':
     dependencies:
       ansi-html: 0.0.9
@@ -19376,12 +19383,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
 
   babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
@@ -23325,13 +23332,13 @@ snapshots:
       '@parcel/transformer-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-json': 2.8.3(@parcel/core@2.8.3)
 
-  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       lodash.merge: 4.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23342,7 +23349,7 @@ snapshots:
       - graphql
       - react-native-b4a
 
-  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0
@@ -23350,10 +23357,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-page-utils: 3.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       globby: 11.1.0
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -23384,30 +23391,30 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-sass@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)):
+  gatsby-plugin-sass@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       resolve-url-loader: 3.1.5
       sass: 1.99.0
-      sass-loader: 16.0.8(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      sass-loader: 16.0.8(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@rspack/core'
       - node-sass
       - sass-embedded
       - webpack
 
-  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       minimatch: 3.1.5
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       sitemap: 7.1.3
 
-  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
@@ -23415,8 +23422,8 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23433,12 +23440,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       fastq: 1.20.1
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.14.0
@@ -23490,13 +23497,13 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  gatsby-remark-embed-gist@1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(react@18.3.1):
+  gatsby-remark-embed-gist@1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       async-unist-util-visit: 1.0.0
       cheerio: 1.2.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
-      gatsby-transformer-remark: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-transformer-remark: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       node-fetch: 2.7.0(encoding@0.1.13)
       parse-numeric-range: 1.3.0
       react: 18.3.1
@@ -23509,17 +23516,17 @@ snapshots:
       remark-burger: 1.0.1
       unist-util-visit: 2.0.3
 
-  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0):
+  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       parse-numeric-range: 1.3.0
       prismjs: 1.30.0
       unist-util-visit: 2.0.3
 
-  gatsby-remark-twitter-cards@0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
+  gatsby-remark-twitter-cards@0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       jimp: 0.16.13
       path: 0.12.7
       wasm-twitter-card: 0.3.0
@@ -23546,14 +23553,14 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  gatsby-source-filesystem@2.11.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
+  gatsby-source-filesystem@2.11.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/runtime': 7.29.2
       better-queue: 3.8.12
       chokidar: 3.6.0
       file-type: 16.5.4
       fs-extra: 8.1.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 1.10.1
       got: 9.6.0
       md5-file: 5.0.0
@@ -23563,35 +23570,35 @@ snapshots:
       valid-url: 1.0.9
       xstate: 4.38.3
 
-  gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
+  gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/runtime': 7.29.2
       chokidar: 3.6.0
       file-type: 16.5.4
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       mime: 3.0.0
       pretty-bytes: 5.6.0
       valid-url: 1.0.9
       xstate: 4.38.3
 
-  gatsby-source-git@1.1.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
+  gatsby-source-git@1.1.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       fast-glob: 2.2.7
       fs-extra: 5.0.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
-      gatsby-source-filesystem: 2.11.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-source-filesystem: 2.11.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       git-url-parse: 11.6.0
       rimraf: 2.7.1
       simple-git: 1.132.0
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
+  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gray-matter: 4.0.3
       hast-util-raw: 6.1.0
@@ -23625,7 +23632,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1):
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -23650,7 +23657,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       '@parcel/cache': 2.8.3(@parcel/core@2.8.3)
       '@parcel/core': 2.8.3
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
       '@sigmacomputing/babel-plugin-lodash': 3.3.5
       '@types/http-proxy': 1.17.17
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
@@ -23666,7 +23673,7 @@ snapshots:
       babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -23715,9 +23722,9 @@ snapshots:
       gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-page-utils: 3.16.0
       gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
-      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-worker: 2.16.0
@@ -25194,13 +25201,6 @@ snapshots:
   isobject@3.0.1: {}
 
   isomorphic-base64@1.0.2: {}
-
-  isomorphic-fetch@3.0.0(encoding@0.1.13):
-    dependencies:
-      node-fetch: 2.7.0(encoding@0.1.13)
-      whatwg-fetch: 3.6.20
-    transitivePeerDependencies:
-      - encoding
 
   isurl@1.0.0:
     dependencies:
@@ -28999,13 +28999,6 @@ snapshots:
       sass: 1.99.0
       webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.14)(webpack-cli@7.0.2)
 
-  sass-loader@16.0.8(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)):
-    dependencies:
-      neo-async: 2.6.2
-    optionalDependencies:
-      sass: 1.99.0
-      webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.14)
-
   sass@1.99.0:
     dependencies:
       chokidar: 4.0.3
@@ -30881,6 +30874,20 @@ snapshots:
     optionalDependencies:
       webpack: 5.106.2(esbuild@0.28.0)
 
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 4.57.2(tslib@2.8.1)
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      schema-utils: 4.3.3
+    optionalDependencies:
+      webpack: 5.106.2(esbuild@0.28.0)
+    transitivePeerDependencies:
+      - tslib
+    optional: true
+
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.2):
     dependencies:
       colorette: 2.0.20
@@ -30947,6 +30954,46 @@ snapshots:
       - supports-color
       - tslib
       - utf-8-validate
+
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.25
+      '@types/express-serve-static-core': 4.19.8
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.10
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.18.1
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.3.0
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      compression: 1.8.1
+      connect-history-api-fallback: 2.0.0
+      express: 4.22.2
+      graceful-fs: 4.2.11
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      ipaddr.js: 2.4.0
+      launch-editor: 2.13.2
+      open: 10.2.0
+      p-retry: 6.2.1
+      schema-utils: 4.3.3
+      selfsigned: 5.5.0
+      serve-index: 1.9.2
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0))
+      ws: 8.20.1
+    optionalDependencies:
+      webpack: 5.106.2(esbuild@0.28.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - tslib
+      - utf-8-validate
+    optional: true
 
   webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)):
     dependencies:
@@ -31153,8 +31200,6 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
-
-  whatwg-fetch@3.6.20: {}
 
   whatwg-mimetype@4.0.0: {}
 

--- a/services/personal-website/gatsby-config.ts
+++ b/services/personal-website/gatsby-config.ts
@@ -170,7 +170,7 @@ const config: GatsbyConfig = {
               query Content {
                 recentContent: allContent(
                   limit: 10,
-                  sort: { order: DESC, fields: [date] }
+                  sort: { date: DESC }
                 ) {
                   nodes {
                     title

--- a/services/personal-website/src/components/related-articles.tsx
+++ b/services/personal-website/src/components/related-articles.tsx
@@ -32,7 +32,7 @@ const RelatedArticlesContainer = ({ article: currentArticle }: Props) => {
   const data = useStaticQuery<{ posts: { nodes: Article[] } }>(graphql`
     query RelatedArticles {
       posts: allContent(
-        sort: { order: DESC, fields: [date] }
+        sort: { date: DESC }
         filter: { type: { eq: "article" } }
         limit: 1000
       ) {

--- a/services/personal-website/src/pages/404.tsx
+++ b/services/personal-website/src/pages/404.tsx
@@ -72,7 +72,7 @@ export const query = graphql`
 
   query {
     allButWeeknotesAndLists: allContent(
-      sort: { fields: [date], order: DESC }
+      sort: { date: DESC }
       filter: {
         topics: { elemMatch: { topic: { nin: ["weeknotes", "lists"] } } }
       }
@@ -90,7 +90,7 @@ export const query = graphql`
       }
     }
     onlyWeeknotes: allContent(
-      sort: { fields: [date], order: DESC }
+      sort: { date: DESC }
       filter: { topics: { elemMatch: { topic: { eq: "weeknotes" } } } }
       limit: 1
     ) {
@@ -106,7 +106,7 @@ export const query = graphql`
       }
     }
     onlyLists: allContent(
-      sort: { fields: [date], order: DESC }
+      sort: { date: DESC }
       filter: { topics: { elemMatch: { topic: { eq: "lists" } } } }
       limit: 1
     ) {

--- a/services/personal-website/src/pages/blog.tsx
+++ b/services/personal-website/src/pages/blog.tsx
@@ -80,7 +80,7 @@ export const query = graphql`
         type: { in: ["article", "content-placeholder"] }
         topics: { elemMatch: { topic: { ne: "lists" } } }
       }
-      sort: { fields: [date], order: DESC }
+      sort: { date: DESC }
     ) {
       totalCount
       edges {

--- a/services/personal-website/src/pages/index.tsx
+++ b/services/personal-website/src/pages/index.tsx
@@ -67,7 +67,7 @@ export const query = graphql`
 
   query {
     allButWeeknotesAndLists: allContent(
-      sort: { fields: [date], order: DESC }
+      sort: { date: DESC }
       filter: {
         topics: { elemMatch: { topic: { nin: ["weeknotes", "lists"] } } }
       }
@@ -85,7 +85,7 @@ export const query = graphql`
       }
     }
     onlyWeeknotes: allContent(
-      sort: { fields: [date], order: DESC }
+      sort: { date: DESC }
       filter: { topics: { elemMatch: { topic: { eq: "weeknotes" } } } }
       limit: 3
     ) {
@@ -101,7 +101,7 @@ export const query = graphql`
       }
     }
     onlyLists: allContent(
-      sort: { fields: [date], order: DESC }
+      sort: { date: DESC }
       filter: { topics: { elemMatch: { topic: { eq: "lists" } } } }
       limit: 3
     ) {

--- a/services/personal-website/src/pages/talks.tsx
+++ b/services/personal-website/src/pages/talks.tsx
@@ -78,7 +78,7 @@ export const query = graphql`
   query {
     talks: allContent(
       filter: { type: { eq: "talk" } }
-      sort: { fields: [date], order: DESC }
+      sort: { date: DESC }
     ) {
       edges {
         node {

--- a/services/personal-website/src/templates/topic.tsx
+++ b/services/personal-website/src/templates/topic.tsx
@@ -123,7 +123,7 @@ export const pageQuery = graphql`
       }
     }
     content: allContent(
-      sort: { fields: [date], order: DESC }
+      sort: { date: DESC }
       filter: { topics: { elemMatch: { topicId: { eq: $topicId } } } }
     ) {
       totalCount

--- a/services/storybook/.storybook/isomorphic-fetch-stub.js
+++ b/services/storybook/.storybook/isomorphic-fetch-stub.js
@@ -1,1 +1,0 @@
-module.exports = (...args) => globalThis.fetch(...args)

--- a/services/storybook/.storybook/main.js
+++ b/services/storybook/.storybook/main.js
@@ -55,11 +55,6 @@ module.exports = {
       type: 'asset/resource',
     })
 
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      'isomorphic-fetch': path.resolve(__dirname, 'isomorphic-fetch-stub.js'),
-    }
-
     return config
   },
 }


### PR DESCRIPTION
# Why?
Gatsby builds throw a deprecation warning around sort syntax

# What?
Fix that warning!  And drop isomorphic-fetch in the process.