### PR TITLE
fix(gatsby-remark-rewrite-images): handle null or undefined

### DIFF
--- a/libraries/gatsby-remark-rewrite-images/rewrite-images.js
+++ b/libraries/gatsby-remark-rewrite-images/rewrite-images.js
@@ -1,5 +1,5 @@
 const mediaDomain = 'https://media.alexwilson.tech/'
-const rewriteImage = (src) => src
+const rewriteImage = (src) => !src ? src : src
     .replace(/^https?\:\/\/alexwilson.tech\//, '/')
     .replace(/^\/pictures\//, mediaDomain)
 


### PR DESCRIPTION
# Why?
When an image is specifically null or undefined, blog builds break.

# What?
When image `src` is falsey, just pass that directly back.
