### PR TITLE
build personal-website via github app

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -40,10 +40,19 @@ jobs:
       - uses: ./.github/actions/setup-monorepo
         with:
           install-filter: '@alexwilson/personal-website...'
+      - name: Mint content read token
+        id: content-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.BLOG_CONTENT_READ_CLIENT_ID }}
+          private-key: ${{ secrets.BLOG_CONTENT_READ_PRIVATE_KEY }}
+          owner: alexwilson
+          repositories: content
+          permission-contents: read
       - name: Build
         run: pnpm --filter @alexwilson/personal-website run build
         env:
-          GITHUB_TOKEN: ${{ secrets.CONTENT_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.content-token.outputs.token }}
           CI: true
       - name: Save Build Artefact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
# Why?
Currently we use a PAT for downloading content from the content repository.

# What?
Switch to using a scoped github app instead, and generating a short-lived token.