### PR TITLE
ci: silence default branch warning

### DIFF
--- a/.github/actions/github-pages/entrypoint.sh
+++ b/.github/actions/github-pages/entrypoint.sh
@@ -7,6 +7,7 @@ echo "Deploying ${GITHUB_SHA} to GitHub Pages"
 echo "Initialising in ${PWD} as ${GITHUB_ACTOR}"
 
 git init
+git config set advice.defaultBranchName false
 git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"


### PR DESCRIPTION
# Why?
Git throws a small error complaining about the default branch name

# What?
Silence it