### PR TITLE
Harden webmention ingestion

### DIFF
--- a/components/legacy-components/src/webmentions/webmentions.tsx
+++ b/components/legacy-components/src/webmentions/webmentions.tsx
@@ -26,16 +26,31 @@ const repliesFromWebmentions = (webmentions: Webmention[]) =>
 
 type FaceProps = { webmention: Webmention }
 
+// Webmentions are third-party input: only link author URLs with a safe scheme.
+const safeAuthorUrl = (value: string) => {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:" ? url.href : null
+  } catch {
+    return null
+  }
+}
+
 function Face({ webmention }: FaceProps) {
-  return (
-    <a href={webmention.author.url} title={webmention.author.name}>
-      <ResponsiveImage
-        src={webmention.author.photo}
-        width={64}
-        height={64}
-        quality={"lossless"}
-        format={"png"}
-      />
+  const photo = (
+    <ResponsiveImage
+      src={webmention.author.photo}
+      width={64}
+      height={64}
+      quality={"lossless"}
+      format={"png"}
+    />
+  )
+  const url = safeAuthorUrl(webmention.author.url)
+
+  return url === null ? photo : (
+    <a href={url} title={webmention.author.name} rel="noopener noreferrer">
+      {photo}
     </a>
   )
 }

--- a/services/webmention/src/lambda/__tests__/webmention-io.test.ts
+++ b/services/webmention/src/lambda/__tests__/webmention-io.test.ts
@@ -257,7 +257,7 @@ describe("webmention-io handler — Webmention wm-property coverage", () => {
 });
 
 describe("webmention-io handler — no webhook token configured", () => {
-  it("skips the secret check when WEBMENTION_IO_WEBHOOK_TOKEN is unset", async () => {
+  it("rejects every request when WEBMENTION_IO_WEBHOOK_TOKEN is unset (fail closed)", async () => {
     vi.resetModules();
     const previous = process.env.WEBMENTION_IO_WEBHOOK_TOKEN;
     delete process.env.WEBMENTION_IO_WEBHOOK_TOKEN;
@@ -274,8 +274,8 @@ describe("webmention-io handler — no webhook token configured", () => {
         () => {},
       )) as { statusCode: number; body: string };
 
-      expect(res.statusCode).toBe(200);
-      expect(sendMock).toHaveBeenCalledOnce();
+      expect(res.statusCode).toBe(401);
+      expect(sendMock).not.toHaveBeenCalled();
     } finally {
       process.env.WEBMENTION_IO_WEBHOOK_TOKEN = previous;
       vi.resetModules();
@@ -284,23 +284,120 @@ describe("webmention-io handler — no webhook token configured", () => {
 });
 
 describe("webmention-io handler — malformed input", () => {
-  it("throws on a non-JSON body (callers/API Gateway should reject upstream)", async () => {
-    await expect(call("this is not json")).rejects.toThrow();
+  it("returns 400 on a non-JSON body", async () => {
+    const res = await call("this is not json");
+    expect(res.statusCode).toBe(400);
     expect(sendMock).not.toHaveBeenCalled();
   });
 
-  it("throws on an empty body rather than silently writing garbage", async () => {
-    await expect(call("")).rejects.toThrow();
+  it("returns 400 on an empty body", async () => {
+    const res = await call("");
+    expect(res.statusCode).toBe(400);
     expect(sendMock).not.toHaveBeenCalled();
   });
 
-  it("throws when the post object is missing", async () => {
-    await expect(
-      call({
-        secret: TOKEN,
-        target: `https://alexwilson.tech/content/${ARTICLE_UUID}`,
+  it("returns 400 when the post object is missing", async () => {
+    const res = await call({
+      secret: TOKEN,
+      target: `https://alexwilson.tech/content/${ARTICLE_UUID}`,
+    });
+    expect(res.statusCode).toBe(400);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when post is not an object", async () => {
+    const res = await call({
+      secret: TOKEN,
+      target: `https://alexwilson.tech/content/${ARTICLE_UUID}`,
+      post: ["not", "a", "post"],
+    });
+    expect(res.statusCode).toBe(400);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when wm-id is missing", async () => {
+    const res = await call({
+      secret: TOKEN,
+      target: `https://alexwilson.tech/content/${ARTICLE_UUID}`,
+      post: makePost({ "wm-id": undefined }),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when target is not a string", async () => {
+    const res = await call({
+      secret: TOKEN,
+      target: 42,
+      post: makePost(),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("webmention-io handler — hostile URLs are rejected, not stored", () => {
+  const VALID_TARGET = `https://alexwilson.tech/content/${ARTICLE_UUID}`;
+
+  async function expectRejected(post: Record<string, unknown>) {
+    const res = await call({ secret: TOKEN, target: VALID_TARGET, post });
+    expect(res.statusCode).toBe(400);
+    expect(sendMock).not.toHaveBeenCalled();
+  }
+
+  it("rejects a javascript: author url", async () => {
+    await expectRejected(
+      makePost({
+        author: {
+          name: "Mallory",
+          photo: "https://example.test/me.png",
+          url: "javascript:alert(document.domain)",
+        },
       }),
-    ).rejects.toThrow();
-    expect(sendMock).not.toHaveBeenCalled();
+    );
+  });
+
+  it("rejects a data: author photo", async () => {
+    await expectRejected(
+      makePost({
+        author: {
+          name: "Mallory",
+          photo: "data:text/html,<script>alert(1)</script>",
+          url: "https://example.test",
+        },
+      }),
+    );
+  });
+
+  it("rejects a non-URL author url", async () => {
+    await expectRejected(
+      makePost({
+        author: {
+          name: "Mallory",
+          photo: "https://example.test/me.png",
+          url: "not a url at all",
+        },
+      }),
+    );
+  });
+
+  it("rejects a non-object author", async () => {
+    await expectRejected(makePost({ author: "Mallory" }));
+  });
+
+  it("rejects a javascript: post url", async () => {
+    await expectRejected(makePost({ url: "javascript:alert(1)" }));
+  });
+
+  it("rejects a javascript: wm-source", async () => {
+    await expectRejected(makePost({ "wm-source": "javascript:alert(1)" }));
+  });
+
+  it("still stores a valid post with no author", async () => {
+    const post = makePost();
+    delete (post as Record<string, unknown>).author;
+    const res = await call({ secret: TOKEN, target: VALID_TARGET, post });
+    expect(res.statusCode).toBe(200);
+    expect(sendMock).toHaveBeenCalledOnce();
   });
 });

--- a/services/webmention/src/lambda/webmention-io.ts
+++ b/services/webmention/src/lambda/webmention-io.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import type { APIGatewayProxyHandler, APIGatewayProxyEvent } from "aws-lambda";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
@@ -10,18 +11,30 @@ const webhookToken = process.env.WEBMENTION_IO_WEBHOOK_TOKEN || undefined;
 export const handler: APIGatewayProxyHandler = async (
   event: APIGatewayProxyEvent,
 ) => {
-  const body = JSON.parse(event.body || "");
-
-  if (webhookToken && body.secret !== webhookToken) {
-    return {
-      statusCode: 401,
-      body: JSON.stringify({ message: "Unauthorized" }),
-    };
+  let body: unknown;
+  try {
+    body = JSON.parse(event.body || "");
+  } catch {
+    return reply(400, "Request body must be JSON");
+  }
+  if (typeof body !== "object" || body === null) {
+    return reply(400, "Request body must be a JSON object");
   }
 
-  const webmentionData = body.post;
-  const webmentionId = String(body.post["wm-id"]);
-  const contentId = extractArticleIdFromUrl(body.target);
+  const { secret, post, target } = body as Record<string, unknown>;
+
+  if (!secretMatches(secret)) {
+    return reply(401, "Unauthorized");
+  }
+
+  const problem = validateWebmention(post, target);
+  if (problem) {
+    return reply(400, problem);
+  }
+
+  const webmentionData = post as Record<string, unknown>;
+  const webmentionId = String(webmentionData["wm-id"]);
+  const contentId = extractArticleIdFromUrl(target as string);
 
   // Persist entire webmention
   await dynamoDb.send(
@@ -35,11 +48,75 @@ export const handler: APIGatewayProxyHandler = async (
     }),
   );
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify({ message: "Webmention processed successfully" }),
-  };
+  return reply(200, "Webmention processed successfully");
 };
+
+function reply(statusCode: number, message: string) {
+  return { statusCode, body: JSON.stringify({ message }) };
+}
+
+// Constant-time comparison; a missing token configuration denies everything.
+function secretMatches(secret: unknown): boolean {
+  if (!webhookToken || typeof secret !== "string") {
+    return false;
+  }
+  const provided = createHash("sha256").update(secret).digest();
+  const expected = createHash("sha256").update(webhookToken).digest();
+  return timingSafeEqual(provided, expected);
+}
+
+/**
+ * Webmentions are third-party content that ends up rendered on the site, so
+ * anything that doesn't look like a genuine webmention.io payload — in
+ * particular URL fields with a scheme other than http(s) — is rejected
+ * before it is stored.
+ */
+function validateWebmention(post: unknown, target: unknown): string | null {
+  if (typeof target !== "string") {
+    return "target must be a string";
+  }
+  if (typeof post !== "object" || post === null || Array.isArray(post)) {
+    return "post must be an object";
+  }
+
+  const p = post as Record<string, unknown>;
+  const id = p["wm-id"];
+  if (typeof id !== "string" && typeof id !== "number") {
+    return "post is missing wm-id";
+  }
+
+  for (const field of ["url", "wm-source", "wm-target"]) {
+    if (p[field] !== undefined && !isHttpUrl(p[field])) {
+      return `post ${field} must be an http(s) URL`;
+    }
+  }
+
+  if (p.author !== undefined) {
+    if (typeof p.author !== "object" || p.author === null) {
+      return "author must be an object";
+    }
+    const author = p.author as Record<string, unknown>;
+    for (const field of ["url", "photo"]) {
+      if (author[field] !== undefined && !isHttpUrl(author[field])) {
+        return `author ${field} must be an http(s) URL`;
+      }
+    }
+  }
+
+  return null;
+}
+
+function isHttpUrl(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Extracts the article ID from a URL.


### PR DESCRIPTION
# Why?
The current webmention endpint (since it accepts user input) is technically vulnerable to a stored XSS attack.

# What?
1. Perform better validation at Webmention ingestion
2. Explicitly *only* render HTTP links.
