### PR TITLE
ci: bump enable-github-automerge-action to 3.0.0

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # Enable auto-merge *before* issuing an approval.
       - name: Enable Github Automerge
-        uses: alexwilson/enable-github-automerge-action@56e3117d1ae1540309dc8f7a9f2825bc3c5f06ff # 2.0.0
+        uses: alexwilson/enable-github-automerge-action@2c32e18a76e0726ffe7a573bfff2d42a20885126 # 3.0.0
         with:
           github-token: "${{ secrets.PR_GH_TOKEN }}"
 


### PR DESCRIPTION
## Summary
- Bumps `alexwilson/enable-github-automerge-action` from 2.0.0 to 3.0.0 in `.github/workflows/auto-approve.yml`, repinned to commit SHA `2c32e18a76e0726ffe7a573bfff2d42a20885126`.
- The 3.0.0 release is tagged breaking due to an internal ESM migration (Rollup + `@actions/*` v3/v9); the `github-token` input is unchanged so no workflow edits beyond the pin are needed.

## Test plan
- [ ] Next dependabot PR labeled `dependencies` triggers the `auto-update-dependencies` job and the Enable Github Automerge step completes without errors.
- [ ] Auto-merge is enabled on that PR before the auto-approve step runs.