### PR TITLE
Cloudflare: Explicitly set redirect priority

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,9 +25,11 @@ module "cloudflare_antoligycom" {
   redirect_rules = [{
     target     = "www.antoligy.com/*"
     forward_to = "https://ax.gy/$1"
+    priority   = 1
     }, {
     target     = "antoligy.com/*"
     forward_to = "https://ax.gy/$1"
+    priority   = 2
   }]
 }
 
@@ -39,8 +41,10 @@ module "cloudflare_axgy" {
   redirect_rules = [{
     target     = "www.ax.gy/*"
     forward_to = "https://alexwilson.tech/$1"
+    priority   = 1
     }, {
     target     = "ax.gy/*"
     forward_to = "https://alexwilson.tech/$1"
+    priority   = 2
   }]
 }

--- a/terraform/modules/cloudflare/main.tf
+++ b/terraform/modules/cloudflare/main.tf
@@ -16,6 +16,7 @@ resource "cloudflare_page_rule" "rules" {
   for_each = { for rule in var.redirect_rules : rule.target => rule }
   zone_id  = cloudflare_zone.zone.id
   target   = each.value.target
+  priority = each.value.priority
   actions {
     forwarding_url {
       url         = each.value.forward_to

--- a/terraform/modules/cloudflare/variables.tf
+++ b/terraform/modules/cloudflare/variables.tf
@@ -14,5 +14,6 @@ variable "redirect_rules" {
   type = list(object({
     target     = string
     forward_to = string
+    priority   = number
   }))
 }


### PR DESCRIPTION
# Why?
There's permanent drift in my Cloudflare terraform module because all redirects share the same priority.

# What?
Explicitly set the priority of redirects.
