### PR TITLE
Fetch Gatsby content from the GitHub API

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -34,9 +34,9 @@ jobs:
           path: |
             services/personal-website/public
             services/personal-website/.cache
-          key: build-${{ hashFiles('pnpm-lock.yaml') }}
+          key: build-v2-${{ hashFiles('pnpm-lock.yaml', 'services/personal-website/gatsby-config.ts', 'services/personal-website/gatsby-node.ts') }}
           restore-keys: |
-            build-
+            build-v2-
       - uses: ./.github/actions/setup-monorepo
         with:
           install-filter: '@alexwilson/personal-website...'

--- a/libraries/gatsby-source-github-repository/.gitignore
+++ b/libraries/gatsby-source-github-repository/.gitignore
@@ -1,0 +1,3 @@
+dist/
+*.tsbuildinfo
+coverage/

--- a/libraries/gatsby-source-github-repository/README.md
+++ b/libraries/gatsby-source-github-repository/README.md
@@ -1,0 +1,133 @@
+# gatsby-source-github-repository
+
+Source Gatsby `File` nodes from a GitHub repository via the GitHub API, without cloning. Uses content-addressed caching to keep API usage near zero across builds.
+
+## Why
+
+The standard options for sourcing content from a GitHub repo at build time are:
+
+- `gatsby-source-filesystem` against a working tree (you must clone separately).
+- `gatsby-source-git`, which clones at build time.
+
+This plugin fetches files directly via the GitHub REST API. Compared to cloning, that means:
+
+- **Content-addressed caching.** Blob SHAs are immutable, so once a file is in the cache it never needs to be re-fetched.
+- **ETag-based ref short-circuit.** When the source branch hasn't moved, the conditional request returns `304 Not Modified` and doesn't count against your rate limit.
+
+Steady-state incremental builds use 1–2 API calls regardless of how many files are in the repo.
+
+## Install
+
+```sh
+pnpm add gatsby-source-github-repository
+```
+
+Peer-depends on `gatsby >= 5`.
+
+## Usage
+
+```ts
+{
+  resolve: `gatsby-source-github-repository`,
+  options: {
+    name: `posts`,
+    owner: `alexwilson`,
+    repo: `content`,
+    ref: `main`,
+    patterns: [`posts/**`],
+    token: process.env.GITHUB_TOKEN,
+  },
+}
+```
+
+Downstream transformers (`gatsby-transformer-remark`, `gatsby-transformer-sharp`, etc.) work without modification: the plugin materialises blobs into Gatsby's cache directory and emits `File` nodes pointing at them.
+
+## Options
+
+| Option       | Type                                | Default      | Notes                                                                 |
+| ------------ | ----------------------------------- | ------------ | --------------------------------------------------------------------- |
+| `name`       | string                              | `"github"`   | `sourceInstanceName` on emitted File nodes.                           |
+| `owner`      | string                              | —            | Required. Repository owner.                                           |
+| `repo`       | string                              | —            | Required. Repository name.                                            |
+| `ref`        | string                              | `"main"`     | Branch, tag, or 40-character commit SHA.                              |
+| `patterns`   | string[]                            | `["**"]`     | Minimatch patterns. A blob is sourced if it matches at least one.     |
+| `token`      | string \| `() => Promise<string>`   | —            | Required. See below.                                                  |
+| `userAgent`  | string                              | plugin name  | Sent as `User-Agent`.                                                 |
+| `pollInterval` | number (seconds)                  | `0`          | Background poll cadence during `gatsby develop`. `0` disables. See below. |
+| `concurrency` | number (1–50)                      | `8`          | Maximum in-flight blob fetches during sourcing. Higher = faster cold builds. |
+
+### `token`
+
+Either a string or an async callback that resolves to one.
+
+- **String.** A bearer token sent as `Authorization: token <value>`. Works with PATs, OAuth tokens, and pre-minted GitHub App installation tokens.
+- **Callback.** `() => string | Promise<string>`. Called per request, so it owns minting and renewal. Use this when the token expires within the build window — most often, GitHub App installation tokens (1h TTL) and broker-issued tokens.
+
+#### GitHub App installation tokens
+
+```ts
+import { createAppAuth } from "@octokit/auth-app";
+
+const appAuth = createAppAuth({
+  appId: process.env.GITHUB_APP_ID,
+  privateKey: process.env.GITHUB_APP_PRIVATE_KEY,
+  installationId: process.env.GITHUB_APP_INSTALLATION_ID,
+});
+
+// ...inside gatsby-config.ts plugins:
+{
+  resolve: `gatsby-source-github-repository`,
+  options: {
+    // ...
+    token: async () => (await appAuth({ type: "installation" })).token,
+  },
+}
+```
+
+`@octokit/auth-app` caches and refreshes the token internally.
+
+## Live updates during development
+
+By default, `gatsby develop` sources content once at startup. To pick up upstream changes without restarting, set `pollInterval` (seconds) and the plugin will check the ref in the background:
+
+```ts
+{
+  // ...
+  pollInterval: process.env.NODE_ENV === "development" ? 30 : 0,
+}
+```
+
+Each poll is a conditional `GET` on the ref. Unchanged refs return `304 Not Modified` and don't count against your rate limit, so a 30-second poll is essentially free. When the ref moves, the plugin fetches only blobs whose SHAs changed, re-emits their `File` nodes, and deletes nodes for paths that have disappeared.
+
+Polling only runs under `gatsby develop` (via `onCreateDevServer`). `gatsby build` ignores `pollInterval`.
+
+If you'd rather trigger refreshes manually instead of polling, leave `pollInterval` at `0` and use Gatsby's built-in refresh endpoint: start develop with `ENABLE_GATSBY_REFRESH_ENDPOINT=true` and `POST` to `http://localhost:8000/__refresh` whenever you want to re-source. Webhook-driven refreshes work the same way.
+
+## Rate limits
+
+The plugin captures GitHub's `x-ratelimit-*` headers from every response and surfaces them in the reporter:
+
+```
+source alexwilson/content@main (posts) → abc1234 (223 files, 220 cached, 3 fetched; rate limit: 4823/5000, resets in 38m)
+```
+
+When less than 10% of the budget remains, you'll see a `warn` line so you can react before the build fails:
+
+```
+[gatsby-source-github-repository] alexwilson/content: rate limit: 412/5000, resets in 14m — approaching GitHub API rate limit
+```
+
+The plugin also retries on rate-limit responses (`429 Too Many Requests` and `403 Forbidden` with a `retry-after` header or `x-ratelimit-remaining: 0`). Retries are bounded — at most 2 — and honour `retry-after` up to 60 seconds; beyond that the error propagates to Gatsby.
+
+## Caching
+
+Two cache namespaces in Gatsby's persistent cache:
+
+- `ref:{owner}/{repo}:{ref}` → `{ etag, commitSha }`. Backs the conditional GET on the ref.
+- `tree:{owner}/{repo}:{commitSha}` → tree entries. Trees are immutable per commit SHA.
+- `blob:{sha}` → base64 blob content. Immutable.
+
+## Limits
+
+- The recursive tree endpoint returns at most 100,000 entries / 7MB. If your source exceeds this, narrow with `patterns` (the plugin still walks the whole tree) — a future change could fetch sub-trees per directory.
+- Blob fetches are sequential. For very large first-time builds, parallelising is straightforward but not yet implemented.

--- a/libraries/gatsby-source-github-repository/__tests__/client.test.ts
+++ b/libraries/gatsby-source-github-repository/__tests__/client.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it, vi } from "vitest";
+import { RequestError } from "@octokit/request-error";
+
+import { createClient, parseRetryAfter } from "../src/lib/client.js";
+
+function makeCache(seed: Record<string, unknown> = {}): {
+  store: Map<string, unknown>;
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+} {
+  const store = new Map<string, unknown>(Object.entries(seed));
+  return {
+    store,
+    get: vi.fn(async (k: string) => store.get(k)),
+    set: vi.fn(async (k: string, v: unknown) => {
+      store.set(k, v);
+    }),
+  };
+}
+
+function makeClient({
+  request,
+  cache,
+  sleep,
+}: {
+  request?: any;
+  cache?: ReturnType<typeof makeCache>;
+  sleep?: any;
+} = {}) {
+  return createClient({
+    getToken: async () => "test-token",
+    cache: (cache ?? makeCache()) as never,
+    owner: "o",
+    repo: "r",
+    userAgent: "test",
+    request,
+    sleep: sleep ?? (async () => {}),
+  });
+}
+
+function ok(data: unknown, headers: Record<string, string> = {}) {
+  return { status: 200, headers, data, url: "https://api.github.com/x" };
+}
+
+function notModifiedError() {
+  return new RequestError("not modified", 304, {
+    response: { status: 304, headers: {}, url: "x", data: undefined },
+    request: { method: "GET", url: "x", headers: {} },
+  });
+}
+
+function rateLimitedError(status: number, headers: Record<string, string>) {
+  return new RequestError("rate limited", status, {
+    response: { status, headers, url: "x", data: undefined },
+    request: { method: "GET", url: "x", headers: {} },
+  });
+}
+
+describe("resolveRef", () => {
+  it("returns the input directly when it is a 40-char commit SHA", async () => {
+    const request = vi.fn();
+    const client = makeClient({ request });
+    const result = await client.resolveRef("a".repeat(40));
+    expect(result).toEqual({ commitSha: "a".repeat(40), fromCache: false });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("stores etag and commit SHA on a fresh response", async () => {
+    const cache = makeCache();
+    const request = vi.fn(async () =>
+      ok({ sha: "deadbeef".padEnd(40, "0") }, { etag: '"abc"' }),
+    );
+    const client = makeClient({ request, cache });
+
+    const result = await client.resolveRef("main");
+    expect(result.fromCache).toBe(false);
+    expect(result.commitSha).toBe("deadbeef".padEnd(40, "0"));
+    expect(cache.set).toHaveBeenCalledWith("ref:o/r:main", {
+      etag: '"abc"',
+      commitSha: "deadbeef".padEnd(40, "0"),
+    });
+  });
+
+  it("sends If-None-Match when an etag is cached, and returns cached SHA on 304", async () => {
+    const cache = makeCache({
+      "ref:o/r:main": { etag: '"abc"', commitSha: "cached-sha".padEnd(40, "0") },
+    });
+    const request = vi.fn(async () => {
+      throw notModifiedError();
+    });
+    const client = makeClient({ request, cache });
+
+    const result = await client.resolveRef("main");
+    expect(result).toEqual({
+      commitSha: "cached-sha".padEnd(40, "0"),
+      fromCache: true,
+    });
+    expect(request).toHaveBeenCalledWith(
+      "GET /repos/{owner}/{repo}/commits/{ref}",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer test-token",
+          "if-none-match": '"abc"',
+        }),
+      }),
+    );
+  });
+});
+
+describe("authedRequest header merging", () => {
+  it("always sends authorization, even when caller passes other headers", async () => {
+    const request = vi.fn(async () => ok({ sha: "x".repeat(40) }, {}));
+    const client = makeClient({ request });
+    await client.resolveRef("main");
+
+    const passed = request.mock.calls[0][1];
+    expect(passed.headers).toMatchObject({
+      authorization: "Bearer test-token",
+      "user-agent": "test",
+      accept: "application/vnd.github+json",
+    });
+  });
+
+  it("merges caller headers on top of auth headers without dropping auth", async () => {
+    const cache = makeCache({
+      "ref:o/r:main": { etag: '"e"', commitSha: "y".repeat(40) },
+    });
+    const request = vi.fn(async () => ok({ sha: "z".repeat(40) }, { etag: '"f"' }));
+    const client = makeClient({ request, cache });
+
+    await client.resolveRef("main");
+
+    const passed = request.mock.calls[0][1];
+    expect(passed.headers.authorization).toBe("Bearer test-token");
+    expect(passed.headers["if-none-match"]).toBe('"e"');
+  });
+});
+
+describe("getTree", () => {
+  it("returns cached tree without a request", async () => {
+    const entries = [{ path: "a.md", sha: "s1", size: 1, mode: "100644" }];
+    const cache = makeCache({ "tree:o/r:commit": { entries } });
+    const request = vi.fn();
+    const client = makeClient({ request, cache });
+
+    const result = await client.getTree("commit");
+    expect(result.entries).toEqual(entries);
+    expect(result.fromCache).toBe(true);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("fetches and caches the tree, dropping non-blob entries", async () => {
+    const cache = makeCache();
+    const request = vi.fn(async () =>
+      ok({
+        truncated: false,
+        tree: [
+          { path: "posts", type: "tree", sha: "t1" },
+          { path: "posts/a.md", type: "blob", sha: "b1", size: 10, mode: "100644" },
+          { path: "posts/b.md", type: "blob", sha: "b2", size: 20, mode: "100644" },
+        ],
+      }),
+    );
+    const client = makeClient({ request, cache });
+
+    const result = await client.getTree("commit");
+    expect(result.entries).toEqual([
+      { path: "posts/a.md", sha: "b1", size: 10, mode: "100644" },
+      { path: "posts/b.md", sha: "b2", size: 20, mode: "100644" },
+    ]);
+    expect(cache.set).toHaveBeenCalledWith(
+      "tree:o/r:commit",
+      expect.objectContaining({ entries: result.entries }),
+    );
+  });
+
+  it("throws when the API reports the tree is truncated", async () => {
+    const request = vi.fn(async () => ok({ truncated: true, tree: [] }));
+    const client = makeClient({ request });
+    await expect(client.getTree("commit")).rejects.toThrow(/truncated/);
+  });
+});
+
+describe("getBlob", () => {
+  it("returns a buffer from the cache without a request", async () => {
+    const cache = makeCache({ "blob:s1": Buffer.from("hello").toString("base64") });
+    const request = vi.fn();
+    const client = makeClient({ request, cache });
+
+    const { buffer, fromCache } = await client.getBlob("s1");
+    expect(buffer.toString()).toBe("hello");
+    expect(fromCache).toBe(true);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("fetches, decodes base64, and caches the content", async () => {
+    const cache = makeCache();
+    const request = vi.fn(async () =>
+      ok({ encoding: "base64", content: Buffer.from("world").toString("base64") }),
+    );
+    const client = makeClient({ request, cache });
+
+    const { buffer, fromCache } = await client.getBlob("s2");
+    expect(buffer.toString()).toBe("world");
+    expect(fromCache).toBe(false);
+    expect(cache.set).toHaveBeenCalledWith(
+      "blob:s2",
+      Buffer.from("world").toString("base64"),
+    );
+  });
+
+  it("rejects unexpected encodings", async () => {
+    const request = vi.fn(async () =>
+      ok({ encoding: "utf-8", content: "raw" }),
+    );
+    const client = makeClient({ request });
+    await expect(client.getBlob("s3")).rejects.toThrow(/encoding utf-8/);
+  });
+});
+
+describe("rate-limit snapshot", () => {
+  it("captures the latest x-ratelimit headers from successful responses", async () => {
+    const request = vi.fn(async () =>
+      ok({ sha: "a".repeat(40) }, {
+        "x-ratelimit-limit": "5000",
+        "x-ratelimit-remaining": "4998",
+        "x-ratelimit-reset": "1234567890",
+      }),
+    );
+    const client = makeClient({ request });
+
+    await client.resolveRef("main");
+
+    expect(client.rateLimit.snapshot).toEqual({
+      limit: 5000,
+      remaining: 4998,
+      reset: 1234567890,
+    });
+  });
+
+  it("captures headers from 304 responses too", async () => {
+    const cache = makeCache({
+      "ref:o/r:main": { etag: '"e"', commitSha: "y".repeat(40) },
+    });
+    const request = vi.fn(async () => {
+      throw new RequestError("304", 304, {
+        response: {
+          status: 304,
+          headers: {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "4999",
+            "x-ratelimit-reset": "9999999999",
+          },
+          url: "x",
+          data: undefined,
+        },
+        request: { method: "GET", url: "x", headers: {} },
+      });
+    });
+    const client = makeClient({ request, cache });
+
+    await client.resolveRef("main");
+
+    expect(client.rateLimit.snapshot?.remaining).toBe(4999);
+  });
+
+  it("leaves snapshot null when responses lack rate-limit headers", async () => {
+    const request = vi.fn(async () => ok({ sha: "a".repeat(40) }, {}));
+    const client = makeClient({ request });
+    await client.resolveRef("main");
+    expect(client.rateLimit.snapshot).toBeNull();
+  });
+});
+
+describe("retry-after handling", () => {
+  it("retries on 429 with retry-after, then succeeds", async () => {
+    const sleep = vi.fn(async () => {});
+    let calls = 0;
+    const request = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw rateLimitedError(429, { "retry-after": "0" });
+      return ok({ sha: "a".repeat(40) }, {});
+    });
+    const client = makeClient({ request, sleep });
+
+    const result = await client.resolveRef("main");
+
+    expect(result.commitSha).toBe("a".repeat(40));
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 403 with retry-after (secondary rate limit)", async () => {
+    const sleep = vi.fn(async () => {});
+    let calls = 0;
+    const request = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw rateLimitedError(403, { "retry-after": "2" });
+      return ok({ sha: "a".repeat(40) }, {});
+    });
+    const client = makeClient({ request, sleep });
+
+    await client.resolveRef("main");
+
+    expect(sleep).toHaveBeenCalledWith(2000);
+  });
+
+  it("retries on 403 with x-ratelimit-remaining=0 (primary rate limit)", async () => {
+    const sleep = vi.fn(async () => {});
+    const resetSeconds = Math.floor(Date.now() / 1000) + 5;
+    let calls = 0;
+    const request = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw rateLimitedError(403, {
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(resetSeconds),
+        });
+      }
+      return ok({ sha: "a".repeat(40) }, {});
+    });
+    const client = makeClient({ request, sleep });
+
+    await client.resolveRef("main");
+
+    expect(sleep).toHaveBeenCalledTimes(1);
+    const slept = sleep.mock.calls[0]![0];
+    expect(slept).toBeGreaterThan(3000);
+    expect(slept).toBeLessThanOrEqual(6000);
+  });
+
+  it("gives up after MAX_RETRIES retries", async () => {
+    const sleep = vi.fn(async () => {});
+    const request = vi.fn(async () => {
+      throw rateLimitedError(429, { "retry-after": "0" });
+    });
+    const client = makeClient({ request, sleep });
+
+    await expect(client.resolveRef("main")).rejects.toMatchObject({ status: 429 });
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-rate-limit errors", async () => {
+    const sleep = vi.fn(async () => {});
+    const request = vi.fn(async () => {
+      throw rateLimitedError(500, {});
+    });
+    const client = makeClient({ request, sleep });
+
+    await expect(client.resolveRef("main")).rejects.toMatchObject({ status: 500 });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses seconds", () => {
+    expect(parseRetryAfter("5")).toBe(5000);
+    expect(parseRetryAfter("0")).toBe(0);
+  });
+
+  it("parses HTTP-date format", () => {
+    const future = new Date(Date.now() + 3000).toUTCString();
+    const ms = parseRetryAfter(future);
+    expect(ms).toBeGreaterThan(2000);
+    expect(ms).toBeLessThanOrEqual(4000);
+  });
+
+  it("returns null for empty / undefined / unparseable", () => {
+    expect(parseRetryAfter(undefined)).toBeNull();
+    expect(parseRetryAfter("")).toBeNull();
+    expect(parseRetryAfter("not-a-date")).toBeNull();
+  });
+});

--- a/libraries/gatsby-source-github-repository/__tests__/gatsby-node.test.ts
+++ b/libraries/gatsby-source-github-repository/__tests__/gatsby-node.test.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@octokit/request", () => ({
+  request: vi.fn(),
+}));
+
+import { request as mockRequest } from "@octokit/request";
+import { sourceNodes, onCreateDevServer, pluginOptionsSchema } from "../src/gatsby-node.js";
+
+let tmpdir: string;
+
+function ok(data: unknown, headers: Record<string, string> = {}) {
+  return { status: 200, headers, data, url: "https://api.github.com/x" };
+}
+
+function makeArgs() {
+  const activity = { start: vi.fn(), end: vi.fn(), setStatus: vi.fn() };
+  const reporter = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    activityTimer: vi.fn(() => activity),
+  };
+  return {
+    activity,
+    reporter,
+    cache: {
+      directory: tmpdir,
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => {}),
+    },
+    actions: { createNode: vi.fn(), deleteNode: vi.fn() },
+    createNodeId: (i: string) => `id:${i}`,
+    getNode: () => undefined,
+  };
+}
+
+const baseOptions = {
+  name: "test-instance",
+  owner: "alexwilson",
+  repo: "content",
+  ref: "main",
+  patterns: ["**"],
+  token: "ghp_test",
+  userAgent: "test",
+  pollInterval: 0,
+  concurrency: 4,
+};
+
+beforeEach(async () => {
+  tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "gs-ghr-gn-"));
+  vi.mocked(mockRequest).mockReset();
+});
+
+afterEach(async () => {
+  await fs.rm(tmpdir, { recursive: true, force: true });
+});
+
+describe("gatsby-node exports", () => {
+  it("exposes the three Gatsby lifecycle hooks plus pluginOptionsSchema", () => {
+    expect(typeof sourceNodes).toBe("function");
+    expect(typeof onCreateDevServer).toBe("function");
+    expect(typeof pluginOptionsSchema).toBe("function");
+  });
+});
+
+describe("sourceNodes", () => {
+  it("resolves the ref, fetches the tree, and reports a status line", async () => {
+    vi.mocked(mockRequest)
+      .mockResolvedValueOnce(
+        ok(
+          { sha: "a".repeat(40) },
+          {
+            etag: '"x"',
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "4900",
+            "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 300),
+          },
+        ) as never,
+      )
+      .mockResolvedValueOnce(ok({ truncated: false, tree: [] }) as never);
+
+    const args = makeArgs();
+    await sourceNodes!(args as never, { ...baseOptions, name: "sn-basic" } as never, undefined as never);
+
+    expect(args.reporter.activityTimer).toHaveBeenCalledOnce();
+    expect(args.activity.start).toHaveBeenCalledOnce();
+    expect(args.activity.end).toHaveBeenCalledOnce();
+    expect(args.activity.setStatus.mock.calls[0]![0]).toContain("aaaaaaa");
+    expect(args.activity.setStatus.mock.calls[0]![0]).toContain("rate limit: 4900/5000");
+  });
+
+  it("warns when the rate-limit budget is low", async () => {
+    vi.mocked(mockRequest)
+      .mockResolvedValueOnce(
+        ok(
+          { sha: "b".repeat(40) },
+          {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "100",
+          },
+        ) as never,
+      )
+      .mockResolvedValueOnce(ok({ truncated: false, tree: [] }) as never);
+
+    const args = makeArgs();
+    await sourceNodes!(args as never, { ...baseOptions, name: "sn-low" } as never, undefined as never);
+
+    expect(args.reporter.warn).toHaveBeenCalledOnce();
+    expect(args.reporter.warn.mock.calls[0]![0]).toContain("approaching");
+  });
+
+  it("re-uses the cached instance across calls (same key)", async () => {
+    vi.mocked(mockRequest)
+      .mockResolvedValueOnce(ok({ sha: "c".repeat(40) }) as never)
+      .mockResolvedValueOnce(ok({ truncated: false, tree: [] }) as never)
+      .mockResolvedValueOnce(ok({ sha: "c".repeat(40) }) as never)
+      .mockResolvedValueOnce(ok({ truncated: false, tree: [] }) as never);
+
+    const args = makeArgs();
+    await sourceNodes!(args as never, { ...baseOptions, name: "sn-reuse" } as never, undefined as never);
+    await sourceNodes!(args as never, { ...baseOptions, name: "sn-reuse" } as never, undefined as never);
+
+    expect(args.activity.start).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("onCreateDevServer", () => {
+  it("does nothing when pollInterval is 0", () => {
+    const args = makeArgs();
+    onCreateDevServer!(
+      args as never,
+      { ...baseOptions, name: "dev-off", pollInterval: 0 } as never,
+      undefined as never,
+    );
+    expect(args.reporter.info).not.toHaveBeenCalled();
+  });
+
+  it("logs a polling-started message when pollInterval is positive", async () => {
+    vi.mocked(mockRequest).mockResolvedValue(ok({ sha: "d".repeat(40) }) as never);
+
+    const args = makeArgs();
+    onCreateDevServer!(
+      args as never,
+      { ...baseOptions, name: "dev-on", pollInterval: 60 } as never,
+      undefined as never,
+    );
+
+    expect(args.reporter.info.mock.calls[0]![0]).toMatch(/polling .* every 60s/);
+  });
+});

--- a/libraries/gatsby-source-github-repository/__tests__/index.test.ts
+++ b/libraries/gatsby-source-github-repository/__tests__/index.test.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadNodeContent } from "../src/index.js";
+
+let tmpdir: string;
+
+beforeEach(async () => {
+  tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "gs-ghr-index-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpdir, { recursive: true, force: true });
+});
+
+describe("loadNodeContent", () => {
+  it("reads the file at the node's absolutePath as utf-8", async () => {
+    const filePath = path.join(tmpdir, "hello.md");
+    await fs.writeFile(filePath, "hello world", "utf-8");
+
+    const content = await loadNodeContent({ absolutePath: filePath });
+    expect(content).toBe("hello world");
+  });
+});

--- a/libraries/gatsby-source-github-repository/__tests__/options.test.ts
+++ b/libraries/gatsby-source-github-repository/__tests__/options.test.ts
@@ -1,0 +1,86 @@
+import Joi from "joi";
+import { describe, expect, it } from "vitest";
+
+import { pluginOptionsSchema } from "../src/lib/options.js";
+
+const schema = pluginOptionsSchema({ Joi });
+
+function validate(input: unknown): { error?: unknown; value: any } {
+  return schema.validate(input, { convert: true });
+}
+
+describe("pluginOptionsSchema", () => {
+  it("accepts a minimal valid config and applies defaults", () => {
+    const { error, value } = validate({
+      owner: "alexwilson",
+      repo: "content",
+      token: "ghs_x",
+    });
+    expect(error).toBeUndefined();
+    expect(value.name).toBe("github");
+    expect(value.ref).toBe("main");
+    expect(value.patterns).toEqual(["**"]);
+    expect(value.pollInterval).toBe(0);
+    expect(value.concurrency).toBe(8);
+  });
+
+  it("rejects missing owner/repo/token", () => {
+    expect(validate({}).error).toBeDefined();
+    expect(validate({ owner: "o" }).error).toBeDefined();
+    expect(validate({ owner: "o", repo: "r" }).error).toBeDefined();
+  });
+
+  it("accepts a function for token", () => {
+    const { error } = validate({
+      owner: "o",
+      repo: "r",
+      token: async () => "x",
+    });
+    expect(error).toBeUndefined();
+  });
+
+  it("rejects a non-string, non-function token", () => {
+    expect(validate({ owner: "o", repo: "r", token: 123 }).error).toBeDefined();
+  });
+
+  it("accepts a positive integer pollInterval", () => {
+    const { error, value } = validate({
+      owner: "o",
+      repo: "r",
+      token: "x",
+      pollInterval: 30,
+    });
+    expect(error).toBeUndefined();
+    expect(value.pollInterval).toBe(30);
+  });
+
+  it("rejects negative / non-integer pollInterval", () => {
+    expect(
+      validate({ owner: "o", repo: "r", token: "x", pollInterval: -1 }).error,
+    ).toBeDefined();
+    expect(
+      validate({ owner: "o", repo: "r", token: "x", pollInterval: 1.5 }).error,
+    ).toBeDefined();
+  });
+
+  it("accepts concurrency in [1, 50]", () => {
+    expect(
+      validate({ owner: "o", repo: "r", token: "x", concurrency: 1 }).error,
+    ).toBeUndefined();
+    expect(
+      validate({ owner: "o", repo: "r", token: "x", concurrency: 50 }).error,
+    ).toBeUndefined();
+  });
+
+  it("rejects concurrency out of range or non-integer", () => {
+    expect(
+      validate({ owner: "o", repo: "r", token: "x", concurrency: 0 }).error,
+    ).toBeDefined();
+    expect(
+      validate({ owner: "o", repo: "r", token: "x", concurrency: 51 }).error,
+    ).toBeDefined();
+    expect(
+      validate({ owner: "o", repo: "r", token: "x", concurrency: 2.5 }).error,
+    ).toBeDefined();
+  });
+});

--- a/libraries/gatsby-source-github-repository/__tests__/poller.test.ts
+++ b/libraries/gatsby-source-github-repository/__tests__/poller.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GitHubClient } from "../src/lib/client.js";
+import { pollOnce, withOverlapGuard, type PollContext } from "../src/lib/poller.js";
+import { createState } from "../src/lib/source.js";
+import type { FileNode } from "../src/lib/nodes.js";
+import type { PluginOptions } from "../src/lib/options.js";
+
+let tmpdir: string;
+
+beforeEach(async () => {
+  tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "gs-ghr-poller-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpdir, { recursive: true, force: true });
+});
+
+function makeReporter() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeCtx(client: GitHubClient, lastCommitSha: string | null = null): PollContext {
+  const nodes = new Map<string, FileNode>();
+  const reporter = makeReporter();
+  const state = createState();
+  state.lastCommitSha = lastCommitSha;
+  return {
+    gatsby: {
+      actions: {
+        createNode: (n) => {
+          nodes.set(n.id, n);
+        },
+        deleteNode: (n) => {
+          nodes.delete(n.id);
+        },
+      },
+      cache: {
+        directory: tmpdir,
+        get: async () => undefined,
+        set: async () => {},
+      },
+      createNodeId: (i) => `id:${i}`,
+      getNode: (id) => nodes.get(id),
+    },
+    reporter,
+    options: {
+      name: "posts",
+      owner: "o",
+      repo: "r",
+      ref: "main",
+      patterns: ["**"],
+      token: "x",
+      userAgent: "u",
+      pollInterval: 30,
+      concurrency: 4,
+    } as PluginOptions,
+    state,
+    client,
+    budget: { warned: false },
+  };
+}
+
+function buildClient(sha: string): GitHubClient {
+  return {
+    resolveRef: async () => ({ commitSha: sha, fromCache: false }),
+    getTree: async () => ({ entries: [], truncated: false, fromCache: false }),
+    getBlob: async () => ({ buffer: Buffer.from(""), fromCache: false }),
+    rateLimit: { snapshot: null },
+  };
+}
+
+describe("pollOnce", () => {
+  it("returns false and logs nothing when the ref hasn't moved", async () => {
+    const sha = "a".repeat(40);
+    const ctx = makeCtx(buildClient(sha), sha);
+
+    const moved = await pollOnce(ctx);
+
+    expect(moved).toBe(false);
+    expect(ctx.reporter.info).not.toHaveBeenCalled();
+    expect(ctx.reporter.error).not.toHaveBeenCalled();
+  });
+
+  it("returns true and logs an info line when the ref moves", async () => {
+    const newSha = "b".repeat(40);
+    const ctx = makeCtx(buildClient(newSha), "a".repeat(40));
+
+    const moved = await pollOnce(ctx);
+
+    expect(moved).toBe(true);
+    expect(ctx.reporter.info).toHaveBeenCalledTimes(1);
+    expect(ctx.reporter.info.mock.calls[0]![0]).toContain("aaaaaaa → bbbbbbb");
+  });
+
+  it("renders '—' for the previous SHA on the first move", async () => {
+    const ctx = makeCtx(buildClient("c".repeat(40)));
+
+    await pollOnce(ctx);
+
+    expect(ctx.reporter.info.mock.calls[0]![0]).toContain("— → ccccccc");
+  });
+
+  it("calls reporter.error (not warn) on source failure and returns false", async () => {
+    const client: GitHubClient = {
+      resolveRef: async () => {
+        throw new Error("Bad credentials");
+      },
+      getTree: async () => ({ entries: [], truncated: false, fromCache: false }),
+      getBlob: async () => ({ buffer: Buffer.from(""), fromCache: false }),
+      rateLimit: { snapshot: null },
+    };
+    const ctx = makeCtx(client);
+
+    const moved = await pollOnce(ctx);
+
+    expect(moved).toBe(false);
+    expect(ctx.reporter.error).toHaveBeenCalledTimes(1);
+    expect(ctx.reporter.error.mock.calls[0]![0]).toContain("Bad credentials");
+    expect(ctx.reporter.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns once when the rate-limit budget falls below the threshold", async () => {
+    const client: GitHubClient = {
+      resolveRef: async () => ({ commitSha: "b".repeat(40), fromCache: false }),
+      getTree: async () => ({ entries: [], truncated: false, fromCache: false }),
+      getBlob: async () => ({ buffer: Buffer.from(""), fromCache: false }),
+      rateLimit: { snapshot: { limit: 5000, remaining: 100, reset: null } },
+    };
+    const ctx = makeCtx(client, "a".repeat(40));
+
+    await pollOnce(ctx);
+
+    expect(ctx.reporter.warn).toHaveBeenCalledTimes(1);
+    expect(ctx.budget.warned).toBe(true);
+  });
+});
+
+describe("withOverlapGuard", () => {
+  it("collapses concurrent calls so only one runs at a time", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const work = vi.fn(async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight -= 1;
+    });
+    const guarded = withOverlapGuard(work);
+
+    await Promise.all([guarded(), guarded(), guarded()]);
+
+    expect(peak).toBe(1);
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows sequential calls after the previous one completes", async () => {
+    const work = vi.fn(async () => {});
+    const guarded = withOverlapGuard(work);
+
+    await guarded();
+    await guarded();
+    await guarded();
+
+    expect(work).toHaveBeenCalledTimes(3);
+  });
+
+  it("releases the guard even if the underlying call throws", async () => {
+    let calls = 0;
+    const work = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("boom");
+    });
+    const guarded = withOverlapGuard(work);
+
+    await guarded();
+    await guarded();
+
+    expect(work).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libraries/gatsby-source-github-repository/__tests__/reporter.test.ts
+++ b/libraries/gatsby-source-github-repository/__tests__/reporter.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { formatRateLimit, maybeWarnLowBudget } from "../src/lib/reporter.js";
+
+function makeReporter() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe("formatRateLimit", () => {
+  it("returns 'unknown' when snapshot is null", () => {
+    expect(formatRateLimit(null)).toBe("rate limit: unknown");
+  });
+
+  it("renders limit, remaining, and minutes-until-reset", () => {
+    const now = 1_000_000_000_000;
+    const reset = Math.floor(now / 1000) + 600; // 10 minutes from now
+    expect(
+      formatRateLimit({ limit: 5000, remaining: 4900, reset }, now),
+    ).toBe("rate limit: 4900/5000, resets in 10m");
+  });
+
+  it("omits reset segment when reset is null", () => {
+    expect(
+      formatRateLimit({ limit: 5000, remaining: 4900, reset: null }),
+    ).toBe("rate limit: 4900/5000");
+  });
+
+  it("clamps negative minutes-until-reset to 0", () => {
+    const now = 1_000_000_000_000;
+    const reset = Math.floor(now / 1000) - 60; // 1 minute in the past
+    expect(
+      formatRateLimit({ limit: 5000, remaining: 4900, reset }, now),
+    ).toMatch(/resets in 0m/);
+  });
+});
+
+describe("maybeWarnLowBudget", () => {
+  it("does nothing when snapshot is null", () => {
+    const reporter = makeReporter();
+    maybeWarnLowBudget(reporter, { warned: false }, null, "o/r");
+    expect(reporter.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns once when remaining drops below 10% of limit", () => {
+    const reporter = makeReporter();
+    const state = { warned: false };
+    maybeWarnLowBudget(
+      reporter,
+      state,
+      { limit: 5000, remaining: 400, reset: null },
+      "o/r",
+    );
+    expect(reporter.warn).toHaveBeenCalledTimes(1);
+    expect(reporter.warn.mock.calls[0]![0]).toMatch(/approaching/i);
+    expect(state.warned).toBe(true);
+  });
+
+  it("does not warn again on subsequent low-budget snapshots", () => {
+    const reporter = makeReporter();
+    const state = { warned: true };
+    maybeWarnLowBudget(
+      reporter,
+      state,
+      { limit: 5000, remaining: 400, reset: null },
+      "o/r",
+    );
+    expect(reporter.warn).not.toHaveBeenCalled();
+  });
+
+  it("re-arms once remaining climbs back above the threshold", () => {
+    const reporter = makeReporter();
+    const state = { warned: true };
+    maybeWarnLowBudget(
+      reporter,
+      state,
+      { limit: 5000, remaining: 4500, reset: null },
+      "o/r",
+    );
+    expect(state.warned).toBe(false);
+    expect(reporter.warn).not.toHaveBeenCalled();
+
+    maybeWarnLowBudget(
+      reporter,
+      state,
+      { limit: 5000, remaining: 400, reset: null },
+      "o/r",
+    );
+    expect(reporter.warn).toHaveBeenCalledTimes(1);
+    expect(state.warned).toBe(true);
+  });
+
+  it("uses the label in the warning message", () => {
+    const reporter = makeReporter();
+    maybeWarnLowBudget(
+      reporter,
+      { warned: false },
+      { limit: 5000, remaining: 100, reset: null },
+      "alexwilson/content",
+    );
+    expect(reporter.warn.mock.calls[0]![0]).toContain("alexwilson/content");
+  });
+});

--- a/libraries/gatsby-source-github-repository/__tests__/source.test.ts
+++ b/libraries/gatsby-source-github-repository/__tests__/source.test.ts
@@ -1,0 +1,245 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createState, runSource, type GatsbyHelpers } from "../src/lib/source.js";
+import type { GitHubClient, TreeEntry } from "../src/lib/client.js";
+import type { FileNode } from "../src/lib/nodes.js";
+
+let tmpdir: string;
+let nodes: Map<string, FileNode>;
+let actions: { createNode: ReturnType<typeof vi.fn>; deleteNode: ReturnType<typeof vi.fn> };
+let gatsby: GatsbyHelpers;
+
+beforeEach(async () => {
+  tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "gs-ghr-"));
+  nodes = new Map<string, FileNode>();
+  actions = {
+    createNode: vi.fn((node: FileNode) => nodes.set(node.id, node)),
+    deleteNode: vi.fn((node: FileNode) => nodes.delete(node.id)),
+  };
+  gatsby = {
+    actions,
+    cache: {
+      directory: tmpdir,
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => {}),
+    },
+    createNodeId: (input: string) => `id:${input}`,
+    getNode: (id: string) => nodes.get(id),
+  };
+});
+
+afterEach(async () => {
+  await fs.rm(tmpdir, { recursive: true, force: true });
+});
+
+interface Fixture {
+  sha: string;
+  files: Array<{ entry: TreeEntry; content: string }>;
+}
+
+function blob(p: string, sha: string, content: string) {
+  return { entry: { path: p, sha, size: content.length, mode: "100644" }, content };
+}
+
+function fakeClient(commits: Fixture[]): GitHubClient {
+  let i = -1;
+  const current = (): Fixture => commits[Math.max(0, Math.min(i, commits.length - 1))]!;
+  return {
+    resolveRef: vi.fn(async () => {
+      i += 1;
+      return { commitSha: current().sha, fromCache: false };
+    }),
+    getTree: vi.fn(async () => ({
+      entries: current().files.map((f) => f.entry),
+      truncated: false as const,
+      fromCache: false,
+    })),
+    getBlob: vi.fn(async (sha: string) => {
+      const f = current().files.find((x) => x.entry.sha === sha)!;
+      return { buffer: Buffer.from(f.content), fromCache: false };
+    }),
+    rateLimit: { snapshot: null },
+  };
+}
+
+const options = { name: "posts", ref: "main", patterns: ["**"], concurrency: 8 };
+
+describe("runSource", () => {
+  it("emits a File node per matching blob and records its ID in state", async () => {
+    const state = createState();
+    const client = fakeClient([
+      {
+        sha: "a".repeat(40),
+        files: [blob("posts/one.md", "sha-1", "alpha"), blob("posts/two.md", "sha-2", "beta")],
+      },
+    ]);
+
+    const result = await runSource(gatsby, options, state, client);
+
+    expect(result.matched).toBe(2);
+    expect(actions.createNode).toHaveBeenCalledTimes(2);
+    expect(state.lastIds.size).toBe(2);
+    expect(state.lastCommitSha).toBe("a".repeat(40));
+
+    const written = await fs.readFile(
+      path.join(tmpdir, "files", "posts", "posts/one.md"),
+      "utf8",
+    );
+    expect(written).toBe("alpha");
+  });
+
+  it("filters out blobs that don't match any pattern", async () => {
+    const state = createState();
+    const client = fakeClient([
+      {
+        sha: "a".repeat(40),
+        files: [blob("posts/keep.md", "k", "x"), blob("ignored/skip.md", "s", "y")],
+      },
+    ]);
+
+    await runSource(gatsby, { ...options, patterns: ["posts/**"] }, state, client);
+
+    expect(actions.createNode).toHaveBeenCalledTimes(1);
+    const created = actions.createNode.mock.calls[0]![0];
+    expect(created.relativePath).toMatch(/keep\.md$/);
+  });
+
+  it("uses the blob SHA as contentDigest", async () => {
+    const state = createState();
+    const client = fakeClient([
+      { sha: "c".repeat(40), files: [blob("a.md", "blob-sha-xyz", "hi")] },
+    ]);
+
+    await runSource(gatsby, options, state, client);
+
+    const created = actions.createNode.mock.calls[0]![0];
+    expect(created.internal.contentDigest).toBe("blob-sha-xyz");
+  });
+
+  it("deletes nodes for paths that disappear between passes", async () => {
+    const state = createState();
+    const client = fakeClient([
+      {
+        sha: "a".repeat(40),
+        files: [blob("keep.md", "k1", "k"), blob("gone.md", "g1", "g")],
+      },
+      {
+        sha: "b".repeat(40),
+        files: [blob("keep.md", "k1", "k")],
+      },
+    ]);
+
+    await runSource(gatsby, options, state, client);
+    expect(nodes.size).toBe(2);
+
+    await runSource(gatsby, options, state, client);
+
+    expect(nodes.size).toBe(1);
+    expect(actions.deleteNode).toHaveBeenCalledTimes(1);
+    const deleted = actions.deleteNode.mock.calls[0]![0];
+    expect(deleted.relativePath).toMatch(/gone\.md$/);
+  });
+
+  it("skips deleteNode when the node has already been GC'd", async () => {
+    const state = createState();
+    const client = fakeClient([
+      { sha: "a".repeat(40), files: [blob("gone.md", "g1", "g")] },
+      { sha: "b".repeat(40), files: [] },
+    ]);
+
+    await runSource(gatsby, options, state, client);
+    nodes.clear();
+    await runSource(gatsby, options, state, client);
+
+    expect(actions.deleteNode).not.toHaveBeenCalled();
+  });
+
+  it("re-emits unchanged nodes on subsequent passes (Gatsby treats this as idempotent)", async () => {
+    const state = createState();
+    const client = fakeClient([
+      { sha: "a".repeat(40), files: [blob("a.md", "s1", "x")] },
+      { sha: "b".repeat(40), files: [blob("a.md", "s1", "x")] },
+    ]);
+
+    await runSource(gatsby, options, state, client);
+    await runSource(gatsby, options, state, client);
+
+    expect(actions.createNode).toHaveBeenCalledTimes(2);
+    expect(actions.deleteNode).not.toHaveBeenCalled();
+    expect(state.lastCommitSha).toBe("b".repeat(40));
+  });
+
+  it("counts cached vs fetched blobs correctly when both occur", async () => {
+    const state = createState();
+    const files = [blob("a.md", "s-a", "alpha"), blob("b.md", "s-b", "beta")];
+    const fromCacheMap: Record<string, boolean> = { "s-a": true, "s-b": false };
+    const client: GitHubClient = {
+      resolveRef: async () => ({ commitSha: "a".repeat(40), fromCache: false }),
+      getTree: async () => ({
+        entries: files.map((f) => f.entry),
+        truncated: false,
+        fromCache: false,
+      }),
+      getBlob: async (sha) => {
+        const f = files.find((x) => x.entry.sha === sha)!;
+        return { buffer: Buffer.from(f.content), fromCache: fromCacheMap[sha]! };
+      },
+      rateLimit: { snapshot: null },
+    };
+
+    const result = await runSource(gatsby, options, state, client);
+    expect(result.cached).toBe(1);
+    expect(result.fetched).toBe(1);
+  });
+
+  it("respects concurrency: runs at most N blob fetches in parallel", async () => {
+    const state = createState();
+    const files = Array.from({ length: 12 }, (_, i) =>
+      blob(`p/${i}.md`, `s-${i}`, `c-${i}`),
+    );
+    let inFlight = 0;
+    let peak = 0;
+    const client: GitHubClient = {
+      resolveRef: async () => ({ commitSha: "a".repeat(40), fromCache: false }),
+      getTree: async () => ({
+        entries: files.map((f) => f.entry),
+        truncated: false,
+        fromCache: false,
+      }),
+      getBlob: async (sha) => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight -= 1;
+        const f = files.find((x) => x.entry.sha === sha)!;
+        return { buffer: Buffer.from(f.content), fromCache: false };
+      },
+      rateLimit: { snapshot: null },
+    };
+
+    await runSource(gatsby, { ...options, concurrency: 4 }, state, client);
+
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(actions.createNode).toHaveBeenCalledTimes(12);
+  });
+
+  it("rewrites a file if its bytes have changed on disk", async () => {
+    const state = createState();
+    const client = fakeClient([
+      { sha: "a".repeat(40), files: [blob("changed.md", "s1", "fresh")] },
+    ]);
+    // Pre-populate the file with different bytes
+    const target = path.join(tmpdir, "files", "posts", "changed.md");
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, "stale");
+
+    await runSource(gatsby, options, state, client);
+
+    const written = await fs.readFile(target, "utf8");
+    expect(written).toBe("fresh");
+  });
+});

--- a/libraries/gatsby-source-github-repository/gatsby-node.js
+++ b/libraries/gatsby-source-github-repository/gatsby-node.js
@@ -1,0 +1,3 @@
+// Gatsby looks for `gatsby-node.{js,ts,mjs,cjs}` at the plugin root by filename
+// convention. This shim forwards to the compiled TypeScript output in dist/.
+export * from "./dist/gatsby-node.js";

--- a/libraries/gatsby-source-github-repository/package.json
+++ b/libraries/gatsby-source-github-repository/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "gatsby-source-github-repository",
+  "version": "0.1.0",
+  "description": "Source Gatsby File nodes from a GitHub repository via the GitHub API, with App authentication and content-addressed caching.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./gatsby-node": {
+      "types": "./dist/gatsby-node.d.ts",
+      "default": "./gatsby-node.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "gatsby-node.js",
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.12"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepare": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Alex Wilson <alex@alexwilson.tech>",
+  "license": "ISC",
+  "private": true,
+  "dependencies": {
+    "@octokit/request": "^10.0.0",
+    "gatsby-source-filesystem": "^5.16.0",
+    "minimatch": "^10.0.0"
+  },
+  "peerDependencies": {
+    "gatsby": ">=5"
+  },
+  "devDependencies": {
+    "@octokit/request-error": "^6.1.0",
+    "@types/node": "^25.7.0",
+    "@vitest/coverage-v8": "4.1.7",
+    "gatsby": "^5.16.1",
+    "joi": "^17.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/libraries/gatsby-source-github-repository/src/gatsby-node.ts
+++ b/libraries/gatsby-source-github-repository/src/gatsby-node.ts
@@ -1,0 +1,110 @@
+import type { GatsbyNode } from "gatsby";
+
+import { createClient, type GitHubClient } from "./lib/client.js";
+import { pluginOptionsSchema as schema, type PluginOptions, type TokenSource } from "./lib/options.js";
+import { pollOnce, withOverlapGuard } from "./lib/poller.js";
+import { formatRateLimit, maybeWarnLowBudget, type LowBudgetState } from "./lib/reporter.js";
+import { createState, runSource, type SourceState } from "./lib/source.js";
+
+export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = schema as never;
+
+interface Instance {
+  state: SourceState;
+  client: GitHubClient;
+  budget: LowBudgetState;
+  interval: ReturnType<typeof setInterval> | null;
+}
+
+// Module-scoped so onCreateDevServer can re-enter (config reload) without losing the interval.
+const instances = new Map<string, Instance>();
+
+function instanceKey(opts: PluginOptions): string {
+  return `${opts.owner}/${opts.repo}@${opts.ref}#${opts.name}`;
+}
+
+function tokenGetter(token: TokenSource): () => Promise<string> {
+  if (typeof token === "string") {
+    const trimmed = token.trim();
+    return async () => trimmed;
+  }
+  return async () => {
+    const resolved = await token();
+    return typeof resolved === "string" ? resolved.trim() : "";
+  };
+}
+
+function getInstance(cache: { directory: string } & Parameters<typeof createClient>[0]["cache"], options: PluginOptions): Instance {
+  const key = instanceKey(options);
+  let inst = instances.get(key);
+  if (!inst) {
+    const client = createClient({
+      getToken: tokenGetter(options.token),
+      cache,
+      owner: options.owner,
+      repo: options.repo,
+      userAgent: options.userAgent,
+    });
+    inst = {
+      state: createState(),
+      client,
+      budget: { warned: false },
+      interval: null,
+    };
+    instances.set(key, inst);
+  }
+  return inst;
+}
+
+export const sourceNodes: GatsbyNode["sourceNodes"] = async (args, pluginOptions) => {
+  const options = pluginOptions as unknown as PluginOptions;
+  const { reporter, cache } = args;
+  const { owner, repo, ref, name } = options;
+  const inst = getInstance(cache as never, options);
+
+  const activity = reporter.activityTimer(
+    `source ${owner}/${repo}@${ref} (${name})`,
+  );
+  activity.start();
+
+  try {
+    const result = await runSource(args as never, options, inst.state, inst.client);
+    const rateLimit = formatRateLimit(inst.client.rateLimit.snapshot);
+    activity.setStatus(
+      `${owner}/${repo}@${ref} → ${result.commitSha.slice(0, 7)} ` +
+        `(${result.matched} files, ${result.cached} cached, ${result.fetched} fetched; ${rateLimit})`,
+    );
+    maybeWarnLowBudget(reporter, inst.budget, inst.client.rateLimit.snapshot, `${owner}/${repo}`);
+  } finally {
+    activity.end();
+  }
+};
+
+export const onCreateDevServer: GatsbyNode["onCreateDevServer"] = (args, pluginOptions) => {
+  const options = pluginOptions as unknown as PluginOptions;
+  const interval = options.pollInterval ?? 0;
+  if (interval <= 0) return;
+
+  const { reporter, cache } = args;
+  const { owner, repo, ref } = options;
+  const inst = getInstance(cache as never, options);
+
+  if (inst.interval) clearInterval(inst.interval);
+
+  const tick = withOverlapGuard(() =>
+    pollOnce({
+      gatsby: args as never,
+      reporter,
+      options,
+      state: inst.state,
+      client: inst.client,
+      budget: inst.budget,
+    }),
+  );
+
+  inst.interval = setInterval(tick, interval * 1000);
+  inst.interval.unref?.(); // poll must not keep the process alive
+
+  reporter.info(
+    `[gatsby-source-github-repository] polling ${owner}/${repo}@${ref} every ${interval}s`,
+  );
+};

--- a/libraries/gatsby-source-github-repository/src/index.ts
+++ b/libraries/gatsby-source-github-repository/src/index.ts
@@ -1,0 +1,5 @@
+import fs from "node:fs/promises";
+
+// loadNodeContent must live outside gatsby-node.js: Gatsby's API validator rejects non-lifecycle exports there.
+export const loadNodeContent = (node: { absolutePath: string }): Promise<string> =>
+  fs.readFile(node.absolutePath, "utf-8");

--- a/libraries/gatsby-source-github-repository/src/lib/cache.ts
+++ b/libraries/gatsby-source-github-repository/src/lib/cache.ts
@@ -1,0 +1,10 @@
+export interface CacheLike {
+  get<T = unknown>(key: string): Promise<T | undefined>;
+  set(key: string, value: unknown): Promise<void>;
+}
+
+export const refKey = (owner: string, repo: string, ref: string): string =>
+  `ref:${owner}/${repo}:${ref}`;
+export const treeKey = (owner: string, repo: string, commitSha: string): string =>
+  `tree:${owner}/${repo}:${commitSha}`;
+export const blobKey = (sha: string): string => `blob:${sha}`;

--- a/libraries/gatsby-source-github-repository/src/lib/client.ts
+++ b/libraries/gatsby-source-github-repository/src/lib/client.ts
@@ -1,0 +1,270 @@
+import { request as defaultRequest } from "@octokit/request";
+
+import { blobKey, refKey, treeKey, type CacheLike } from "./cache.js";
+
+const MAX_RETRIES = 2;
+const MAX_RETRY_SLEEP_MS = 60_000;
+
+export interface RateLimitSnapshot {
+  limit: number;
+  remaining: number;
+  reset: number | null;
+}
+
+export interface TreeEntry {
+  path: string;
+  sha: string;
+  size: number;
+  mode: string;
+}
+
+export interface RefResolution {
+  commitSha: string;
+  fromCache: boolean;
+}
+
+export interface TreeResult {
+  entries: TreeEntry[];
+  truncated: false;
+  fromCache: boolean;
+}
+
+export interface BlobResult {
+  buffer: Buffer;
+  fromCache: boolean;
+}
+
+export interface GitHubClient {
+  resolveRef(ref: string): Promise<RefResolution>;
+  getTree(commitSha: string): Promise<TreeResult>;
+  getBlob(sha: string): Promise<BlobResult>;
+  rateLimit: { snapshot: RateLimitSnapshot | null };
+}
+
+interface ApiResponse {
+  status: number;
+  headers: Record<string, string | undefined>;
+  data: any;
+  url?: string;
+}
+type RequestFn = (route: string, params: Record<string, unknown>) => Promise<ApiResponse>;
+type SleepFn = (ms: number) => Promise<void>;
+
+export interface ClientOptions {
+  getToken: () => Promise<string>;
+  cache: CacheLike;
+  owner: string;
+  repo: string;
+  userAgent: string;
+  request?: RequestFn;
+  sleep?: SleepFn;
+}
+
+interface CachedRef {
+  etag: string | null;
+  commitSha: string;
+}
+
+interface CachedTree {
+  entries: TreeEntry[];
+}
+
+interface ApiError {
+  status?: number;
+  response?: { headers?: Record<string, string | undefined> };
+}
+
+export function createClient({
+  getToken,
+  cache,
+  owner,
+  repo,
+  userAgent,
+  request = defaultRequest as unknown as RequestFn,
+  sleep = defaultSleep,
+}: ClientOptions): GitHubClient {
+  const rateLimit: { snapshot: RateLimitSnapshot | null } = { snapshot: null };
+
+  const authedRequest = async (
+    route: string,
+    params: Record<string, unknown> & { headers?: Record<string, string> } = {},
+  ): Promise<ApiResponse> => {
+    const token = await getToken();
+    const { headers: callerHeaders, ...rest } = params;
+    const finalParams = {
+      owner,
+      repo,
+      ...rest,
+      headers: {
+        // Fine-grained PATs (`github_pat_*`) reject the legacy `token` prefix.
+        authorization: `Bearer ${token}`,
+        "user-agent": userAgent,
+        accept: "application/vnd.github+json",
+        ...(callerHeaders ?? {}),
+      },
+    };
+
+    let attempt = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        const res = await request(route, finalParams as Record<string, unknown>);
+        captureRateLimit(rateLimit, res.headers);
+        return res;
+      } catch (err) {
+        const apiErr = err as ApiError;
+        captureRateLimit(rateLimit, apiErr.response?.headers);
+
+        const wait = retryDelayMs(apiErr);
+        if (wait !== null && attempt < MAX_RETRIES) {
+          await sleep(Math.min(wait, MAX_RETRY_SLEEP_MS));
+          attempt += 1;
+          continue;
+        }
+        throw err;
+      }
+    }
+  };
+
+  async function resolveRef(ref: string): Promise<RefResolution> {
+    if (isCommitSha(ref)) {
+      return { commitSha: ref, fromCache: false };
+    }
+
+    const cacheKey = refKey(owner, repo, ref);
+    const cached = await cache.get<CachedRef>(cacheKey);
+
+    const conditionalHeaders: Record<string, string> = cached?.etag
+      ? { "if-none-match": cached.etag }
+      : {};
+
+    try {
+      const res = await authedRequest("GET /repos/{owner}/{repo}/commits/{ref}", {
+        ref,
+        headers: conditionalHeaders,
+      });
+
+      const commitSha = res.data.sha as string;
+      const etag = res.headers?.etag ?? null;
+      await cache.set(cacheKey, { etag, commitSha });
+      return { commitSha, fromCache: false };
+    } catch (err) {
+      // Duck-type, not instanceof: pnpm can resolve multiple copies of @octokit/request-error.
+      const apiErr = err as ApiError;
+      if (apiErr.status === 304 && cached?.commitSha) {
+        return { commitSha: cached.commitSha, fromCache: true };
+      }
+      throw err;
+    }
+  }
+
+  async function getTree(commitSha: string): Promise<TreeResult> {
+    const cacheKey = treeKey(owner, repo, commitSha);
+    const cached = await cache.get<CachedTree>(cacheKey);
+    if (cached) return { entries: cached.entries, truncated: false, fromCache: true };
+
+    const res = await authedRequest(
+      "GET /repos/{owner}/{repo}/git/trees/{tree_sha}",
+      { tree_sha: commitSha, recursive: "1" },
+    );
+
+    if (res.data.truncated) {
+      throw new Error(
+        `[gatsby-source-github-repository] tree for ${owner}/${repo}@${commitSha} is truncated; ` +
+          `the recursive tree endpoint only returns up to 100,000 entries / 7MB. ` +
+          `Narrow the source via patterns, or fetch sub-trees per directory.`,
+      );
+    }
+
+    const entries: TreeEntry[] = (res.data.tree as Array<{ path: string; type: string; sha: string; size: number; mode: string }>)
+      .filter((e) => e.type === "blob")
+      .map((e) => ({ path: e.path, sha: e.sha, size: e.size, mode: e.mode }));
+
+    await cache.set(cacheKey, { entries });
+    return { entries, truncated: false, fromCache: false };
+  }
+
+  async function getBlob(sha: string): Promise<BlobResult> {
+    const cacheKey = blobKey(sha);
+    const cached = await cache.get<string>(cacheKey);
+    if (cached) {
+      return { buffer: Buffer.from(cached, "base64"), fromCache: true };
+    }
+
+    const res = await authedRequest(
+      "GET /repos/{owner}/{repo}/git/blobs/{file_sha}",
+      { file_sha: sha },
+    );
+
+    if (res.data.encoding !== "base64") {
+      throw new Error(
+        `[gatsby-source-github-repository] unexpected blob encoding ${res.data.encoding} for ${sha}`,
+      );
+    }
+
+    await cache.set(cacheKey, res.data.content);
+    return {
+      buffer: Buffer.from(res.data.content as string, "base64"),
+      fromCache: false,
+    };
+  }
+
+  return { resolveRef, getTree, getBlob, rateLimit };
+}
+
+function isCommitSha(value: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(value);
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function captureRateLimit(
+  target: { snapshot: RateLimitSnapshot | null },
+  headers: Record<string, string | undefined> | undefined,
+): void {
+  if (!headers) return;
+  const limit = Number(headers["x-ratelimit-limit"]);
+  const remaining = Number(headers["x-ratelimit-remaining"]);
+  const reset = Number(headers["x-ratelimit-reset"]);
+  if (!Number.isFinite(limit) || !Number.isFinite(remaining)) return;
+  target.snapshot = {
+    limit,
+    remaining,
+    reset: Number.isFinite(reset) ? reset : null,
+  };
+}
+
+function retryDelayMs(err: ApiError): number | null {
+  const status = err.status;
+  const headers = err.response?.headers;
+  if (!headers) return null;
+
+  const retryAfter = headers["retry-after"];
+
+  if (status === 429) {
+    return parseRetryAfter(retryAfter) ?? 1_000;
+  }
+
+  if (status === 403) {
+    if (retryAfter) return parseRetryAfter(retryAfter);
+    const remaining = Number(headers["x-ratelimit-remaining"]);
+    const reset = Number(headers["x-ratelimit-reset"]);
+    if (remaining === 0 && Number.isFinite(reset)) {
+      const ms = reset * 1000 - Date.now();
+      return Math.max(0, ms);
+    }
+  }
+
+  return null;
+}
+
+export function parseRetryAfter(value: string | undefined): number | null {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const epochMs = Date.parse(value);
+  if (Number.isFinite(epochMs)) return Math.max(0, epochMs - Date.now());
+  return null;
+}

--- a/libraries/gatsby-source-github-repository/src/lib/nodes.ts
+++ b/libraries/gatsby-source-github-repository/src/lib/nodes.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+// @ts-expect-error — gatsby-source-filesystem ships JS without types for this helper
+import { createFileNode } from "gatsby-source-filesystem/create-file-node.js";
+
+import type { TreeEntry } from "./client.js";
+
+export interface FileNode {
+  id: string;
+  internal: { contentDigest: string; type: string; mediaType?: string };
+  absolutePath: string;
+  relativePath: string;
+  [key: string]: unknown;
+}
+
+export interface EmitFileNodeArgs {
+  workingDirectory: string;
+  name: string;
+  entry: TreeEntry;
+  buffer: Buffer;
+  createNodeId: (input: string) => string;
+  actions: { createNode: (node: FileNode) => void };
+}
+
+export async function emitFileNode({
+  workingDirectory,
+  name,
+  entry,
+  buffer,
+  createNodeId,
+  actions,
+}: EmitFileNodeArgs): Promise<FileNode> {
+  const absolutePath = path.join(workingDirectory, name, entry.path);
+  await writeIfChanged(absolutePath, buffer);
+
+  // fastHash skips the md5 inside createFileNode; the blob SHA replaces it.
+  const fileNode = (await createFileNode(absolutePath, createNodeId, {
+    name,
+    path: path.join(workingDirectory, name),
+    fastHash: true,
+  })) as FileNode;
+  fileNode.internal.contentDigest = entry.sha;
+
+  actions.createNode(fileNode);
+  return fileNode;
+}
+
+async function writeIfChanged(absolutePath: string, buffer: Buffer): Promise<void> {
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  try {
+    const existing = await fs.readFile(absolutePath);
+    if (existing.equals(buffer)) return;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  await fs.writeFile(absolutePath, buffer);
+}

--- a/libraries/gatsby-source-github-repository/src/lib/options.ts
+++ b/libraries/gatsby-source-github-repository/src/lib/options.ts
@@ -1,0 +1,56 @@
+import type Joi from "joi";
+
+export type TokenSource = string | (() => string | Promise<string>);
+
+export interface PluginOptions {
+  name: string;
+  owner: string;
+  repo: string;
+  ref: string;
+  patterns: string[];
+  token: TokenSource;
+  userAgent: string;
+  pollInterval: number;
+  concurrency: number;
+}
+
+interface JoiArg {
+  Joi: typeof Joi;
+}
+
+export const pluginOptionsSchema = ({ Joi }: JoiArg): Joi.Schema =>
+  Joi.object({
+    name: Joi.string()
+      .description("sourceInstanceName applied to emitted File nodes.")
+      .default("github"),
+    owner: Joi.string().required().description("GitHub repository owner."),
+    repo: Joi.string().required().description("GitHub repository name."),
+    ref: Joi.string()
+      .default("main")
+      .description("Branch name, tag name, or commit SHA to source from."),
+    patterns: Joi.array()
+      .items(Joi.string())
+      .default(["**"])
+      .description("Minimatch patterns. Only blobs matching at least one are sourced."),
+    token: Joi.alternatives(Joi.string(), Joi.function())
+      .required()
+      .description(
+        "Bearer token for the GitHub API. Either a string (PAT, OAuth, or pre-minted installation token) or a `() => Promise<string>` callback for tokens that need to be minted or refreshed per request.",
+      ),
+    userAgent: Joi.string().default("gatsby-source-github-repository"),
+    pollInterval: Joi.number()
+      .integer()
+      .min(0)
+      .default(0)
+      .description(
+        "Seconds between background polls during `gatsby develop`. 0 disables polling. Each poll is a conditional GET on the ref; unchanged refs return 304 and don't count against rate limits. Has no effect in `gatsby build`.",
+      ),
+    concurrency: Joi.number()
+      .integer()
+      .min(1)
+      .max(50)
+      .default(8)
+      .description(
+        "Maximum number of in-flight blob fetches during sourcing. Higher values speed up cold builds at the cost of more parallel load on the GitHub API. Cached blobs don't count.",
+      ),
+  });

--- a/libraries/gatsby-source-github-repository/src/lib/poller.ts
+++ b/libraries/gatsby-source-github-repository/src/lib/poller.ts
@@ -1,0 +1,66 @@
+import type { GitHubClient } from "./client.js";
+import { formatRateLimit, maybeWarnLowBudget, type LowBudgetState, type ReporterLike } from "./reporter.js";
+import { runSource, type GatsbyHelpers, type SourceState } from "./source.js";
+import type { PluginOptions } from "./options.js";
+
+export interface PollContext {
+  gatsby: GatsbyHelpers;
+  reporter: ReporterLike;
+  options: PluginOptions;
+  state: SourceState;
+  client: GitHubClient;
+  budget: LowBudgetState;
+}
+
+/**
+ * One poll tick: re-source, log on SHA change, surface errors loudly.
+ * Returns true if the ref moved, false otherwise.
+ *
+ * Exposed for unit testing; the production scheduler invokes this on an interval.
+ */
+export async function pollOnce(ctx: PollContext): Promise<boolean> {
+  const { gatsby, reporter, options, state, client, budget } = ctx;
+  const { owner, repo, ref } = options;
+  const previousSha = state.lastCommitSha;
+  try {
+    const result = await runSource(gatsby, options, state, client);
+    if (result.commitSha !== previousSha) {
+      reporter.info(
+        `[gatsby-source-github-repository] ${owner}/${repo}@${ref}: ` +
+          `${previousSha?.slice(0, 7) ?? "—"} → ${result.commitSha.slice(0, 7)} ` +
+          `(${result.fetched} fetched; ${formatRateLimit(client.rateLimit.snapshot)})`,
+      );
+    }
+    maybeWarnLowBudget(reporter, budget, client.rateLimit.snapshot, `${owner}/${repo}`);
+    return result.commitSha !== previousSha;
+  } catch (err) {
+    // reporter.error renders red without exiting; the next poll retries.
+    reporter.error(
+      `[gatsby-source-github-repository] poll failed for ${owner}/${repo}@${ref}: ${(err as Error).message}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Wrap an async function so concurrent calls collapse: while one invocation is
+ * in flight, additional calls return immediately without running. Errors are
+ * swallowed so a setInterval driver doesn't generate unhandled rejections —
+ * callers should handle errors inside `fn` (e.g. via reporter.error).
+ */
+export function withOverlapGuard<Args extends unknown[]>(
+  fn: (...args: Args) => Promise<unknown>,
+): (...args: Args) => Promise<void> {
+  let inFlight = false;
+  return async (...args: Args) => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await fn(...args);
+    } catch {
+      // intentionally swallowed; see docstring
+    } finally {
+      inFlight = false;
+    }
+  };
+}

--- a/libraries/gatsby-source-github-repository/src/lib/reporter.ts
+++ b/libraries/gatsby-source-github-repository/src/lib/reporter.ts
@@ -1,0 +1,44 @@
+import type { RateLimitSnapshot } from "./client.js";
+
+const LOW_BUDGET_FRACTION = 0.1;
+
+export interface ReporterLike {
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+}
+
+export function formatRateLimit(
+  snapshot: RateLimitSnapshot | null,
+  now: number = Date.now(),
+): string {
+  if (!snapshot) return "rate limit: unknown";
+  const { limit, remaining, reset } = snapshot;
+  const minutesUntilReset = reset
+    ? Math.max(0, Math.round((reset * 1000 - now) / 60_000))
+    : null;
+  const resetPart = minutesUntilReset !== null ? `, resets in ${minutesUntilReset}m` : "";
+  return `rate limit: ${remaining}/${limit}${resetPart}`;
+}
+
+export interface LowBudgetState {
+  warned: boolean;
+}
+
+export function maybeWarnLowBudget(
+  reporter: ReporterLike,
+  state: LowBudgetState,
+  snapshot: RateLimitSnapshot | null,
+  label: string,
+): void {
+  if (!snapshot) return;
+  const low = snapshot.remaining / snapshot.limit < LOW_BUDGET_FRACTION;
+  if (low && !state.warned) {
+    reporter.warn(
+      `[gatsby-source-github-repository] ${label}: ${formatRateLimit(snapshot)} — approaching GitHub API rate limit`,
+    );
+    state.warned = true;
+  } else if (!low && state.warned) {
+    state.warned = false;
+  }
+}

--- a/libraries/gatsby-source-github-repository/src/lib/source.ts
+++ b/libraries/gatsby-source-github-repository/src/lib/source.ts
@@ -1,0 +1,104 @@
+import path from "node:path";
+
+import { minimatch } from "minimatch";
+
+import type { GitHubClient } from "./client.js";
+import type { CacheLike } from "./cache.js";
+import { emitFileNode, type FileNode } from "./nodes.js";
+import type { PluginOptions } from "./options.js";
+
+export interface SourceState {
+  lastIds: Set<string>;
+  lastCommitSha: string | null;
+}
+
+export interface GatsbyHelpers {
+  actions: {
+    createNode: (node: FileNode) => void;
+    deleteNode: (node: FileNode) => void;
+  };
+  cache: CacheLike & { directory: string };
+  createNodeId: (input: string) => string;
+  getNode: (id: string) => FileNode | undefined;
+}
+
+export interface SourceResult {
+  commitSha: string;
+  matched: number;
+  fetched: number;
+  cached: number;
+}
+
+export async function runSource(
+  gatsby: GatsbyHelpers,
+  options: Pick<PluginOptions, "ref" | "patterns" | "name" | "concurrency">,
+  state: SourceState,
+  client: GitHubClient,
+): Promise<SourceResult> {
+  const { actions, cache, createNodeId, getNode } = gatsby;
+  const { ref, patterns, name, concurrency = 8 } = options;
+
+  const { commitSha } = await client.resolveRef(ref);
+  const { entries } = await client.getTree(commitSha);
+  const matched = entries.filter((entry) => matchesAny(entry.path, patterns));
+
+  const workingDirectory = path.join(cache.directory, "files");
+  const seenIds = new Set<string>();
+  let fetched = 0;
+  let cached = 0;
+
+  await pool(matched, concurrency, async (entry) => {
+    const { buffer, fromCache } = await client.getBlob(entry.sha);
+    if (fromCache) cached += 1;
+    else fetched += 1;
+
+    const node = await emitFileNode({
+      workingDirectory,
+      name,
+      entry,
+      buffer,
+      createNodeId,
+      actions,
+    });
+    seenIds.add(node.id);
+  });
+
+  for (const id of state.lastIds) {
+    if (!seenIds.has(id)) {
+      const node = getNode(id);
+      if (node) actions.deleteNode(node);
+    }
+  }
+
+  state.lastIds = seenIds;
+  state.lastCommitSha = commitSha;
+
+  return { commitSha, matched: matched.length, fetched, cached };
+}
+
+export function createState(): SourceState {
+  return { lastIds: new Set<string>(), lastCommitSha: null };
+}
+
+function matchesAny(filepath: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    if (minimatch(filepath, pattern)) return true;
+  }
+  return false;
+}
+
+async function pool<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const workerCount = Math.max(1, Math.min(concurrency, items.length));
+  const next = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      await worker(items[idx]!);
+    }
+  };
+  await Promise.all(Array.from({ length: workerCount }, next));
+}

--- a/libraries/gatsby-source-github-repository/tsconfig.json
+++ b/libraries/gatsby-source-github-repository/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/libraries/gatsby-source-github-repository/vitest.config.ts
+++ b/libraries/gatsby-source-github-repository/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: false,
+    include: ["__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.d.ts"],
+      reporter: ["text", "html"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,40 @@ importers:
         specifier: 2.0.3
         version: 2.0.3
 
+  libraries/gatsby-source-github-repository:
+    dependencies:
+      '@octokit/request':
+        specifier: ^10.0.0
+        version: 10.0.9
+      gatsby-source-filesystem:
+        specifier: ^5.16.0
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      minimatch:
+        specifier: ^10.0.0
+        version: 10.2.5
+    devDependencies:
+      '@octokit/request-error':
+        specifier: ^6.1.0
+        version: 6.1.8
+      '@types/node':
+        specifier: ^25.7.0
+        version: 25.8.0
+      '@vitest/coverage-v8':
+        specifier: 4.1.7
+        version: 4.1.7(vitest@4.1.6)
+      gatsby:
+        specifier: ^5.16.1
+        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      joi:
+        specifier: ^17.0.0
+        version: 17.13.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
+
   services/auth:
     dependencies:
       '@octokit/request':
@@ -84,7 +118,7 @@ importers:
     devDependencies:
       '@better-auth/cli':
         specifier: 1.4.21
-        version: 1.4.21(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260515.1)(@types/better-sqlite3@7.6.13)(better-call@1.3.5(zod@4.4.3))(drizzle-kit@0.31.10)(gel@2.2.0)(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)))
+        version: 1.4.21(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260515.1)(@types/better-sqlite3@7.6.13)(better-call@1.3.5(zod@4.4.3))(drizzle-kit@0.31.10)(gel@2.2.0)(jose@6.2.3)(kysely@0.28.17)(magicast@0.5.3)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)))
       '@cloudflare/workers-types':
         specifier: 4.20260515.1
         version: 4.20260515.1
@@ -299,9 +333,9 @@ importers:
       gatsby-source-filesystem:
         specifier: 5.16.0
         version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
-      gatsby-source-git:
-        specifier: 1.1.0
-        version: 1.1.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      gatsby-source-github-repository:
+        specifier: workspace:*
+        version: link:../../libraries/gatsby-source-github-repository
       gatsby-transformer-remark:
         specifier: 6.16.0
         version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
@@ -350,7 +384,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@types/node@25.8.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
+        version: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
 
   services/storybook:
     dependencies:
@@ -454,7 +488,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@types/node@25.8.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
+        version: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
 
 packages:
 
@@ -1146,6 +1180,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@better-auth/cli@1.4.21':
     resolution: {integrity: sha512-bKEa8BupnZxNjLk9ZDntvgQGm5jogeE2wHdMbYifhet3GTyxgDi6pXoOK8+aqHYQGg1C3OALi9hVVWnrv7JJWQ==}
@@ -3131,10 +3169,6 @@ packages:
     resolution: {integrity: sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==}
     engines: {node: '>=16'}
 
-  '@mrmlnc/readdir-enhanced@2.2.1':
-    resolution: {integrity: sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==}
-    engines: {node: '>=4'}
-
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
     cpu: [arm64]
@@ -3192,10 +3226,6 @@ packages:
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@1.1.3':
-    resolution: {integrity: sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==}
-    engines: {node: '>= 6'}
 
   '@nodelib/fs.stat@2.0.5':
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
@@ -3370,6 +3400,9 @@ packages:
   '@octokit/openapi-types@24.2.0':
     resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
 
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
   '@octokit/openapi-types@27.0.0':
     resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
 
@@ -3398,6 +3431,10 @@ packages:
     resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
     engines: {node: '>= 18'}
 
+  '@octokit/request-error@6.1.8':
+    resolution: {integrity: sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==}
+    engines: {node: '>= 18'}
+
   '@octokit/request-error@7.1.0':
     resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
     engines: {node: '>= 20'}
@@ -3416,6 +3453,9 @@ packages:
 
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
@@ -4322,14 +4362,6 @@ packages:
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
-  '@sindresorhus/is@0.14.0':
-    resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
-    engines: {node: '>=6'}
-
-  '@sindresorhus/is@0.7.0':
-    resolution: {integrity: sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==}
-    engines: {node: '>=4'}
-
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -4473,10 +4505,6 @@ packages:
 
   '@swc/helpers@0.4.37':
     resolution: {integrity: sha512-O4U8DmGtYvuWDrqmkAqhmA+sV8D3eJzvKSUgg5L5eaCCPdywZBLc97UgJT/fQaCkQ5onJzJWNojgErJk1bThaw==}
-
-  '@szmarczak/http-timer@1.1.2':
-    resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}
-    engines: {node: '>=6'}
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -4665,9 +4693,6 @@ packages:
 
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-
-  '@types/node@25.7.0':
-    resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
 
   '@types/node@25.8.0':
     resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
@@ -4862,6 +4887,15 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.7':
+    resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.7
+      vitest: 4.1.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -4885,6 +4919,9 @@ packages:
   '@vitest/pretty-format@4.1.6':
     resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
   '@vitest/runner@4.1.6':
     resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
 
@@ -4902,6 +4939,9 @@ packages:
 
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -5200,18 +5240,6 @@ packages:
   arity-n@1.0.4:
     resolution: {integrity: sha512-fExL2kFDC1Q2DUOx3whE/9KoN66IzkY4b4zUHUBFM1ojEYjZZYDcUW3bek/ufGionX9giIKDC5redH2IlGqcQQ==}
 
-  arr-diff@4.0.0:
-    resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
-    engines: {node: '>=0.10.0'}
-
-  arr-flatten@1.1.0:
-    resolution: {integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==}
-    engines: {node: '>=0.10.0'}
-
-  arr-union@3.1.0:
-    resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
-    engines: {node: '>=0.10.0'}
-
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -5236,10 +5264,6 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-
-  array-unique@0.3.2:
-    resolution: {integrity: sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==}
-    engines: {node: '>=0.10.0'}
 
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
@@ -5284,16 +5308,15 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  assign-symbols@1.0.0:
-    resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
-    engines: {node: '>=0.10.0'}
-
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -5547,10 +5570,6 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  base@0.11.2:
-    resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
-    engines: {node: '>=0.10.0'}
-
   baseline-browser-mapping@2.10.29:
     resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
     engines: {node: '>=6.0.0'}
@@ -5706,12 +5725,6 @@ packages:
     resolution: {integrity: sha512-kIPXZS5qwyKiX/HcRvDYfmBQUa8XP17I0mYZZ0y4UhpYOSvtsLHDYqmomS+Mj20aDvD3knEiQ0ecQy2nhio3yA==}
     engines: {node: '>8.0.0'}
 
-  better-queue-memory@1.0.4:
-    resolution: {integrity: sha512-SWg5wFIShYffEmJpI6LgbL8/3Dqhku7xI1oEiy6FroP9DbcZlG0ZDjxvPdP9t7hTGW40IpIcC6zVoGT1oxjOuA==}
-
-  better-queue@3.8.12:
-    resolution: {integrity: sha512-D9KZ+Us+2AyaCz693/9AyjTg0s8hEmkiM/MB3i09cs4MdK1KgTSGJluXRYmOulR69oLZVo2XDFtqsExDt8oiLA==}
-
   better-sqlite3@12.10.0:
     resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
@@ -5777,10 +5790,6 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
-  braces@2.3.2:
-    resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
-    engines: {node: '>=0.10.0'}
-
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -5841,10 +5850,6 @@ packages:
     resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  cache-base@1.0.1:
-    resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
-    engines: {node: '>=0.10.0'}
-
   cache-manager@2.11.1:
     resolution: {integrity: sha512-XhUuc9eYwkzpK89iNewFwtvcDYMUsvtwzHeyEOPJna/WsVsXcrzsA1ft2M0QqPNunEzLhNCYPo05tEfG+YuNow==}
 
@@ -5859,13 +5864,6 @@ packages:
   cacheable-request@10.2.14:
     resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
     engines: {node: '>=14.16'}
-
-  cacheable-request@2.1.4:
-    resolution: {integrity: sha512-vag0O2LKZ/najSoUwDbVlnlCFvhBE/7mGTY2B5FgCBDcRD+oVV1HYTOwM6JZfMg/hIcM6IwnTZ1uQQL5/X3xIQ==}
-
-  cacheable-request@6.1.0:
-    resolution: {integrity: sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==}
-    engines: {node: '>=8'}
 
   cacheable-request@7.0.4:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
@@ -5882,9 +5880,6 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
-
-  call-me-maybe@1.0.2:
-    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -6047,10 +6042,6 @@ packages:
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
-  class-utils@0.3.6:
-    resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==}
-    engines: {node: '>=0.10.0'}
-
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -6100,9 +6091,6 @@ packages:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
 
-  clone-response@1.0.2:
-    resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
-
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
@@ -6135,10 +6123,6 @@ packages:
 
   collapse-white-space@1.0.6:
     resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
-
-  collection-visit@1.0.0:
-    resolution: {integrity: sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==}
-    engines: {node: '>=0.10.0'}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -6215,9 +6199,6 @@ packages:
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
-
-  component-emitter@1.3.1:
-    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
   compose-function@3.0.3:
     resolution: {integrity: sha512-xzhzTJ5eC+gmIzvZq+C3kCJHsp9os6tJkrigDRZclyGtOKINbZtE8n1Tzmeh32jW+BUDPbvZpibwvJHBLGMVwg==}
@@ -6342,10 +6323,6 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
-
-  copy-descriptor@0.1.1:
-    resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}
-    engines: {node: '>=0.10.0'}
 
   core-js-compat@3.31.0:
     resolution: {integrity: sha512-hM7YCu1cU6Opx7MXNu0NuumM0ezNeAeRKadixyiQELWY3vT3De9S4J5ZBMraWV2vZnrE1Cirl0GtFtDtMUXzPw==}
@@ -6967,10 +6944,6 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
-  decompress-response@3.3.0:
-    resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
-    engines: {node: '>=4'}
-
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -7012,9 +6985,6 @@ packages:
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
-  defer-to-connect@1.1.3:
-    resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==}
-
   defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
@@ -7034,18 +7004,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  define-property@0.2.5:
-    resolution: {integrity: sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==}
-    engines: {node: '>=0.10.0'}
-
-  define-property@1.0.0:
-    resolution: {integrity: sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==}
-    engines: {node: '>=0.10.0'}
-
-  define-property@2.0.2:
-    resolution: {integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==}
-    engines: {node: '>=0.10.0'}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -7397,9 +7355,6 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
-
-  duplexer3@0.1.5:
-    resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==}
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -7813,10 +7768,6 @@ packages:
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
-  expand-brackets@2.1.4:
-    resolution: {integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==}
-    engines: {node: '>=0.10.0'}
-
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -7846,20 +7797,12 @@ packages:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
 
-  extend-shallow@3.0.2:
-    resolution: {integrity: sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==}
-    engines: {node: '>=0.10.0'}
-
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
-
-  extglob@2.0.4:
-    resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==}
-    engines: {node: '>=0.10.0'}
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
@@ -7869,10 +7812,6 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
-
-  fast-glob@2.2.7:
-    resolution: {integrity: sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==}
-    engines: {node: '>=4.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -7943,10 +7882,6 @@ packages:
   filesize@8.0.7:
     resolution: {integrity: sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==}
     engines: {node: '>= 0.4.0'}
-
-  fill-range@4.0.0:
-    resolution: {integrity: sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==}
-    engines: {node: '>=0.10.0'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -8019,10 +7954,6 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  for-in@1.0.2:
-    resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
-    engines: {node: '>=0.10.0'}
-
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -8063,16 +7994,9 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
-  fragment-cache@0.2.1:
-    resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
-    engines: {node: '>=0.10.0'}
-
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-
-  from2@2.3.0:
-    resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -8087,13 +8011,6 @@ packages:
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
-
-  fs-extra@5.0.0:
-    resolution: {integrity: sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==}
-
-  fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
 
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -8135,10 +8052,6 @@ packages:
     resolution: {integrity: sha512-O+2ouCR0Yex04AllxPMIWxlwcj2GiGsvK8sC6AfVL092j0rQJAfwEEBhgVNhFrniPnEanaADRKbgjj2k6vPaBw==}
     engines: {node: '>=18.0.0 <26'}
     hasBin: true
-
-  gatsby-core-utils@1.10.1:
-    resolution: {integrity: sha512-4P3feGCJckg+DRWWl2beFk7N9c63zmCryEGPaU1OHCp+ZT2bO0ihCBuXywDWuuEp6SYP9PZ1fs0YJ/Rt6q6lag==}
-    engines: {node: '>=10.13.0'}
 
   gatsby-core-utils@4.16.0:
     resolution: {integrity: sha512-QCZ9BmQp3YyYxH0Wf4bofayL3vJnayqSvsBUAhKXGh/Os0fn1KMNyAjPLnW+zrGFQaK05Vjdlp99I/Wnc3M33A==}
@@ -8256,22 +8169,11 @@ packages:
     resolution: {integrity: sha512-Xh2MwKtr9UYQnhlv5xpLXADRG6j/9dPgTLf010jNKQmvPsETkwZ3TZwnOpIgbGYJjg50rYzSCQ9RAuYXlqLmMA==}
     engines: {node: '>=18.0.0 <26'}
 
-  gatsby-source-filesystem@2.11.1:
-    resolution: {integrity: sha512-Ao526Mmhm8KkF+0Tvf9Le5kKnqX7kgC1wecp82BW2KLQgdtG7UIgmHvG6PkjuFNiJ2ghXPC3vRK3J/vDPyLtkA==}
-    engines: {node: '>=10.13.0'}
-    peerDependencies:
-      gatsby: ^2.2.0
-
   gatsby-source-filesystem@5.16.0:
     resolution: {integrity: sha512-z64lyDaonLpD1fHV8s9MYVBz2z6Mv3jwEntwt/KA4QKPJsH/qD1eKZ0OBSilGqEadzLw7EcgTGkTXBAz1gd8fg==}
     engines: {node: '>=18.0.0 <26'}
     peerDependencies:
       gatsby: ^5.0.0-next
-
-  gatsby-source-git@1.1.0:
-    resolution: {integrity: sha512-f5HllxwS+ivVn6SitSJPEQe8tf/apjwq5TOZRiEIRJtlrm9eSBqM2hO6ZIOK5na6UuvI+BH8xxbgj0qrwNTznA==}
-    peerDependencies:
-      gatsby: '>2.0.0-alpha'
 
   gatsby-transformer-remark@6.16.0:
     resolution: {integrity: sha512-k1uq8G+EIC1nuDLMdvX/8SgcDCN572VlmvUsRu2oLdr9o3yz3Ulxz6qScejHLDT1UpBEixMtYjtiP5NHoUquCg==}
@@ -8325,14 +8227,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@3.0.0:
-    resolution: {integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==}
-    engines: {node: '>=4'}
-
-  get-stream@4.1.0:
-    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
-    engines: {node: '>=6'}
-
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
@@ -8355,10 +8249,6 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
-
-  get-value@2.0.6:
-    resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
-    engines: {node: '>=0.10.0'}
 
   get-video-id@3.7.0:
     resolution: {integrity: sha512-hU5pnODTo87slfs9MUFO3vpJr23AESJHmF20T3ivqQJZ/Wz0W5TxjSrGoyB6X538Shyi6tCCpQSeBoV88F9NYA==}
@@ -8387,14 +8277,8 @@ packages:
     deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
-  git-up@4.0.5:
-    resolution: {integrity: sha512-YUvVDg/vX3d0syBsk/CKUTib0srcQME0JyHkL5BaYdwLsiCslPWmDSi8PUMo9pXYjrryMcmsCoCgsTpSCJEQaA==}
-
   git-up@7.0.0:
     resolution: {integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==}
-
-  git-url-parse@11.6.0:
-    resolution: {integrity: sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==}
 
   git-url-parse@14.0.0:
     resolution: {integrity: sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==}
@@ -8407,9 +8291,6 @@ packages:
 
   github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
-
-  glob-parent@3.1.0:
-    resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -8424,9 +8305,6 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
-
-  glob-to-regexp@0.3.0:
-    resolution: {integrity: sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==}
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
@@ -8479,14 +8357,6 @@ packages:
   got@12.6.1:
     resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
     engines: {node: '>=14.16'}
-
-  got@8.3.2:
-    resolution: {integrity: sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==}
-    engines: {node: '>=4'}
-
-  got@9.6.0:
-    resolution: {integrity: sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==}
-    engines: {node: '>=8.6'}
 
   gotrue-js@0.9.29:
     resolution: {integrity: sha512-NSFwJlFfWxHd1zHDitysbh+amFPHBAyQG1YmecZJTaSe8TlC7Wja1ewdUBikfJBblN3SqghS6aViMd+Q/pPzGQ==}
@@ -8572,15 +8442,9 @@ packages:
     resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
     engines: {node: '>= 0.4'}
 
-  has-symbol-support-x@1.4.2:
-    resolution: {integrity: sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==}
-
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
-
-  has-to-string-tag-x@1.4.1:
-    resolution: {integrity: sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==}
 
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
@@ -8588,22 +8452,6 @@ packages:
 
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
-
-  has-value@0.3.1:
-    resolution: {integrity: sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==}
-    engines: {node: '>=0.10.0'}
-
-  has-value@1.0.0:
-    resolution: {integrity: sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==}
-    engines: {node: '>=0.10.0'}
-
-  has-values@0.1.4:
-    resolution: {integrity: sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==}
-    engines: {node: '>=0.10.0'}
-
-  has-values@1.0.0:
-    resolution: {integrity: sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==}
-    engines: {node: '>=0.10.0'}
 
   hash-wasm@4.12.0:
     resolution: {integrity: sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==}
@@ -8714,6 +8562,9 @@ packages:
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
@@ -8742,9 +8593,6 @@ packages:
 
   htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
-
-  http-cache-semantics@3.8.1:
-    resolution: {integrity: sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -8954,10 +8802,6 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
-  into-stream@3.1.0:
-    resolution: {integrity: sha512-TcdjPibTksa1NQximqep2r17ISRiNE9fwlfbg3F8ANdvP5/yrFTew86VcO//jk4QTaMlbjypPBq76HN2zaKfZQ==}
-    engines: {node: '>=4'}
-
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
@@ -8980,10 +8824,6 @@ packages:
   is-absolute@1.0.0:
     resolution: {integrity: sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==}
     engines: {node: '>=0.10.0'}
-
-  is-accessor-descriptor@1.0.1:
-    resolution: {integrity: sha512-YBUanLI8Yoihw923YeFUS5fs0fF2f5TSFTNiYAAzhhDscDa3lEqYuz1pDOEP5KvX94I9ey3vsqjJcLVFVU+3QA==}
-    engines: {node: '>= 0.10'}
 
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -9025,9 +8865,6 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
-  is-buffer@1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
-
   is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
     engines: {node: '>=4'}
@@ -9048,10 +8885,6 @@ packages:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
-  is-data-descriptor@1.0.1:
-    resolution: {integrity: sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==}
-    engines: {node: '>= 0.4'}
-
   is-data-view@1.0.2:
     resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
     engines: {node: '>= 0.4'}
@@ -9062,14 +8895,6 @@ packages:
 
   is-decimal@1.0.4:
     resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
-
-  is-descriptor@0.1.7:
-    resolution: {integrity: sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==}
-    engines: {node: '>= 0.4'}
-
-  is-descriptor@1.0.3:
-    resolution: {integrity: sha512-JCNNGbwWZEVaSPtS45mdtrneRWJFp07LLmykxeFV5F6oBvNF8vHSfJuJgoT472pSfk+Mf8VnlrspaFBHWM8JAw==}
-    engines: {node: '>= 0.4'}
 
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
@@ -9083,10 +8908,6 @@ packages:
 
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
-    engines: {node: '>=0.10.0'}
-
-  is-extendable@1.0.1:
-    resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==}
     engines: {node: '>=0.10.0'}
 
   is-extglob@1.0.0:
@@ -9114,10 +8935,6 @@ packages:
 
   is-glob@2.0.1:
     resolution: {integrity: sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==}
-    engines: {node: '>=0.10.0'}
-
-  is-glob@3.1.0:
-    resolution: {integrity: sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==}
     engines: {node: '>=0.10.0'}
 
   is-glob@4.0.3:
@@ -9162,10 +8979,6 @@ packages:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
 
-  is-number@3.0.0:
-    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==}
-    engines: {node: '>=0.10.0'}
-
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -9173,9 +8986,6 @@ packages:
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
-
-  is-object@1.0.2:
-    resolution: {integrity: sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==}
 
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
@@ -9213,10 +9023,6 @@ packages:
 
   is-relative@1.0.0:
     resolution: {integrity: sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==}
-    engines: {node: '>=0.10.0'}
-
-  is-retry-allowed@1.2.0:
-    resolution: {integrity: sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==}
     engines: {node: '>=0.10.0'}
 
   is-root@2.1.0:
@@ -9333,10 +9139,6 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
-  isobject@2.1.0:
-    resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
-    engines: {node: '>=0.10.0'}
-
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
@@ -9344,9 +9146,17 @@ packages:
   isomorphic-base64@1.0.2:
     resolution: {integrity: sha512-pQFyLwShVPA1Qr0dE1ZPguJkbOsFGDfSq6Wzz6XaO33v74X6/iQjgYPozwkeKGQxOI1/H3Fz7+ROtnV1veyKEg==}
 
-  isurl@1.0.0:
-    resolution: {integrity: sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==}
-    engines: {node: '>= 4'}
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -9430,6 +9240,9 @@ packages:
   js-sha256@0.9.0:
     resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -9454,9 +9267,6 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
-
-  json-buffer@3.0.0:
-    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -9511,9 +9321,6 @@ packages:
   jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
 
-  jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
-
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
@@ -9534,22 +9341,8 @@ packages:
   jwt-decode@3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
 
-  keyv@3.0.0:
-    resolution: {integrity: sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==}
-
-  keyv@3.1.0:
-    resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  kind-of@3.2.2:
-    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
-    engines: {node: '>=0.10.0'}
-
-  kind-of@4.0.0:
-    resolution: {integrity: sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==}
-    engines: {node: '>=0.10.0'}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -9827,14 +9620,6 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
-  lowercase-keys@1.0.0:
-    resolution: {integrity: sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==}
-    engines: {node: '>=0.10.0'}
-
-  lowercase-keys@1.0.1:
-    resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==}
-    engines: {node: '>=0.10.0'}
-
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
@@ -9875,9 +9660,16 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -9902,10 +9694,6 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
-  map-visit@1.0.0:
-    resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
-    engines: {node: '>=0.10.0'}
-
   mapbox-to-css-font@2.4.5:
     resolution: {integrity: sha512-VJ6nB8emkO9VODI0Fk+TQ/0zKBTqmf/Pkt8Xv0kHstoc0iXRajA00DAid4Kc3K5xeFIOoiZrVxijEzj0GLVO2w==}
 
@@ -9924,11 +9712,6 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  md5-file@5.0.0:
-    resolution: {integrity: sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
 
   mdast-util-compact@1.0.4:
     resolution: {integrity: sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==}
@@ -10102,10 +9885,6 @@ packages:
   micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
 
-  micromatch@3.1.10:
-    resolution: {integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==}
-    engines: {node: '>=0.10.0'}
-
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -10137,11 +9916,6 @@ packages:
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
-    hasBin: true
-
-  mime@2.6.0:
-    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
-    engines: {node: '>=4.0.0'}
     hasBin: true
 
   mime@3.0.0:
@@ -10258,10 +10032,6 @@ packages:
   mitt@1.2.0:
     resolution: {integrity: sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==}
 
-  mixin-deep@1.3.2:
-    resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
-    engines: {node: '>=0.10.0'}
-
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -10322,10 +10092,6 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
-  nanomatch@1.2.13:
-    resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
-    engines: {node: '>=0.10.0'}
-
   nanostores@1.3.0:
     resolution: {integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -10381,9 +10147,6 @@ packages:
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
-
-  node-eta@0.9.0:
-    resolution: {integrity: sha512-mTCTZk29tmX1OGfVkPt63H3c3VqXrI2Kvua98S7iUIB/Gbp0MNw05YtUomxQIxnnKMyRIIuY9izPcFixzhSBrA==}
 
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
@@ -10452,14 +10215,6 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-
-  normalize-url@2.0.1:
-    resolution: {integrity: sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==}
-    engines: {node: '>=4'}
-
-  normalize-url@4.5.1:
-    resolution: {integrity: sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==}
-    engines: {node: '>=8'}
 
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
@@ -10561,10 +10316,6 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  object-copy@0.1.0:
-    resolution: {integrity: sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==}
-    engines: {node: '>=0.10.0'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -10572,10 +10323,6 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-
-  object-visit@1.0.1:
-    resolution: {integrity: sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==}
-    engines: {node: '>=0.10.0'}
 
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
@@ -10592,10 +10339,6 @@ packages:
   object.groupby@1.0.3:
     resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
     engines: {node: '>= 0.4'}
-
-  object.pick@1.3.0:
-    resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
-    engines: {node: '>=0.10.0'}
 
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
@@ -10693,14 +10436,6 @@ packages:
   oxc-resolver@11.19.1:
     resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
-  p-cancelable@0.4.1:
-    resolution: {integrity: sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==}
-    engines: {node: '>=4'}
-
-  p-cancelable@1.1.0:
-    resolution: {integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==}
-    engines: {node: '>=6'}
-
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
@@ -10715,10 +10450,6 @@ packages:
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
-    engines: {node: '>=4'}
-
-  p-is-promise@1.1.0:
-    resolution: {integrity: sha512-zL7VE4JVS2IFSkR2GQKDSPEVxkoH43/p7oEnwpdCndKYJO0HVeRB7fA8TJwuLOTBREtK0ea8eHaxdwcpob5dmg==}
     engines: {node: '>=4'}
 
   p-limit@1.3.0:
@@ -10776,10 +10507,6 @@ packages:
   p-retry@6.2.1:
     resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
     engines: {node: '>=16.17'}
-
-  p-timeout@2.0.1:
-    resolution: {integrity: sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==}
-    engines: {node: '>=4'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -10870,17 +10597,11 @@ packages:
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
-  parse-path@4.0.4:
-    resolution: {integrity: sha512-Z2lWUis7jlmXC1jeOG9giRO2+FsuyNipeQ43HAjqAZjwSe3SEf+q/84FGPHoso3kyntbxa4c4i77t3m6fGf8cw==}
-
   parse-path@7.1.0:
     resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
 
   parse-srcset@1.0.2:
     resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
-
-  parse-url@6.0.5:
-    resolution: {integrity: sha512-e35AeLTSIlkw/5GFq70IN7po8fmDUjpDPY1rIK+VubRfsUvBonjQ+PBZG+vWMACnQSmNlvl524IucoDmcioMxA==}
 
   parse-url@8.1.0:
     resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
@@ -10910,18 +10631,11 @@ packages:
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
-  pascalcase@0.1.1:
-    resolution: {integrity: sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==}
-    engines: {node: '>=0.10.0'}
-
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-case@3.0.4:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
-
-  path-dirname@1.0.2:
-    resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -11112,10 +10826,6 @@ packages:
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
-
-  posix-character-classes@0.1.1:
-    resolution: {integrity: sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==}
-    engines: {node: '>=0.10.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -11367,10 +11077,6 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prepend-http@2.0.0:
-    resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
-    engines: {node: '>=4'}
-
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
@@ -11460,9 +11166,6 @@ packages:
   protocol-buffers-schema@3.6.1:
     resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
 
-  protocols@1.4.8:
-    resolution: {integrity: sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==}
-
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
@@ -11503,10 +11206,6 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
-
-  query-string@5.1.1:
-    resolution: {integrity: sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==}
-    engines: {node: '>=0.10.0'}
 
   query-string@6.14.1:
     resolution: {integrity: sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==}
@@ -11925,10 +11624,6 @@ packages:
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
-  regex-not@1.0.2:
-    resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==}
-    engines: {node: '>=0.10.0'}
-
   regex-parser@2.3.1:
     resolution: {integrity: sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==}
 
@@ -12034,10 +11729,6 @@ packages:
   renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
 
-  repeat-element@1.1.4:
-    resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==}
-    engines: {node: '>=0.10.0'}
-
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
     engines: {node: '>=0.10'}
@@ -12108,9 +11799,6 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  responselike@1.0.2:
-    resolution: {integrity: sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==}
-
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
@@ -12121,10 +11809,6 @@ packages:
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
-
-  ret@0.1.15:
-    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
-    engines: {node: '>=0.12'}
 
   retext-english@3.0.4:
     resolution: {integrity: sha512-yr1PgaBDde+25aJXrnt3p1jvT8FVLVat2Bx8XeAWX13KXo8OT+3nWGU3HWxM4YFJvmfqvJYJZG2d7xxaO774gw==}
@@ -12146,11 +11830,6 @@ packages:
 
   rework@1.0.1:
     resolution: {integrity: sha512-eEjL8FdkdsxApd0yWVZgBGzfCQiT8yqSc2H1p4jpZpQdtz7ohETiDMoje5PlM8I9WgkqkreVxFUKYOiJdVWDXw==}
-
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -12218,9 +11897,6 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
-
-  safe-regex@1.1.0:
-    resolution: {integrity: sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -12375,10 +12051,6 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  set-value@2.0.1:
-    resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==}
-    engines: {node: '>=0.10.0'}
-
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
@@ -12458,9 +12130,6 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
-  simple-git@1.132.0:
-    resolution: {integrity: sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==}
 
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
@@ -12548,18 +12217,6 @@ packages:
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
-  snapdragon-node@2.1.1:
-    resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
-    engines: {node: '>=0.10.0'}
-
-  snapdragon-util@3.0.1:
-    resolution: {integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==}
-    engines: {node: '>=0.10.0'}
-
-  snapdragon@0.8.2:
-    resolution: {integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==}
-    engines: {node: '>=0.10.0'}
-
   socket.io-adapter@2.5.6:
     resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
@@ -12593,10 +12250,6 @@ packages:
   sort-desc@0.1.1:
     resolution: {integrity: sha512-jfZacW5SKOP97BF5rX5kQfJmRVZP5/adDUTY8fCSPvNcXDVpUEe2pr/iKGlcyZzchRJZrswnp68fgk3qBXgkJw==}
     engines: {node: '>=0.10.0'}
-
-  sort-keys@2.0.0:
-    resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
-    engines: {node: '>=4'}
 
   sort-object@0.3.2:
     resolution: {integrity: sha512-aAQiEdqFTTdsvUFxXm3umdo04J7MRljoVGbBlkH7BgNsMvVNAJyGj7C/wV1A8wHWAJj/YikeZbfuCKqhggNWGA==}
@@ -12658,10 +12311,6 @@ packages:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
 
-  split-string@3.1.0:
-    resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
-    engines: {node: '>=0.10.0'}
-
   split2@3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
 
@@ -12705,10 +12354,6 @@ packages:
   state-toggle@1.0.3:
     resolution: {integrity: sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==}
 
-  static-extend@0.1.2:
-    resolution: {integrity: sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==}
-    engines: {node: '>=0.10.0'}
-
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -12748,10 +12393,6 @@ packages:
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
-
-  strict-uri-encode@1.1.0:
-    resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
-    engines: {node: '>=0.10.0'}
 
   strict-uri-encode@2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
@@ -13043,10 +12684,6 @@ packages:
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
 
-  timed-out@4.0.1:
-    resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
-    engines: {node: '>=0.10.0'}
-
   timers-ext@0.1.8:
     resolution: {integrity: sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==}
     engines: {node: '>=0.12'}
@@ -13115,25 +12752,9 @@ packages:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
 
-  to-object-path@0.3.0:
-    resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
-    engines: {node: '>=0.10.0'}
-
-  to-readable-stream@1.0.0:
-    resolution: {integrity: sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==}
-    engines: {node: '>=6'}
-
-  to-regex-range@2.1.1:
-    resolution: {integrity: sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==}
-    engines: {node: '>=0.10.0'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  to-regex@3.0.2:
-    resolution: {integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==}
-    engines: {node: '>=0.10.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -13349,9 +12970,6 @@ packages:
   underscore.string@3.3.6:
     resolution: {integrity: sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==}
 
-  undici-types@7.21.0:
-    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
-
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -13391,10 +13009,6 @@ packages:
 
   unified@9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
-
-  union-value@1.0.1:
-    resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
-    engines: {node: '>=0.10.0'}
 
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -13469,10 +13083,6 @@ packages:
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
-  universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
-
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -13488,10 +13098,6 @@ packages:
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
-
-  unset-value@1.0.0:
-    resolution: {integrity: sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==}
-    engines: {node: '>=0.10.0'}
 
   upath@2.0.1:
     resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
@@ -13536,14 +13142,6 @@ packages:
     peerDependenciesMeta:
       file-loader:
         optional: true
-
-  url-parse-lax@3.0.0:
-    resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==}
-    engines: {node: '>=4'}
-
-  url-to-options@1.0.1:
-    resolution: {integrity: sha512-0kQLIzG4fdk/G5NONku64rSH/x32NOA39LVQqlK8Le6lvTF6GGRJpqaQFGgU+CLwySIqBSMdwYM0sYcW9f6P4A==}
-    engines: {node: '>= 4'}
 
   url@0.10.3:
     resolution: {integrity: sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==}
@@ -13607,10 +13205,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  use@3.1.1:
-    resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
-    engines: {node: '>=0.10.0'}
-
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
 
@@ -13648,11 +13242,6 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
@@ -15185,7 +14774,9 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@better-auth/cli@1.4.21(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260515.1)(@types/better-sqlite3@7.6.13)(better-call@1.3.5(zod@4.4.3))(drizzle-kit@0.31.10)(gel@2.2.0)(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)))':
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@better-auth/cli@1.4.21(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260515.1)(@types/better-sqlite3@7.6.13)(better-call@1.3.5(zod@4.4.3))(drizzle-kit@0.31.10)(gel@2.2.0)(jose@6.2.3)(kysely@0.28.17)(magicast@0.5.3)(nanostores@1.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
@@ -15199,7 +14790,7 @@ snapshots:
       '@types/pg': 8.20.0
       better-auth: 1.4.21(@prisma/client@5.22.0)(better-sqlite3@12.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.41.0(@cloudflare/workers-types@4.20260515.1)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(gel@2.2.0)(kysely@0.28.17)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)))
       better-sqlite3: 12.10.0
-      c12: 3.3.4
+      c12: 3.3.4(magicast@0.5.3)
       chalk: 5.6.2
       commander: 12.1.0
       dotenv: 17.4.2
@@ -17057,11 +16648,6 @@ snapshots:
       chevrotain: 10.5.0
       lilconfig: 2.1.0
 
-  '@mrmlnc/readdir-enhanced@2.2.1':
-    dependencies:
-      call-me-maybe: 1.0.2
-      glob-to-regexp: 0.3.0
-
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -17114,8 +16700,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@1.1.3': {}
 
   '@nodelib/fs.stat@2.0.5': {}
 
@@ -17343,6 +16927,8 @@ snapshots:
 
   '@octokit/openapi-types@24.2.0': {}
 
+  '@octokit/openapi-types@25.1.0': {}
+
   '@octokit/openapi-types@27.0.0': {}
 
   '@octokit/plugin-enterprise-rest@6.0.1': {}
@@ -17366,6 +16952,10 @@ snapshots:
       '@octokit/types': 13.10.0
       deprecation: 2.3.1
       once: 1.4.0
+
+  '@octokit/request-error@6.1.8':
+    dependencies:
+      '@octokit/types': 14.1.0
 
   '@octokit/request-error@7.1.0':
     dependencies:
@@ -17398,6 +16988,10 @@ snapshots:
   '@octokit/types@13.10.0':
     dependencies:
       '@octokit/openapi-types': 24.2.0
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
 
   '@octokit/types@16.0.0':
     dependencies:
@@ -18422,10 +18016,6 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
-  '@sindresorhus/is@0.14.0': {}
-
-  '@sindresorhus/is@0.7.0': {}
-
   '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/is@5.6.0': {}
@@ -18634,10 +18224,6 @@ snapshots:
       '@swc/legacy-helpers': '@swc/helpers@0.4.14'
       tslib: 2.8.1
 
-  '@szmarczak/http-timer@1.1.2':
-    dependencies:
-      defer-to-connect: 1.1.3
-
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -18733,7 +18319,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 25.7.0
+      '@types/node': 25.8.0
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -18851,10 +18437,6 @@ snapshots:
   '@types/node@16.9.1': {}
 
   '@types/node@17.0.45': {}
-
-  '@types/node@25.7.0':
-    dependencies:
-      undici-types: 7.21.0
 
   '@types/node@25.8.0':
     dependencies:
@@ -19094,6 +18676,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)
 
+  '@vitest/coverage-v8@4.1.7(vitest@4.1.6)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.7
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -19135,6 +18731,10 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
   '@vitest/runner@4.1.6':
     dependencies:
       '@vitest/utils': 4.1.6
@@ -19162,6 +18762,12 @@ snapshots:
   '@vitest/utils@4.1.6':
     dependencies:
       '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -19546,12 +19152,6 @@ snapshots:
 
   arity-n@1.0.4: {}
 
-  arr-diff@4.0.0: {}
-
-  arr-flatten@1.1.0: {}
-
-  arr-union@3.1.0: {}
-
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -19577,8 +19177,6 @@ snapshots:
   array-move@4.0.0: {}
 
   array-union@2.1.0: {}
-
-  array-unique@0.3.2: {}
 
   array.prototype.findlast@1.2.5:
     dependencies:
@@ -19645,13 +19243,17 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  assign-symbols@1.0.0: {}
-
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astral-regex@2.0.0: {}
 
@@ -19834,6 +19436,14 @@ snapshots:
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
 
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@babel/types': 7.29.0
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-core-utils: 4.16.0
+
   babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
@@ -19954,16 +19564,6 @@ snapshots:
 
   base64id@2.0.0: {}
 
-  base@0.11.2:
-    dependencies:
-      cache-base: 1.0.1
-      class-utils: 0.3.6
-      component-emitter: 1.3.1
-      define-property: 1.0.0
-      isobject: 3.0.1
-      mixin-deep: 1.3.2
-      pascalcase: 0.1.1
-
   baseline-browser-mapping@2.10.29: {}
 
   batch@0.6.1: {}
@@ -20080,14 +19680,6 @@ snapshots:
     dependencies:
       open: 7.4.2
 
-  better-queue-memory@1.0.4: {}
-
-  better-queue@3.8.12:
-    dependencies:
-      better-queue-memory: 1.0.4
-      node-eta: 0.9.0
-      uuid: 9.0.1
-
   better-sqlite3@12.10.0:
     dependencies:
       bindings: 1.5.0
@@ -20191,21 +19783,6 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  braces@2.3.2:
-    dependencies:
-      arr-flatten: 1.1.0
-      array-unique: 0.3.2
-      extend-shallow: 2.0.1
-      fill-range: 4.0.0
-      isobject: 3.0.1
-      repeat-element: 1.1.4
-      snapdragon: 0.8.2
-      snapdragon-node: 2.1.1
-      split-string: 3.1.0
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -20256,7 +19833,7 @@ snapshots:
 
   bytestreamjs@2.0.1: {}
 
-  c12@3.3.4:
+  c12@3.3.4(magicast@0.5.3):
     dependencies:
       chokidar: 5.0.0
       confbox: 0.2.4
@@ -20270,6 +19847,8 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       rc9: 3.0.1
+    optionalDependencies:
+      magicast: 0.5.3
 
   cacache@20.0.4:
     dependencies:
@@ -20283,18 +19862,6 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 7.0.4
       ssri: 13.0.1
-
-  cache-base@1.0.1:
-    dependencies:
-      collection-visit: 1.0.0
-      component-emitter: 1.3.1
-      get-value: 2.0.6
-      has-value: 1.0.0
-      isobject: 3.0.1
-      set-value: 2.0.1
-      to-object-path: 0.3.0
-      union-value: 1.0.1
-      unset-value: 1.0.0
 
   cache-manager@2.11.1:
     dependencies:
@@ -20315,26 +19882,6 @@ snapshots:
       mimic-response: 4.0.0
       normalize-url: 8.1.1
       responselike: 3.0.0
-
-  cacheable-request@2.1.4:
-    dependencies:
-      clone-response: 1.0.2
-      get-stream: 3.0.0
-      http-cache-semantics: 3.8.1
-      keyv: 3.0.0
-      lowercase-keys: 1.0.0
-      normalize-url: 2.0.1
-      responselike: 1.0.2
-
-  cacheable-request@6.1.0:
-    dependencies:
-      clone-response: 1.0.3
-      get-stream: 5.2.0
-      http-cache-semantics: 4.2.0
-      keyv: 3.1.0
-      lowercase-keys: 2.0.0
-      normalize-url: 4.5.1
-      responselike: 1.0.2
 
   cacheable-request@7.0.4:
     dependencies:
@@ -20362,8 +19909,6 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-
-  call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
 
@@ -20564,13 +20109,6 @@ snapshots:
 
   cjs-module-lexer@1.4.3: {}
 
-  class-utils@0.3.6:
-    dependencies:
-      arr-union: 3.1.0
-      define-property: 0.2.5
-      isobject: 3.0.1
-      static-extend: 0.1.2
-
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -20623,10 +20161,6 @@ snapshots:
       kind-of: 6.0.3
       shallow-clone: 3.0.1
 
-  clone-response@1.0.2:
-    dependencies:
-      mimic-response: 1.0.1
-
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
@@ -20646,11 +20180,6 @@ snapshots:
   codemirror@5.65.21: {}
 
   collapse-white-space@1.0.6: {}
-
-  collection-visit@1.0.0:
-    dependencies:
-      map-visit: 1.0.0
-      object-visit: 1.0.1
 
   color-convert@1.9.3:
     dependencies:
@@ -20713,8 +20242,6 @@ snapshots:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
-
-  component-emitter@1.3.1: {}
 
   compose-function@3.0.3:
     dependencies:
@@ -20858,8 +20385,6 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
-
-  copy-descriptor@0.1.1: {}
 
   core-js-compat@3.31.0:
     dependencies:
@@ -22321,10 +21846,6 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
-  decompress-response@3.3.0:
-    dependencies:
-      mimic-response: 1.0.1
-
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -22354,8 +21875,6 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
-  defer-to-connect@1.1.3: {}
-
   defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
@@ -22373,19 +21892,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  define-property@0.2.5:
-    dependencies:
-      is-descriptor: 0.1.7
-
-  define-property@1.0.0:
-    dependencies:
-      is-descriptor: 1.0.3
-
-  define-property@2.0.2:
-    dependencies:
-      is-descriptor: 1.0.3
-      isobject: 3.0.1
 
   defu@6.1.7: {}
 
@@ -22571,8 +22077,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  duplexer3@0.1.5: {}
 
   duplexer@0.1.2: {}
 
@@ -23251,18 +22755,6 @@ snapshots:
 
   exif-parser@0.1.12: {}
 
-  expand-brackets@2.1.4:
-    dependencies:
-      debug: 2.6.9
-      define-property: 0.2.5
-      extend-shallow: 2.0.1
-      posix-character-classes: 0.1.1
-      regex-not: 1.0.2
-      snapdragon: 0.8.2
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
@@ -23323,11 +22815,6 @@ snapshots:
     dependencies:
       is-extendable: 0.1.1
 
-  extend-shallow@3.0.2:
-    dependencies:
-      assign-symbols: 1.0.0
-      is-extendable: 1.0.1
-
   extend@3.0.2: {}
 
   external-editor@3.1.0:
@@ -23336,35 +22823,11 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
-  extglob@2.0.4:
-    dependencies:
-      array-unique: 0.3.2
-      define-property: 1.0.0
-      expand-brackets: 2.1.4
-      extend-shallow: 2.0.1
-      fragment-cache: 0.2.1
-      regex-not: 1.0.2
-      snapdragon: 0.8.2
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
-
-  fast-glob@2.2.7:
-    dependencies:
-      '@mrmlnc/readdir-enhanced': 2.2.1
-      '@nodelib/fs.stat': 1.1.3
-      glob-parent: 3.1.0
-      is-glob: 4.0.3
-      merge2: 1.4.1
-      micromatch: 3.1.10
-    transitivePeerDependencies:
-      - supports-color
 
   fast-glob@3.3.3:
     dependencies:
@@ -23444,13 +22907,6 @@ snapshots:
 
   filesize@8.0.7: {}
 
-  fill-range@4.0.0:
-    dependencies:
-      extend-shallow: 2.0.1
-      is-number: 3.0.0
-      repeat-string: 1.6.1
-      to-regex-range: 2.1.1
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -23517,8 +22973,6 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  for-in@1.0.2: {}
-
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -23575,16 +23029,7 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  fragment-cache@0.2.1:
-    dependencies:
-      map-cache: 0.2.2
-
   fresh@0.5.2: {}
-
-  from2@2.3.0:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 2.3.8
 
   fs-constants@1.0.0: {}
 
@@ -23601,18 +23046,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-
-  fs-extra@5.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-
-  fs-extra@8.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
 
   fs-extra@9.1.0:
     dependencies:
@@ -23694,17 +23127,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  gatsby-core-utils@1.10.1:
-    dependencies:
-      ci-info: 2.0.0
-      configstore: 5.0.1
-      fs-extra: 8.1.0
-      got: 8.3.2
-      node-object-hash: 2.3.10
-      proper-lockfile: 4.1.2
-      tmp: 0.2.5
-      xdg-basedir: 4.0.0
 
   gatsby-core-utils@4.16.0:
     dependencies:
@@ -23815,6 +23237,27 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@babel/traverse': 7.29.0
+      '@sindresorhus/slugify': 1.1.2
+      chokidar: 3.6.0
+      fs-exists-cached: 1.0.0
+      fs-extra: 11.3.5
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-core-utils: 4.16.0
+      gatsby-page-utils: 3.16.0
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      globby: 11.1.0
+      lodash: 4.18.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - graphql
+      - react-native-b4a
+      - supports-color
+
   gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -23872,6 +23315,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/runtime': 7.29.2
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+    transitivePeerDependencies:
+      - supports-color
+
   gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
@@ -23891,6 +23347,24 @@ snapshots:
       fastq: 1.20.1
       fs-extra: 11.3.5
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-core-utils: 4.16.0
+      gatsby-sharp: 1.16.0
+      graphql: 16.14.0
+      graphql-compose: 9.1.0(graphql@16.14.0)
+      import-from: 4.0.0
+      joi: 17.13.3
+      mime: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      fastq: 1.20.1
+      fs-extra: 11.3.5
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.14.0
@@ -23998,23 +23472,6 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  gatsby-source-filesystem@2.11.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      better-queue: 3.8.12
-      chokidar: 3.6.0
-      file-type: 16.5.4
-      fs-extra: 8.1.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
-      gatsby-core-utils: 1.10.1
-      got: 9.6.0
-      md5-file: 5.0.0
-      mime: 2.6.0
-      pretty-bytes: 5.6.0
-      progress: 2.0.3
-      valid-url: 1.0.9
-      xstate: 4.38.3
-
   gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -24028,17 +23485,18 @@ snapshots:
       valid-url: 1.0.9
       xstate: 4.38.3
 
-  gatsby-source-git@1.1.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
+  gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
-      fast-glob: 2.2.7
-      fs-extra: 5.0.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
-      gatsby-source-filesystem: 2.11.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
-      git-url-parse: 11.6.0
-      rimraf: 2.7.1
-      simple-git: 1.132.0
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/runtime': 7.29.2
+      chokidar: 3.6.0
+      file-type: 16.5.4
+      fs-extra: 11.3.5
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-core-utils: 4.16.0
+      mime: 3.0.0
+      pretty-bytes: 5.6.0
+      valid-url: 1.0.9
+      xstate: 4.38.3
 
   gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
@@ -24220,6 +23678,212 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
       react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@18.3.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      redux: 4.2.1
+      redux-thunk: 2.4.2(redux@4.2.1)
+      resolve-from: 5.0.0
+      semver: 7.8.0
+      shallow-compare: 1.2.2
+      signal-exit: 3.0.7
+      slugify: 1.6.9
+      socket.io: 4.8.3
+      socket.io-client: 4.8.3
+      stack-trace: 0.0.10
+      string-similarity: 1.2.2
+      strip-ansi: 6.0.1
+      style-loader: 2.0.0(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      style-to-object: 0.4.4
+      terser-webpack-plugin: 5.6.0(esbuild@0.28.0)(postcss@8.5.14)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      tmp: 0.2.5
+      true-case-path: 2.2.1
+      type-of: 2.0.1
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14)))(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      uuid: 8.3.2
+      webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.14)
+      webpack-dev-middleware: 5.3.4(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      webpack-merge: 5.10.0
+      webpack-stats-plugin: 1.1.3
+      webpack-virtual-modules: 0.6.2
+      xstate: 4.38.3
+      yaml-loader: 0.8.1
+    optionalDependencies:
+      gatsby-sharp: 1.16.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - '@types/webpack'
+      - babel-eslint
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - clean-css
+      - cssnano
+      - csso
+      - encoding
+      - esbuild
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - eslint-plugin-jest
+      - eslint-plugin-testing-library
+      - html-minifier-terser
+      - lightningcss
+      - react-native-b4a
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@7.32.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/parser': 7.29.3
+      '@babel/runtime': 7.29.2
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@builder.io/partytown': 0.7.6
+      '@expo/devcert': 1.2.1
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@gatsbyjs/webpack-hot-middleware': 2.25.3
+      '@graphql-codegen/add': 3.2.3(graphql@16.14.0)
+      '@graphql-codegen/core': 2.6.8(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@16.14.0)
+      '@graphql-codegen/typescript': 2.8.8(encoding@0.1.13)(graphql@16.14.0)
+      '@graphql-codegen/typescript-operations': 2.5.13(encoding@0.1.13)(graphql@16.14.0)
+      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.0)(graphql@16.14.0)
+      '@graphql-tools/load': 7.8.14(graphql@16.14.0)
+      '@jridgewell/trace-mapping': 0.3.31
+      '@nodelib/fs.walk': 1.2.8
+      '@parcel/cache': 2.8.3(@parcel/core@2.8.3)
+      '@parcel/core': 2.8.3
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      '@sigmacomputing/babel-plugin-lodash': 3.3.5
+      '@types/http-proxy': 1.17.17
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@vercel/webpack-asset-relocator-loader': 1.7.3
+      acorn-loose: 8.5.2
+      acorn-walk: 8.3.5
+      address: 1.2.2
+      anser: 2.3.5
+      autoprefixer: 10.5.0(postcss@8.5.14)
+      axios: 1.16.0(debug@4.4.3)
+      babel-jsx-utils: 1.1.0
+      babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      babel-plugin-add-module-exports: 1.0.4
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
+      better-opn: 2.1.1
+      bluebird: 3.7.2
+      body-parser: 2.2.2
+      browserslist: 4.28.2
+      cache-manager: 2.11.1
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      common-tags: 1.8.2
+      compression: 1.8.1
+      cookie: 0.5.0
+      core-js: 3.49.0
+      cors: 2.8.6
+      css-loader: 5.2.7(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      css-minimizer-webpack-plugin: 2.0.0(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      css.escape: 1.5.1
+      date-fns: 2.30.0
+      debug: 4.4.3
+      deepmerge: 4.3.1
+      detect-port: 1.6.1
+      dotenv: 8.6.0
+      enhanced-resolve: 5.21.2
+      error-stack-parser: 2.1.4
+      eslint: 7.32.0
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
+      eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
+      eslint-plugin-react: 7.37.5(eslint@7.32.0)
+      eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
+      eslint-webpack-plugin: 2.7.0(eslint@7.32.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      event-source-polyfill: 1.0.31
+      execa: 5.1.1
+      express: 4.22.2
+      express-http-proxy: 1.6.3
+      fastest-levenshtein: 1.0.16
+      fastq: 1.20.1
+      file-loader: 6.2.0(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      find-cache-dir: 3.3.2
+      fs-exists-cached: 1.0.0
+      fs-extra: 11.3.5
+      gatsby-cli: 5.16.0(encoding@0.1.13)
+      gatsby-core-utils: 4.16.0
+      gatsby-graphiql-explorer: 3.16.0
+      gatsby-legacy-polyfills: 3.16.0
+      gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      gatsby-page-utils: 3.16.0
+      gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      gatsby-worker: 2.16.0
+      glob: 7.2.3
+      globby: 11.1.0
+      got: 11.8.6
+      graphql: 16.14.0
+      graphql-compose: 9.1.0(graphql@16.14.0)
+      graphql-http: 1.22.4(graphql@16.14.0)
+      graphql-tag: 2.12.6(graphql@16.14.0)
+      hasha: 5.2.2
+      invariant: 2.2.4
+      is-relative: 1.0.0
+      is-relative-url: 3.0.0
+      joi: 17.13.3
+      json-loader: 0.5.7
+      latest-version: 7.0.0
+      linkfs: 2.1.0
+      lmdb: 2.5.3
+      lodash: 4.18.1
+      meant: 1.0.3
+      memoizee: 0.4.17
+      micromatch: 4.0.8
+      mime: 3.0.0
+      mini-css-extract-plugin: 1.6.2(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      mitt: 1.2.0
+      moment: 2.30.1
+      multer: 2.1.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      node-html-parser: 5.4.2
+      normalize-path: 3.0.0
+      null-loader: 4.0.1(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      opentracing: 0.14.7
+      p-defer: 3.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      physical-cpu-count: 2.0.0
+      platform: 1.3.6
+      postcss: 8.5.14
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.5.14)
+      postcss-loader: 5.3.0(postcss@8.5.14)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      prompts: 2.4.2
+      prop-types: 15.8.1
+      query-string: 6.14.1
+      raw-loader: 4.0.2(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      react: 19.2.6
+      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
+      react-dom: 19.2.6(react@19.2.6)
+      react-refresh: 0.14.2
+      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@19.2.6)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
       redux: 4.2.1
       redux-thunk: 2.4.2(redux@4.2.1)
       resolve-from: 5.0.0
@@ -24542,12 +24206,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@3.0.0: {}
-
-  get-stream@4.1.0:
-    dependencies:
-      pump: 3.0.4
-
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.4
@@ -24567,8 +24225,6 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  get-value@2.0.6: {}
 
   get-video-id@3.7.0: {}
 
@@ -24595,19 +24251,10 @@ snapshots:
       meow: 8.1.2
       semver: 7.8.1
 
-  git-up@4.0.5:
-    dependencies:
-      is-ssh: 1.4.1
-      parse-url: 6.0.5
-
   git-up@7.0.0:
     dependencies:
       is-ssh: 1.4.1
       parse-url: 8.1.0
-
-  git-url-parse@11.6.0:
-    dependencies:
-      git-up: 4.0.5
 
   git-url-parse@14.0.0:
     dependencies:
@@ -24621,11 +24268,6 @@ snapshots:
 
   github-slugger@1.5.0: {}
 
-  glob-parent@3.1.0:
-    dependencies:
-      is-glob: 3.1.0
-      path-dirname: 1.0.2
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -24637,8 +24279,6 @@ snapshots:
   glob-to-regex.js@1.2.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
-
-  glob-to-regexp@0.3.0: {}
 
   glob-to-regexp@0.4.1: {}
 
@@ -24729,44 +24369,6 @@ snapshots:
       p-cancelable: 3.0.0
       responselike: 3.0.0
 
-  got@8.3.2:
-    dependencies:
-      '@sindresorhus/is': 0.7.0
-      '@types/keyv': 3.1.4
-      '@types/responselike': 1.0.3
-      cacheable-request: 2.1.4
-      decompress-response: 3.3.0
-      duplexer3: 0.1.5
-      get-stream: 3.0.0
-      into-stream: 3.1.0
-      is-retry-allowed: 1.2.0
-      isurl: 1.0.0
-      lowercase-keys: 1.0.1
-      mimic-response: 1.0.1
-      p-cancelable: 0.4.1
-      p-timeout: 2.0.1
-      pify: 3.0.0
-      safe-buffer: 5.2.1
-      timed-out: 4.0.1
-      url-parse-lax: 3.0.0
-      url-to-options: 1.0.1
-
-  got@9.6.0:
-    dependencies:
-      '@sindresorhus/is': 0.14.0
-      '@szmarczak/http-timer': 1.1.2
-      '@types/keyv': 3.1.4
-      '@types/responselike': 1.0.3
-      cacheable-request: 6.1.0
-      decompress-response: 3.3.0
-      duplexer3: 0.1.5
-      get-stream: 4.1.0
-      lowercase-keys: 1.0.1
-      mimic-response: 1.0.1
-      p-cancelable: 1.1.0
-      to-readable-stream: 1.0.0
-      url-parse-lax: 3.0.0
-
   gotrue-js@0.9.29:
     dependencies:
       micro-api-client: 3.3.0
@@ -24844,38 +24446,13 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
 
-  has-symbol-support-x@1.4.2: {}
-
   has-symbols@1.1.0: {}
-
-  has-to-string-tag-x@1.4.1:
-    dependencies:
-      has-symbol-support-x: 1.4.2
 
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
 
   has-unicode@2.0.1: {}
-
-  has-value@0.3.1:
-    dependencies:
-      get-value: 2.0.6
-      has-values: 0.1.4
-      isobject: 2.1.0
-
-  has-value@1.0.0:
-    dependencies:
-      get-value: 2.0.6
-      has-values: 1.0.0
-      isobject: 3.0.1
-
-  has-values@0.1.4: {}
-
-  has-values@1.0.0:
-    dependencies:
-      is-number: 3.0.0
-      kind-of: 4.0.0
 
   hash-wasm@4.12.0: {}
 
@@ -25059,6 +24636,8 @@ snapshots:
 
   html-entities@2.6.0: {}
 
+  html-escaper@2.0.2: {}
+
   html-escaper@3.0.3: {}
 
   html-minifier-terser@6.1.0:
@@ -25106,8 +24685,6 @@ snapshots:
       domhandler: 4.3.1
       domutils: 2.8.0
       entities: 2.2.0
-
-  http-cache-semantics@3.8.1: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -25322,11 +24899,6 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  into-stream@3.1.0:
-    dependencies:
-      from2: 2.3.0
-      p-is-promise: 1.1.0
-
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -25343,10 +24915,6 @@ snapshots:
     dependencies:
       is-relative: 1.0.0
       is-windows: 1.0.2
-
-  is-accessor-descriptor@1.0.1:
-    dependencies:
-      hasown: 2.0.3
 
   is-alphabetical@1.0.4: {}
 
@@ -25393,8 +24961,6 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  is-buffer@1.1.6: {}
-
   is-buffer@2.0.5: {}
 
   is-callable@1.2.7: {}
@@ -25411,10 +24977,6 @@ snapshots:
     dependencies:
       hasown: 2.0.3
 
-  is-data-descriptor@1.0.1:
-    dependencies:
-      hasown: 2.0.3
-
   is-data-view@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -25428,25 +24990,11 @@ snapshots:
 
   is-decimal@1.0.4: {}
 
-  is-descriptor@0.1.7:
-    dependencies:
-      is-accessor-descriptor: 1.0.1
-      is-data-descriptor: 1.0.1
-
-  is-descriptor@1.0.3:
-    dependencies:
-      is-accessor-descriptor: 1.0.1
-      is-data-descriptor: 1.0.1
-
   is-docker@2.2.1: {}
 
   is-docker@3.0.0: {}
 
   is-extendable@0.1.1: {}
-
-  is-extendable@1.0.1:
-    dependencies:
-      is-plain-object: 2.0.4
 
   is-extglob@1.0.0: {}
 
@@ -25471,10 +25019,6 @@ snapshots:
   is-glob@2.0.1:
     dependencies:
       is-extglob: 1.0.0
-
-  is-glob@3.1.0:
-    dependencies:
-      is-extglob: 2.1.1
 
   is-glob@4.0.3:
     dependencies:
@@ -25509,15 +25053,9 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  is-number@3.0.0:
-    dependencies:
-      kind-of: 3.2.2
-
   is-number@7.0.0: {}
 
   is-obj@2.0.0: {}
-
-  is-object@1.0.2: {}
 
   is-plain-obj@1.1.0: {}
 
@@ -25549,8 +25087,6 @@ snapshots:
   is-relative@1.0.0:
     dependencies:
       is-unc-path: 1.0.0
-
-  is-retry-allowed@1.2.0: {}
 
   is-root@2.1.0: {}
 
@@ -25646,18 +25182,22 @@ snapshots:
 
   isexe@4.0.0: {}
 
-  isobject@2.1.0:
-    dependencies:
-      isarray: 1.0.0
-
   isobject@3.0.1: {}
 
   isomorphic-base64@1.0.2: {}
 
-  isurl@1.0.0:
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
     dependencies:
-      has-to-string-tag-x: 1.4.1
-      is-object: 1.0.2
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -25754,6 +25294,8 @@ snapshots:
 
   js-sha256@0.9.0: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -25793,8 +25335,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-buffer@3.0.0: {}
-
   json-buffer@3.0.1: {}
 
   json-loader@0.5.7: {}
@@ -25829,10 +25369,6 @@ snapshots:
 
   jsonc-parser@3.2.0: {}
 
-  jsonfile@4.0.0:
-    optionalDependencies:
-      graceful-fs: 4.2.11
-
   jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
@@ -25854,25 +25390,9 @@ snapshots:
 
   jwt-decode@3.1.2: {}
 
-  keyv@3.0.0:
-    dependencies:
-      json-buffer: 3.0.0
-
-  keyv@3.1.0:
-    dependencies:
-      json-buffer: 3.0.0
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  kind-of@3.2.2:
-    dependencies:
-      is-buffer: 1.1.6
-
-  kind-of@4.0.0:
-    dependencies:
-      is-buffer: 1.1.6
 
   kind-of@6.0.3: {}
 
@@ -26223,10 +25743,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  lowercase-keys@1.0.0: {}
-
-  lowercase-keys@1.0.1: {}
-
   lowercase-keys@2.0.0: {}
 
   lowercase-keys@3.0.0: {}
@@ -26266,9 +25782,19 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.1
 
   make-error@1.3.6: {}
 
@@ -26311,10 +25837,6 @@ snapshots:
 
   map-obj@4.3.0: {}
 
-  map-visit@1.0.0:
-    dependencies:
-      object-visit: 1.0.1
-
   mapbox-to-css-font@2.4.5: {}
 
   markdown-escapes@1.0.4: {}
@@ -26328,8 +25850,6 @@ snapshots:
   material-colors@1.2.6: {}
 
   math-intrinsics@1.1.0: {}
-
-  md5-file@5.0.0: {}
 
   mdast-util-compact@1.0.4:
     dependencies:
@@ -26626,24 +26146,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  micromatch@3.1.10:
-    dependencies:
-      arr-diff: 4.0.0
-      array-unique: 0.3.2
-      braces: 2.3.2
-      define-property: 2.0.2
-      extend-shallow: 3.0.2
-      extglob: 2.0.4
-      fragment-cache: 0.2.1
-      kind-of: 6.0.3
-      nanomatch: 1.2.13
-      object.pick: 1.3.0
-      regex-not: 1.0.2
-      snapdragon: 0.8.2
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -26668,8 +26170,6 @@ snapshots:
       mime-db: 1.54.0
 
   mime@1.6.0: {}
-
-  mime@2.6.0: {}
 
   mime@3.0.0: {}
 
@@ -26786,11 +26286,6 @@ snapshots:
 
   mitt@1.2.0: {}
 
-  mixin-deep@1.3.2:
-    dependencies:
-      for-in: 1.0.2
-      is-extendable: 1.0.1
-
   mkdirp-classic@0.5.3: {}
 
   mkdirp@0.5.6:
@@ -26845,22 +26340,6 @@ snapshots:
 
   nanoid@5.1.11: {}
 
-  nanomatch@1.2.13:
-    dependencies:
-      arr-diff: 4.0.0
-      array-unique: 0.3.2
-      define-property: 2.0.2
-      extend-shallow: 3.0.2
-      fragment-cache: 0.2.1
-      is-windows: 1.0.2
-      kind-of: 6.0.3
-      object.pick: 1.3.0
-      regex-not: 1.0.2
-      snapdragon: 0.8.2
-      to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   nanostores@1.3.0: {}
 
   napi-build-utils@2.0.0: {}
@@ -26899,8 +26378,6 @@ snapshots:
   node-addon-api@6.1.0: {}
 
   node-addon-api@7.1.1: {}
-
-  node-eta@0.9.0: {}
 
   node-exports-info@1.6.0:
     dependencies:
@@ -26979,14 +26456,6 @@ snapshots:
       remove-trailing-separator: 1.1.0
 
   normalize-path@3.0.0: {}
-
-  normalize-url@2.0.1:
-    dependencies:
-      prepend-http: 2.0.0
-      query-string: 5.1.1
-      sort-keys: 2.0.0
-
-  normalize-url@4.5.1: {}
 
   normalize-url@6.1.0: {}
 
@@ -27220,19 +26689,9 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  object-copy@0.1.0:
-    dependencies:
-      copy-descriptor: 0.1.1
-      define-property: 0.2.5
-      kind-of: 3.2.2
-
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
-
-  object-visit@1.0.1:
-    dependencies:
-      isobject: 3.0.1
 
   object.assign@4.1.7:
     dependencies:
@@ -27262,10 +26721,6 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.2
-
-  object.pick@1.3.0:
-    dependencies:
-      isobject: 3.0.1
 
   object.values@1.2.1:
     dependencies:
@@ -27423,10 +26878,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  p-cancelable@0.4.1: {}
-
-  p-cancelable@1.1.0: {}
-
   p-cancelable@2.1.1: {}
 
   p-cancelable@3.0.0: {}
@@ -27434,8 +26885,6 @@ snapshots:
   p-defer@3.0.0: {}
 
   p-finally@1.0.0: {}
-
-  p-is-promise@1.1.0: {}
 
   p-limit@1.3.0:
     dependencies:
@@ -27487,10 +26936,6 @@ snapshots:
       '@types/retry': 0.12.2
       is-network-error: 1.3.2
       retry: 0.13.1
-
-  p-timeout@2.0.1:
-    dependencies:
-      p-finally: 1.0.0
 
   p-timeout@3.2.0:
     dependencies:
@@ -27638,25 +27083,11 @@ snapshots:
 
   parse-numeric-range@1.3.0: {}
 
-  parse-path@4.0.4:
-    dependencies:
-      is-ssh: 1.4.1
-      protocols: 1.4.8
-      qs: 6.15.2
-      query-string: 6.14.1
-
   parse-path@7.1.0:
     dependencies:
       protocols: 2.0.2
 
   parse-srcset@1.0.2: {}
-
-  parse-url@6.0.5:
-    dependencies:
-      is-ssh: 1.4.1
-      normalize-url: 6.1.0
-      parse-path: 4.0.4
-      protocols: 1.4.8
 
   parse-url@8.1.0:
     dependencies:
@@ -27690,16 +27121,12 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
 
-  pascalcase@0.1.1: {}
-
   path-browserify@1.0.1: {}
 
   path-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
-
-  path-dirname@1.0.2: {}
 
   path-exists@3.0.0: {}
 
@@ -27887,8 +27314,6 @@ snapshots:
   platform@1.3.6: {}
 
   pngjs@3.4.0: {}
-
-  posix-character-classes@0.1.1: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -28130,8 +27555,6 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prepend-http@2.0.0: {}
-
   prettier@3.8.3: {}
 
   pretty-bytes@5.6.0: {}
@@ -28217,8 +27640,6 @@ snapshots:
 
   protocol-buffers-schema@3.6.1: {}
 
-  protocols@1.4.8: {}
-
   protocols@2.0.2: {}
 
   proxy-addr@2.0.7:
@@ -28252,12 +27673,6 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
-
-  query-string@5.1.1:
-    dependencies:
-      decode-uri-component: 0.2.2
-      object-assign: 4.1.1
-      strict-uri-encode: 1.1.0
 
   query-string@6.14.1:
     dependencies:
@@ -29060,11 +28475,6 @@ snapshots:
 
   regenerator-runtime@0.13.11: {}
 
-  regex-not@1.0.2:
-    dependencies:
-      extend-shallow: 3.0.2
-      safe-regex: 1.1.0
-
   regex-parser@2.3.1: {}
 
   regexp-to-ast@0.5.0: {}
@@ -29254,8 +28664,6 @@ snapshots:
       lodash: 4.18.1
       strip-ansi: 6.0.1
 
-  repeat-element@1.1.4: {}
-
   repeat-string@1.6.1: {}
 
   require-directory@2.1.1: {}
@@ -29321,10 +28729,6 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  responselike@1.0.2:
-    dependencies:
-      lowercase-keys: 1.0.1
-
   responselike@2.0.1:
     dependencies:
       lowercase-keys: 2.0.0
@@ -29337,8 +28741,6 @@ snapshots:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-
-  ret@0.1.15: {}
 
   retext-english@3.0.4:
     dependencies:
@@ -29357,10 +28759,6 @@ snapshots:
     dependencies:
       convert-source-map: 0.3.5
       css: 2.2.4
-
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
 
   rimraf@3.0.2:
     dependencies:
@@ -29473,10 +28871,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
-
-  safe-regex@1.1.0:
-    dependencies:
-      ret: 0.1.15
 
   safer-buffer@2.1.2: {}
 
@@ -29662,13 +29056,6 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  set-value@2.0.1:
-    dependencies:
-      extend-shallow: 2.0.1
-      is-extendable: 0.1.1
-      is-plain-object: 2.0.4
-      split-string: 3.1.0
-
   setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
@@ -29794,12 +29181,6 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
-  simple-git@1.132.0:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   simple-swizzle@0.2.4:
     dependencies:
       is-arrayish: 0.3.4
@@ -29909,29 +29290,6 @@ snapshots:
       dot-case: 3.0.4
       tslib: 2.8.1
 
-  snapdragon-node@2.1.1:
-    dependencies:
-      define-property: 1.0.0
-      isobject: 3.0.1
-      snapdragon-util: 3.0.1
-
-  snapdragon-util@3.0.1:
-    dependencies:
-      kind-of: 3.2.2
-
-  snapdragon@0.8.2:
-    dependencies:
-      base: 0.11.2
-      debug: 2.6.9
-      define-property: 0.2.5
-      extend-shallow: 2.0.1
-      map-cache: 0.2.2
-      source-map: 0.5.7
-      source-map-resolve: 0.5.3
-      use: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3
@@ -29995,10 +29353,6 @@ snapshots:
   sort-asc@0.1.0: {}
 
   sort-desc@0.1.1: {}
-
-  sort-keys@2.0.0:
-    dependencies:
-      is-plain-obj: 1.1.0
 
   sort-object@0.3.2:
     dependencies:
@@ -30069,10 +29423,6 @@ snapshots:
 
   split-on-first@1.1.0: {}
 
-  split-string@3.1.0:
-    dependencies:
-      extend-shallow: 3.0.2
-
   split2@3.2.2:
     dependencies:
       readable-stream: 3.6.2
@@ -30108,11 +29458,6 @@ snapshots:
   stackframe@1.3.4: {}
 
   state-toggle@1.0.3: {}
-
-  static-extend@0.1.2:
-    dependencies:
-      define-property: 0.2.5
-      object-copy: 0.1.0
 
   statuses@1.5.0: {}
 
@@ -30169,8 +29514,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-
-  strict-uri-encode@1.1.0: {}
 
   strict-uri-encode@2.0.0: {}
 
@@ -30511,8 +29854,6 @@ snapshots:
 
   thunky@1.1.0: {}
 
-  timed-out@4.0.1: {}
-
   timers-ext@0.1.8:
     dependencies:
       es5-ext: 0.10.64
@@ -30566,27 +29907,9 @@ snapshots:
 
   tmp@0.2.5: {}
 
-  to-object-path@0.3.0:
-    dependencies:
-      kind-of: 3.2.2
-
-  to-readable-stream@1.0.0: {}
-
-  to-regex-range@2.1.1:
-    dependencies:
-      is-number: 3.0.0
-      repeat-string: 1.6.1
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  to-regex@3.0.2:
-    dependencies:
-      define-property: 2.0.2
-      extend-shallow: 3.0.2
-      regex-not: 1.0.2
-      safe-regex: 1.1.0
 
   toidentifier@1.0.1: {}
 
@@ -30797,8 +30120,6 @@ snapshots:
       sprintf-js: 1.1.3
       util-deprecate: 1.0.2
 
-  undici-types@7.21.0: {}
-
   undici-types@7.24.6: {}
 
   undici@6.25.0: {}
@@ -30836,13 +30157,6 @@ snapshots:
       is-plain-obj: 2.1.0
       trough: 1.0.5
       vfile: 4.2.1
-
-  union-value@1.0.1:
-    dependencies:
-      arr-union: 3.1.0
-      get-value: 2.0.6
-      is-extendable: 0.1.1
-      set-value: 2.0.1
 
   unique-string@2.0.0:
     dependencies:
@@ -30934,8 +30248,6 @@ snapshots:
 
   universal-user-agent@7.0.3: {}
 
-  universalify@0.1.2: {}
-
   universalify@2.0.1: {}
 
   unixify@1.0.0:
@@ -30950,11 +30262,6 @@ snapshots:
       acorn: 8.16.0
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
-
-  unset-value@1.0.0:
-    dependencies:
-      has-value: 0.3.1
-      isobject: 3.0.1
 
   upath@2.0.1: {}
 
@@ -30998,12 +30305,6 @@ snapshots:
       webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.14)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.14))
-
-  url-parse-lax@3.0.0:
-    dependencies:
-      prepend-http: 2.0.0
-
-  url-to-options@1.0.1: {}
 
   url@0.10.3:
     dependencies:
@@ -31089,8 +30390,6 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  use@3.1.1: {}
-
   utf8-byte-length@1.0.5: {}
 
   utif@2.0.1:
@@ -31122,8 +30421,6 @@ snapshots:
   uuid@8.0.0: {}
 
   uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -31194,7 +30491,7 @@ snapshots:
       tsx: 4.22.1
       yaml: 2.8.4
 
-  vitest@4.1.6(@types/node@25.8.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)):
+  vitest@4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
@@ -31218,6 +30515,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.8.0
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.6)
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw

--- a/services/personal-website/gatsby-config.ts
+++ b/services/personal-website/gatsby-config.ts
@@ -11,21 +11,15 @@ const config: GatsbyConfig = {
   trailingSlash: "never",
   plugins: [
     {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: "null",
-        path: `${__dirname}`,
-        ignore: [/.*/gi],
-      },
-    },
-
-    {
-      resolve: `gatsby-source-git`,
+      resolve: `gatsby-source-github-repository`,
       options: {
         name: `posts`,
-        remote: `https://alexwilson:${process.env.GITHUB_TOKEN}@github.com/alexwilson/content.git`,
-        branch: `main`,
+        owner: `alexwilson`,
+        repo: `content`,
+        ref: `main`,
         patterns: [`posts/**`],
+        token: process.env.GITHUB_TOKEN,
+        pollInterval: process.env.NODE_ENV === `development` ? 30 : 0,
       },
     },
 

--- a/services/personal-website/package.json
+++ b/services/personal-website/package.json
@@ -38,7 +38,7 @@
     "gatsby-remark-prismjs": "7.16.0",
     "gatsby-remark-twitter-cards": "0.6.1",
     "gatsby-source-filesystem": "5.16.0",
-    "gatsby-source-git": "1.1.0",
+    "gatsby-source-github-repository": "workspace:*",
     "gatsby-transformer-remark": "6.16.0",
     "prismjs": "1.30.0",
     "prop-types": "15.8.1",


### PR DESCRIPTION
# Why?

`gatsby-source-git` clones the whole content repo on every build, and it's slow + brittle.

The REST API path gives us blob-SHA caching (immutable, so cached files never get re-fetched), ETag-short-circuited polling (304s don't count toward the rate limit), and optional GitHub App auth through a `token` callback.

Breaking: drops `gatsby-source-git` from `services/personal-website`. The existing `GITHUB_TOKEN` in CI already works.

# What?

New TypeScript plugin at `libraries/gatsby-source-github-repository`. It emits standard `File` nodes, so the existing transformer stack (remark, twitter-cards, and friends) works unchanged. Polls upstream during `gatsby develop`, fans out blob fetches on cold builds, retries on 429/403, and prints remaining rate-limit budget on each pass.

Swapped `services/personal-website` over.