### PR TITLE
feat(cms): build against different branches for development

### DIFF
--- a/services/personal-website/gatsby-config.ts
+++ b/services/personal-website/gatsby-config.ts
@@ -16,7 +16,7 @@ const config: GatsbyConfig = {
         name: `posts`,
         owner: `alexwilson`,
         repo: `content`,
-        ref: `main`,
+        ref: process.env.CONTENT_REF ?? `main`,
         patterns: [`posts/**`],
         token: process.env.GITHUB_TOKEN,
         pollInterval: process.env.NODE_ENV === `development` ? 30 : 0,


### PR DESCRIPTION
# Why?
Currently we build against the `main` branch, which is where published posts live.

# What?
To enable previews, take branch name as an argument and build against that instead.
