### PR TITLE
Implement Columns

### DIFF
--- a/components/columns/.gitignore
+++ b/components/columns/.gitignore
@@ -1,0 +1,2 @@
+dist/
+*.tsbuildinfo

--- a/components/columns/README.md
+++ b/components/columns/README.md
@@ -1,0 +1,15 @@
+# @alexwilson/ds-columns
+
+The presentational utility for the columns block: the `Columns` / `Column` React
+components and stylesheets.
+
+```tsx
+import { Columns, Column } from '@alexwilson/ds-columns/src'
+
+<Columns split="two-wide-left">
+  <Column lang="ja">…</Column>
+  <Column lang="en">…</Column>
+</Columns>
+```
+
+For more see Storybook.

--- a/components/columns/package.json
+++ b/components/columns/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@alexwilson/ds-columns",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Component implementing columns",
+  "author": "Alex Wilson <alex@alexwilson.tech>",
+  "license": "ISC",
+  "type": "module",
+  "engines": {
+    "node": ">=22.12"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepare": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "sass": "^1.45.0"
+  },
+  "dependencies": {
+    "@alexwilson/content": "workspace:*",
+    "@alexwilson/ds-legacy-components": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react": "18.3.28",
+    "react": "18.3.1",
+    "sass": "1.99.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/components/columns/src/columns.scss
+++ b/components/columns/src/columns.scss
@@ -1,0 +1,40 @@
+@use "~@alexwilson/ds-legacy-components/src/util-viewports/viewports" as *;
+
+.alex-columns {
+  display: grid;
+  gap: 1.5em;
+  margin-block: 2em;
+  align-items: start;
+
+  &[data-split="two-equal"],
+  &[data-split="three"] {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  }
+
+  &[data-split="full"] {
+    grid-template-columns: 1fr;
+  }
+
+  &[data-split="two-wide-left"] {
+    grid-template-columns: 2fr 1fr;
+  }
+  &[data-split="two-wide-right"] {
+    grid-template-columns: 1fr 2fr;
+  }
+
+  @include media("<tablet") {
+    &[data-split="two-wide-left"],
+    &[data-split="two-wide-right"] {
+      grid-template-columns: 1fr;
+    }
+  }
+}
+
+.alex-column {
+  > :first-child {
+    margin-block-start: 0;
+  }
+  > :last-child {
+    margin-block-end: 0;
+  }
+}

--- a/components/columns/src/columns.scss
+++ b/components/columns/src/columns.scss
@@ -3,7 +3,9 @@
 .alex-columns {
   display: grid;
   gap: 1.5em;
-  margin-block: 2em;
+  // Match the article's margin-bottom-only rhythm.
+  // @todo Reference this with a token.
+  margin-block: 0 1.5em;
   align-items: start;
 
   &[data-split="two-equal"],

--- a/components/columns/src/columns.stories.tsx
+++ b/components/columns/src/columns.stories.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { SPLITS, SPLIT_NAMES, type SplitName } from '@alexwilson/content'
+
+import { Columns, Column } from './index'
+
+export default {
+  title: 'Content/Columns',
+  component: Columns,
+}
+
+const Prose = ({ heading }: { heading: string }) => (
+  <>
+    <h3>{heading}</h3>
+    <p>A column holds ordinary Markdown, laid out by the chosen split.</p>
+    <ul>
+      <li>One</li>
+      <li>Two</li>
+    </ul>
+  </>
+)
+
+const Demo = ({ split }: { split: SplitName }) => (
+  <Columns split={split}>
+    {Array.from({ length: SPLITS[split].slots }, (_, i) => (
+      <Column key={i}>
+        <Prose heading={`Column ${i + 1}`} />
+      </Column>
+    ))}
+  </Columns>
+)
+
+export const TwoEqual = () => <Demo split="two-equal" />
+export const TwoWideLeft = () => <Demo split="two-wide-left" />
+export const TwoWideRight = () => <Demo split="two-wide-right" />
+export const Three = () => <Demo split="three" />
+
+export const AllSplits = () => (
+  <>
+    {SPLIT_NAMES.map((split) => (
+      <section key={split} style={{ marginBlockEnd: '2rem' }}>
+        <p>
+          <code>{split}</code>
+        </p>
+        <Demo split={split} />
+      </section>
+    ))}
+  </>
+)

--- a/components/columns/src/contract.ts
+++ b/components/columns/src/contract.ts
@@ -1,0 +1,3 @@
+export const COLUMNS_CLASS = 'alex-columns'
+export const COLUMN_CLASS = 'alex-column'
+export const SPLIT_ATTRIBUTE = 'data-split'

--- a/components/columns/src/declarations.d.ts
+++ b/components/columns/src/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module '*.scss' {}

--- a/components/columns/src/index.tsx
+++ b/components/columns/src/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { type SplitName } from '@alexwilson/content'
+
+import { COLUMNS_CLASS, COLUMN_CLASS } from './contract'
+import './columns.scss'
+
+export function Columns({
+  split,
+  children,
+}: {
+  split: SplitName
+  children: React.ReactNode
+}) {
+  return (
+    <div className={COLUMNS_CLASS} data-split={split}>
+      {children}
+    </div>
+  )
+}
+
+export function Column({
+  lang,
+  children,
+}: {
+  lang?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className={COLUMN_CLASS} lang={lang}>
+      {children}
+    </div>
+  )
+}

--- a/components/columns/tsconfig.build.json
+++ b/components/columns/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/contract.ts"]
+}

--- a/components/columns/tsconfig.json
+++ b/components/columns/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "allowJs": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/libraries/content/.gitignore
+++ b/libraries/content/.gitignore
@@ -1,0 +1,3 @@
+dist/
+*.tsbuildinfo
+coverage/

--- a/libraries/content/README.md
+++ b/libraries/content/README.md
@@ -1,0 +1,20 @@
+# @alexwilson/content
+
+A declarative description of what is possible with content. In the spirit of [unist](https://github.com/syntax-tree/unist): this is only grammar. Vocabulary and types lives in outside of it.
+
+## What it declares
+
+- **Vocabulary** — `SPLITS` (the split enum and its column-count rule), `SplitName`,
+  `SPLIT_NAMES`, `isSplitName`, `FALLBACK_SPLIT`, the `columns`/`column` directive
+  names.
+- **Node shapes** — `ColumnsDirective` / `ColumnDirective` as
+  [`mdast-util-directive`](https://github.com/syntax-tree/mdast-util-directive)
+  extensions, and `ColumnContent` (the authoring shape). Just the shapes — the guards
+  and accessors that *operate* on them are AST utilities and live with the
+  transform; the DOM hooks live with the presentation.
+
+
+## Adding a block
+
+Drop `src/<block>.ts` declaring its vocabulary and node shape, re-export from
+`src/index.ts`, and keep it free of behaviour, AST logic and presentation.

--- a/libraries/content/__tests__/columns.test.ts
+++ b/libraries/content/__tests__/columns.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { SPLITS, SPLIT_NAMES, isSplitName, FALLBACK_SPLIT } from '../src/columns'
+
+describe('split vocabulary', () => {
+  it('exposes every split name', () => {
+    expect(SPLIT_NAMES).toEqual([
+      'full',
+      'two-equal',
+      'two-wide-left',
+      'two-wide-right',
+      'three',
+    ])
+  })
+
+  it('records the slot count and ratio flag for each split', () => {
+    expect(SPLITS['two-equal']).toEqual({ slots: 2, ratio: false })
+    expect(SPLITS['two-wide-left']).toEqual({ slots: 2, ratio: true })
+    expect(SPLITS.three).toEqual({ slots: 3, ratio: false })
+  })
+
+  it('marks only ratio splits as ratio: true', () => {
+    expect(SPLIT_NAMES.filter((name) => SPLITS[name].ratio)).toEqual([
+      'two-wide-left',
+      'two-wide-right',
+    ])
+  })
+
+  it('narrows known and rejects unknown split names', () => {
+    expect(isSplitName('two-equal')).toBe(true)
+    expect(isSplitName('two-wide')).toBe(false)
+    expect(isSplitName(undefined)).toBe(false)
+  })
+
+  it('falls back to a real split', () => {
+    expect(isSplitName(FALLBACK_SPLIT)).toBe(true)
+  })
+})

--- a/libraries/content/package.json
+++ b/libraries/content/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@alexwilson/content",
+  "version": "0.1.0",
+  "private": true,
+  "description": "A declarative description of what is possible with content: the node vocabulary, types and DOM-decoration contract for custom blocks. No behaviour, no presentation.",
+  "author": "Alex Wilson <alex@alexwilson.tech>",
+  "license": "ISC",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.12"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepare": "tsc",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@types/mdast": "4.0.4",
+    "@types/unist": "3.0.3",
+    "mdast-util-directive": "3.1.0"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3",
+    "vitest": "4.1.8"
+  }
+}

--- a/libraries/content/src/column.ts
+++ b/libraries/content/src/column.ts
@@ -1,0 +1,12 @@
+import type { ContainerDirective } from 'mdast-util-directive'
+
+export const COLUMN_DIRECTIVE = 'column'
+
+export interface ColumnDirective extends ContainerDirective {
+  name: typeof COLUMN_DIRECTIVE
+}
+
+export interface ColumnContent {
+  lang?: string
+  content: string
+}

--- a/libraries/content/src/columns.ts
+++ b/libraries/content/src/columns.ts
@@ -1,0 +1,25 @@
+import type { ContainerDirective } from 'mdast-util-directive'
+
+export const COLUMNS_DIRECTIVE = 'columns'
+
+export const SPLITS = {
+  full: { slots: 1, ratio: false },
+  'two-equal': { slots: 2, ratio: false },
+  'two-wide-left': { slots: 2, ratio: true },
+  'two-wide-right': { slots: 2, ratio: true },
+  three: { slots: 3, ratio: false },
+} as const
+
+export type SplitName = keyof typeof SPLITS
+
+export const SPLIT_NAMES = Object.keys(SPLITS) as SplitName[]
+
+export const FALLBACK_SPLIT: SplitName = 'full'
+
+export function isSplitName(value: unknown): value is SplitName {
+  return typeof value === 'string' && value in SPLITS
+}
+
+export interface ColumnsDirective extends ContainerDirective {
+  name: typeof COLUMNS_DIRECTIVE
+}

--- a/libraries/content/src/index.ts
+++ b/libraries/content/src/index.ts
@@ -1,0 +1,2 @@
+export * from './columns.js'
+export * from './column.js'

--- a/libraries/content/tsconfig.json
+++ b/libraries/content/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/libraries/content/vitest.config.ts
+++ b/libraries/content/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+})

--- a/libraries/gatsby-remark-content-blocks/README.md
+++ b/libraries/gatsby-remark-content-blocks/README.md
@@ -1,0 +1,16 @@
+# @alexwilson/gatsby-remark-content-blocks
+
+Registers content blocks into `gatsby-transformer-remark`'s `html` field.
+
+```ts
+// gatsby-config.ts
+{
+  resolve: `gatsby-transformer-remark`,
+  options: {
+    plugins: [
+      `@alexwilson/gatsby-remark-content-blocks`,
+      // …existing sub-plugins
+    ],
+  },
+}
+```

--- a/libraries/gatsby-remark-content-blocks/index.js
+++ b/libraries/gatsby-remark-content-blocks/index.js
@@ -1,0 +1,29 @@
+// gatsby-transformer-remark parses with `remark.parse()` and never runs remark
+// transformers, so this sub-plugin needs two hooks:
+//   1. setParserPlugins: remark-directive (the syntax extension) so `::::columns`
+//      parses into directive nodes.
+//   2. default export: the AST mutator gatsby runs after parse, applying the
+//      content-blocks transform (validate + stamp the data-* hints).
+// remark-directive is pinned to v1 to match the transformer's remark-parse@9.
+// CommonJS so gatsby can require it; it require()s the ESM transform (Node >=22.12).
+const remarkDirective = require("remark-directive")
+const remarkContentBlocks = require("@alexwilson/remark-content-blocks").default
+
+const applyContentBlocks = remarkContentBlocks({ emitHtmlHints: true })
+
+module.exports = function gatsbyRemarkContentBlocks({ markdownAST, reporter }) {
+  const file = {
+    message(reason) {
+      if (reporter && typeof reporter.warn === "function") {
+        reporter.warn(`remark-content-blocks: ${reason}`)
+      }
+      return { fatal: null }
+    },
+  }
+  applyContentBlocks(markdownAST, file)
+  return markdownAST
+}
+
+module.exports.setParserPlugins = function setParserPlugins() {
+  return [remarkDirective]
+}

--- a/libraries/gatsby-remark-content-blocks/package.json
+++ b/libraries/gatsby-remark-content-blocks/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@alexwilson/gatsby-remark-content-blocks",
+  "version": "0.1.0",
+  "private": true,
+  "description": "gatsby-transformer-remark sub-plugin: registers remark-directive + @alexwilson/remark-content-blocks via setParserPlugins so content blocks render through the html field.",
+  "author": "Alex Wilson <alex@alexwilson.tech>",
+  "license": "ISC",
+  "main": "index.js",
+  "engines": {
+    "node": ">=22.12"
+  },
+  "dependencies": {
+    "@alexwilson/remark-content-blocks": "workspace:*",
+    "remark-directive": "^1.0.1"
+  },
+  "peerDependencies": {
+    "gatsby-transformer-remark": ">=6"
+  }
+}

--- a/libraries/remark-content-blocks/.gitignore
+++ b/libraries/remark-content-blocks/.gitignore
@@ -1,0 +1,3 @@
+dist/
+*.tsbuildinfo
+coverage/

--- a/libraries/remark-content-blocks/README.md
+++ b/libraries/remark-content-blocks/README.md
@@ -1,0 +1,16 @@
+# @alexwilson/remark-content-blocks
+
+The remark utility that implements the content blocks described by [`@alexwilson/content`](../content).
+
+```js
+unified()
+  .use(remarkParse)
+  .use(remarkDirective)
+  .use(remarkContentBlocks, { emitHtmlHints: true })
+  .use(remarkRehype)
+  .use(rehypeStringify)
+```
+
+## Adding a block
+
+Add a guard + handler in `src/index.ts` and describe the block in `@alexwilson/content`.

--- a/libraries/remark-content-blocks/__tests__/transform.test.ts
+++ b/libraries/remark-content-blocks/__tests__/transform.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkDirective from 'remark-directive'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import { visit } from 'unist-util-visit'
+import { VFile } from 'vfile'
+
+import remarkContentBlocks, {
+  type RemarkContentBlocksOptions,
+} from '../src/index'
+
+const TWO_EQUAL = `::::columns{split=two-equal}
+:::column{lang=ja}
+日本語
+
+- リスト
+:::
+
+:::column{lang=en}
+English side.
+:::
+::::
+`
+
+const UNKNOWN_SPLIT = `::::columns{split=two-wide}
+:::column
+A
+:::
+
+:::column
+B
+:::
+::::
+`
+
+const WRONG_COUNT = `::::columns{split=three}
+:::column
+A
+:::
+
+:::column
+B
+:::
+::::
+`
+
+function toHtml(markdown: string, options?: RemarkContentBlocksOptions) {
+  return unified()
+    .use(remarkParse)
+    .use(remarkDirective)
+    .use(remarkContentBlocks, options)
+    .use(remarkRehype)
+    .use(rehypeStringify)
+    .processSync(markdown)
+}
+
+function findColumns(markdown: string, options?: RemarkContentBlocksOptions) {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkDirective)
+    .use(remarkContentBlocks, options)
+  const tree = processor.runSync(processor.parse(markdown)) as unknown
+  let columns: any
+  visit(tree as any, (node: any) => {
+    if (node.type === 'containerDirective' && node.name === 'columns') {
+      columns = node
+    }
+  })
+  return columns
+}
+
+describe('remarkContentBlocks (hints on)', () => {
+  it('stamps the presentation classes and split into HTML', () => {
+    const html = String(toHtml(TWO_EQUAL))
+    expect(html).toContain('class="alex-columns"')
+    expect(html).toContain('data-split="two-equal"')
+    expect(html).toContain('class="alex-column"')
+    expect(html).toContain('lang="ja"')
+    expect(html).toContain('lang="en"')
+  })
+
+  it('emits no diagnostics for a conforming block', () => {
+    expect(toHtml(TWO_EQUAL).messages).toHaveLength(0)
+  })
+
+  it('warns and falls back to full on an unknown split', () => {
+    const file = toHtml(UNKNOWN_SPLIT)
+    const html = String(file)
+    expect(html).toContain('data-split="full"')
+    expect(html).not.toContain('two-wide')
+    expect(file.messages).toHaveLength(1)
+    expect(file.messages[0].reason).toMatch(/Unknown split "two-wide"/)
+    expect(file.messages[0].fatal).not.toBe(true)
+  })
+
+  it('warns and falls back to full on a column-count mismatch', () => {
+    const file = toHtml(WRONG_COUNT)
+    expect(String(file)).toContain('data-split="full"')
+    expect(file.messages[0].reason).toMatch(/expects 3 column\(s\), found 2/)
+  })
+
+  it('escalates the diagnostic to fatal when failOnError is set', () => {
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .use(remarkContentBlocks, { failOnError: true })
+    const file = new VFile(UNKNOWN_SPLIT)
+    processor.runSync(processor.parse(file), file)
+    expect(file.messages).toHaveLength(1)
+    expect(file.messages[0].fatal).toBe(true)
+  })
+})
+
+describe('remarkContentBlocks (hints off)', () => {
+  it('checks conformance without stamping hints', () => {
+    const columns = findColumns(TWO_EQUAL, { emitHtmlHints: false })
+    expect(columns).toBeDefined()
+    expect(columns.data?.hName).toBeUndefined()
+  })
+
+  it('still reports diagnostics with hints off', () => {
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .use(remarkContentBlocks, { emitHtmlHints: false })
+    const file = new VFile(UNKNOWN_SPLIT)
+    processor.runSync(processor.parse(file), file)
+    expect(file.messages).toHaveLength(1)
+  })
+})

--- a/libraries/remark-content-blocks/package.json
+++ b/libraries/remark-content-blocks/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@alexwilson/remark-content-blocks",
+  "version": "0.1.0",
+  "private": true,
+  "description": "The remark utility that implements the content blocks described by @alexwilson/content: parses, checks conformance, and stamps render hints. Build-time, no React.",
+  "author": "Alex Wilson <alex@alexwilson.tech>",
+  "license": "ISC",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22.12"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepare": "tsc",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@alexwilson/content": "workspace:*",
+    "@alexwilson/ds-columns": "workspace:*",
+    "unist-util-visit": "5.0.0"
+  },
+  "devDependencies": {
+    "@types/mdast": "4.0.4",
+    "mdast-util-directive": "3.1.0",
+    "mdast-util-to-hast": "13.2.1",
+    "rehype-stringify": "10.0.1",
+    "remark-directive": "3.0.1",
+    "remark-parse": "11.0.0",
+    "remark-rehype": "11.1.2",
+    "typescript": "5.9.3",
+    "unified": "11.0.5",
+    "vfile": "6.0.3",
+    "vitest": "4.1.8"
+  }
+}

--- a/libraries/remark-content-blocks/src/index.ts
+++ b/libraries/remark-content-blocks/src/index.ts
@@ -1,0 +1,93 @@
+/// <reference types="mdast-util-to-hast" />
+import type { Plugin } from 'unified'
+import type { Root } from 'mdast'
+import type { ContainerDirective } from 'mdast-util-directive'
+import type { VFile } from 'vfile'
+import { visit } from 'unist-util-visit'
+import {
+  SPLITS,
+  SPLIT_NAMES,
+  FALLBACK_SPLIT,
+  isSplitName,
+  type ColumnsDirective,
+  type SplitName,
+} from '@alexwilson/content'
+import {
+  COLUMNS_CLASS,
+  COLUMN_CLASS,
+  SPLIT_ATTRIBUTE,
+} from '@alexwilson/ds-columns/dist/contract.js'
+
+import { isColumnsDirective, getColumns } from './nodes.js'
+
+export interface RemarkContentBlocksOptions {
+  /** Fail the build on a non-conforming block instead of warning + stacking. */
+  failOnError?: boolean
+  /** Stamp hName/hProperties for the remark-rehype HTML-string path.
+      Set false on pure-React paths that map components on the directive names. */
+  emitHtmlHints?: boolean
+}
+
+interface BlockContext {
+  emitHints: boolean
+  failOnError: boolean
+  file: VFile
+}
+
+const remarkContentBlocks: Plugin<[RemarkContentBlocksOptions?], Root> = (
+  options = {},
+) => {
+  const base = {
+    emitHints: options.emitHtmlHints !== false,
+    failOnError: !!options.failOnError,
+  }
+
+  return (tree, file) => {
+    visit(tree, (node) => {
+      // Add a block: a guard + handler here.
+      if (isColumnsDirective(node)) {
+        applyColumns(node, { ...base, file })
+      }
+    })
+  }
+}
+
+function applyColumns(node: ColumnsDirective, ctx: BlockContext) {
+  const columns = getColumns(node)
+  const split = node.attributes?.split ?? undefined
+  const spec = isSplitName(split) ? SPLITS[split] : undefined
+  const ok = !!spec && columns.length === spec.slots
+
+  if (!ok) {
+    const message = !spec
+      ? `Unknown split "${split}". Use one of: ${SPLIT_NAMES.join(', ')}.`
+      : `Split "${split}" expects ${spec.slots} column(s), found ${columns.length}.`
+    const m = ctx.file.message(message, node)
+    if (ctx.failOnError) m.fatal = true
+  }
+
+  if (!ctx.emitHints) return
+
+  const resolved: SplitName = ok ? (split as SplitName) : FALLBACK_SPLIT
+  decorate(node, { className: [COLUMNS_CLASS], [SPLIT_ATTRIBUTE]: resolved })
+  for (const column of columns) {
+    const lang = column.attributes?.lang ?? undefined
+    decorate(
+      column,
+      lang ? { className: [COLUMN_CLASS], lang } : { className: [COLUMN_CLASS] },
+    )
+  }
+}
+
+function decorate(
+  node: ContainerDirective,
+  properties: Record<string, string | string[]>,
+) {
+  node.data = {
+    ...node.data,
+    hName: 'div',
+    hProperties: { ...node.data?.hProperties, ...properties },
+  }
+}
+
+export default remarkContentBlocks

--- a/libraries/remark-content-blocks/src/nodes.ts
+++ b/libraries/remark-content-blocks/src/nodes.ts
@@ -1,0 +1,21 @@
+import type { ContainerDirective } from 'mdast-util-directive'
+import {
+  COLUMNS_DIRECTIVE,
+  COLUMN_DIRECTIVE,
+  type ColumnsDirective,
+  type ColumnDirective,
+} from '@alexwilson/content'
+
+export function isColumnsDirective(node: unknown): node is ColumnsDirective {
+  const n = node as ContainerDirective | undefined
+  return n?.type === 'containerDirective' && n?.name === COLUMNS_DIRECTIVE
+}
+
+export function isColumnDirective(node: unknown): node is ColumnDirective {
+  const n = node as ContainerDirective | undefined
+  return n?.type === 'containerDirective' && n?.name === COLUMN_DIRECTIVE
+}
+
+export function getColumns(node: ColumnsDirective): ColumnDirective[] {
+  return (node.children ?? []).filter((child) => isColumnDirective(child)) as ColumnDirective[]
+}

--- a/libraries/remark-content-blocks/tsconfig.json
+++ b/libraries/remark-content-blocks/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/libraries/remark-content-blocks/vitest.config.ts
+++ b/libraries/remark-content-blocks/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,28 @@ importers:
 
   .: {}
 
+  components/columns:
+    dependencies:
+      '@alexwilson/content':
+        specifier: workspace:*
+        version: link:../../libraries/content
+      '@alexwilson/ds-legacy-components':
+        specifier: workspace:*
+        version: link:../legacy-components
+    devDependencies:
+      '@types/react':
+        specifier: 18.3.28
+        version: 18.3.28
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      sass:
+        specifier: 1.99.0
+        version: 1.99.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   components/icons: {}
 
   components/legacy-components:
@@ -42,11 +64,42 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  libraries/content:
+    dependencies:
+      '@types/mdast':
+        specifier: 4.0.4
+        version: 4.0.4
+      '@types/unist':
+        specifier: 3.0.3
+        version: 3.0.3
+      mdast-util-directive:
+        specifier: 3.1.0
+        version: 3.1.0
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
+
+  libraries/gatsby-remark-content-blocks:
+    dependencies:
+      '@alexwilson/remark-content-blocks':
+        specifier: workspace:*
+        version: link:../remark-content-blocks
+      gatsby-transformer-remark:
+        specifier: '>=6'
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))
+      remark-directive:
+        specifier: ^1.0.1
+        version: 1.0.1
+
   libraries/gatsby-remark-rewrite-images:
     dependencies:
       gatsby:
         specifier: '>2.0.0-alpha'
-        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       unist-util-visit:
         specifier: 2.0.3
         version: 2.0.3
@@ -84,6 +137,52 @@ importers:
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.8.0)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
+
+  libraries/remark-content-blocks:
+    dependencies:
+      '@alexwilson/content':
+        specifier: workspace:*
+        version: link:../content
+      '@alexwilson/ds-columns':
+        specifier: workspace:*
+        version: link:../../components/columns
+      unist-util-visit:
+        specifier: 5.0.0
+        version: 5.0.0
+    devDependencies:
+      '@types/mdast':
+        specifier: 4.0.4
+        version: 4.0.4
+      mdast-util-directive:
+        specifier: 3.1.0
+        version: 3.1.0
+      mdast-util-to-hast:
+        specifier: 13.2.1
+        version: 13.2.1
+      rehype-stringify:
+        specifier: 10.0.1
+        version: 10.0.1
+      remark-directive:
+        specifier: 3.0.1
+        version: 3.0.1
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: 11.1.2
+        version: 11.1.2
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
+      vfile:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.12(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
 
   services/auth:
     dependencies:
@@ -130,6 +229,12 @@ importers:
 
   services/cms:
     dependencies:
+      '@alexwilson/content':
+        specifier: workspace:*
+        version: link:../../libraries/content
+      '@alexwilson/ds-columns':
+        specifier: workspace:*
+        version: link:../../components/columns
       '@alexwilson/ds-legacy-components':
         specifier: workspace:*
         version: link:../../components/legacy-components
@@ -163,6 +268,24 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      rehype-stringify:
+        specifier: 10.0.1
+        version: 10.0.1
+      remark-directive:
+        specifier: 3.0.1
+        version: 3.0.1
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: 11.1.2
+        version: 11.1.2
+      remark-stringify:
+        specifier: 11.0.0
+        version: 11.0.0
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
     devDependencies:
       '@babel/core':
         specifier: 7.29.0
@@ -263,9 +386,15 @@ importers:
 
   services/personal-website:
     dependencies:
+      '@alexwilson/ds-columns':
+        specifier: workspace:*
+        version: link:../../components/columns
       '@alexwilson/ds-legacy-components':
         specifier: workspace:*
         version: link:../../components/legacy-components
+      '@alexwilson/gatsby-remark-content-blocks':
+        specifier: workspace:*
+        version: link:../../libraries/gatsby-remark-content-blocks
       '@alexwilson/gatsby-remark-rewrite-images':
         specifier: workspace:*
         version: link:../../libraries/gatsby-remark-rewrite-images
@@ -274,37 +403,37 @@ importers:
         version: 4.4.0
       gatsby:
         specifier: 5.16.1
-        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-plugin-feed:
         specifier: 5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-sass:
         specifier: 6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0))
       gatsby-plugin-sitemap:
         specifier: 6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-web-font-loader:
         specifier: 1.0.4
         version: 1.0.4
       gatsby-remark-embed-gist:
         specifier: 1.2.1
-        version: 1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react@18.3.1)
+        version: 1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(react@18.3.1)
       gatsby-remark-embed-video:
         specifier: 3.2.1
         version: 3.2.1
       gatsby-remark-prismjs:
         specifier: 7.16.0
-        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0)
+        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0)
       gatsby-remark-twitter-cards:
         specifier: 0.6.1
-        version: 0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+        version: 0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       gatsby-source-github-repository:
         specifier: workspace:*
         version: link:../../libraries/gatsby-source-github-repository
       gatsby-transformer-remark:
         specifier: 6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       prismjs:
         specifier: 1.30.0
         version: 1.30.0
@@ -4366,6 +4495,9 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -4396,6 +4528,9 @@ packages:
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/hoist-non-react-statics@3.3.7':
     resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
     peerDependencies:
@@ -4425,11 +4560,17 @@ packages:
   '@types/mdast@3.0.15':
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@16.9.1':
     resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
@@ -4519,6 +4660,9 @@ packages:
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -4600,6 +4744,9 @@ packages:
 
   '@udecode/utils@47.2.7':
     resolution: {integrity: sha512-tQ8tIcdW+ZqWWrDgyf/moTLWtcErcHxaOfuCD/6qIL5hCq+jZm67nGHQToOT4Czti5Jr7CDPMgr8lYpdTEZcew==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@uploadcare/cname-prefix@6.18.4':
     resolution: {integrity: sha512-dEDkoMneA01UoJNpS7KcxxCkuP87fdWfK111Q/3nt5WO1gb6VpvZuUse9ac+A/h9iVEkaPxsO7cNsEtLxGKOpQ==}
@@ -5189,6 +5336,9 @@ packages:
   bail@1.0.5:
     resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -5570,6 +5720,9 @@ packages:
   ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   centra@2.7.0:
     resolution: {integrity: sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==}
 
@@ -5605,14 +5758,26 @@ packages:
   character-entities-html4@1.1.4:
     resolution: {integrity: sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==}
 
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
   character-entities-legacy@1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   character-entities@1.2.4:
     resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
 
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   character-reference-invalid@1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
@@ -5751,6 +5916,9 @@ packages:
 
   comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -6455,6 +6623,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
@@ -6563,6 +6734,9 @@ packages:
     resolution: {integrity: sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==}
     engines: {node: '>= 4.0.0'}
     hasBin: true
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   diacritics@1.3.0:
     resolution: {integrity: sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==}
@@ -7871,6 +8045,9 @@ packages:
   hast-util-to-html@7.1.3:
     resolution: {integrity: sha512-yk2+1p3EJTEE9ZEUkgHsUSVhIpCsL/bvT8E5GzmWc+N1Po5gBw+0F8bo7dpxXR0nu0bQVxVZGX2lBGF21CmeDw==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-mdast@7.1.3:
     resolution: {integrity: sha512-3vER9p8B8mCs5b2qzoBiWlC9VnTkFmr8Ufb1eKdcvhVY+nipt52YfMRshk5r9gOE1IZ9/xtlSxebGCv1ig9uKA==}
 
@@ -7882,6 +8059,9 @@ packages:
 
   hast-util-whitespace@1.0.4:
     resolution: {integrity: sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   hastscript@5.1.2:
     resolution: {integrity: sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==}
@@ -7936,6 +8116,9 @@ packages:
 
   html-void-elements@1.0.5:
     resolution: {integrity: sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   html-webpack-plugin@5.6.7:
     resolution: {integrity: sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==}
@@ -8140,12 +8323,18 @@ packages:
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
   is-alphanumeric@1.0.0:
     resolution: {integrity: sha512-ZmRL7++ZkcMOfDuWZuMJyIVLr2keE1o/DeNWh1EmgqGhUcV+9BIVsx0BcSBOHTZqzjs4+dISzr2KAeBEWGgXeA==}
     engines: {node: '>=0.10.0'}
 
   is-alphanumerical@1.0.4:
     resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -8200,6 +8389,9 @@ packages:
   is-decimal@1.0.4:
     resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
@@ -8248,6 +8440,9 @@ packages:
   is-hexadecimal@1.0.4:
     resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-hotkey@0.2.0:
     resolution: {integrity: sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw==}
 
@@ -8294,6 +8489,10 @@ packages:
   is-plain-obj@3.0.0:
     resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
     engines: {node: '>=10'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
@@ -8808,6 +9007,9 @@ packages:
   longest-streak@2.0.4:
     resolution: {integrity: sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -8899,6 +9101,12 @@ packages:
   mdast-util-definitions@4.0.0:
     resolution: {integrity: sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==}
 
+  mdast-util-directive@1.0.1:
+    resolution: {integrity: sha512-VuO1za7BMtWMg8KA8eZrTBorEnCOOW5CXfIuNzUXe7YPie/wLgmNk/jxLMY8m+mzuqnO5eN0JuvlgFtO9EJpbQ==}
+
+  mdast-util-directive@3.1.0:
+    resolution: {integrity: sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==}
+
   mdast-util-find-and-replace@1.1.1:
     resolution: {integrity: sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==}
 
@@ -8907,6 +9115,9 @@ packages:
 
   mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
   mdast-util-gfm-autolink-literal@0.1.3:
     resolution: {integrity: sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==}
@@ -8926,14 +9137,23 @@ packages:
   mdast-util-phrasing@2.0.0:
     resolution: {integrity: sha512-G1rNlW/sViwzbBYD7+k3mKGtoWV2v4GBFky66OYHfktHe7Hg9R+hH4xpeoOtjYiwTvle8C8wlKMpgqPCkaeK8Q==}
 
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
   mdast-util-to-hast@10.2.0:
     resolution: {integrity: sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-hast@4.0.0:
     resolution: {integrity: sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==}
 
   mdast-util-to-markdown@0.6.5:
     resolution: {integrity: sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
 
   mdast-util-to-nlcst@4.0.1:
     resolution: {integrity: sha512-Y4ffygj85MTt70STKnEquw6k73jYWJBaYcb4ITAKgSNokZF7fH8rEHZ1GsRY/JaxqUevMaEnsDmkVv5Z9uVRdg==}
@@ -8943,6 +9163,9 @@ packages:
 
   mdast-util-to-string@2.0.0:
     resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdast-util-toc@5.1.0:
     resolution: {integrity: sha512-csimbRIVkiqc+PpFeKDGQ/Ck2N4f9FYH3zzBMMJzcxoKL8m+cM0n94xXm0I9eaxHnKdY9n145SGTdyJC7i273g==}
@@ -9007,6 +9230,15 @@ packages:
   micro-api-client@3.3.0:
     resolution: {integrity: sha512-y0y6CUB9RLVsy3kfgayU28746QrNMpSm9O/AYGNsBgOkJr/X/Jk0VLGoO8Ude7Bpa8adywzF+MzXNZRFRsNPhg==}
 
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-directive@1.4.0:
+    resolution: {integrity: sha512-8uJN4N2hfhxc0I2Mdya+HZ35D0fyBnHn66aVnHawLj0Nd22Poqgqw3N0vTdYOsNwwrshfMLlPDKtLfEeq4lxgw==}
+
+  micromark-extension-directive@3.0.2:
+    resolution: {integrity: sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==}
+
   micromark-extension-footnote@0.3.2:
     resolution: {integrity: sha512-gr/BeIxbIWQoUm02cIfK7mdMZ/fbroRpLsck4kvFtjbzP4yi+OPVbnukTc/zy0i7spC2xYE/dbX1Sur8BEDJsQ==}
 
@@ -9028,8 +9260,68 @@ packages:
   micromark-extension-gfm@0.3.3:
     resolution: {integrity: sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==}
 
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
   micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -9520,6 +9812,9 @@ packages:
 
   parse-entities@2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse-filepath@1.0.2:
     resolution: {integrity: sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==}
@@ -10061,6 +10356,9 @@ packages:
   property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -10510,6 +10808,9 @@ packages:
   rehype-remove-comments@4.0.2:
     resolution: {integrity: sha512-E2FNohTuIs7QzUnEQs3SdYdCScsTgUN7yPeDNWi+gsvx+pbLzIAyp27TWz3Gm64jpdLi7/6HxyRHxdd1NVQ37A==}
 
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
   rehype-stringify@7.0.0:
     resolution: {integrity: sha512-u3dQI7mIWN2X1H0MBFPva425HbkXgB+M39C9SM5leUS2kh5hHUn2SxQs2c2yZN5eIHipoLMojC0NP5e8fptxvQ==}
 
@@ -10523,17 +10824,29 @@ packages:
   remark-burger@1.0.1:
     resolution: {integrity: sha512-F91SyEzat4hBkWsWElHIvMcCQuWoSeZXTuR4DmLvhUIjYkzzVLaX6GRxhkiDrZb/9asvTrYzwEr9HvxN1tqs9Q==}
 
+  remark-directive@1.0.1:
+    resolution: {integrity: sha512-x6rZs0qa0zu9gW7Avd+rRxHJL2K9TGk+c51NaLfQgCNI7SxwBycRJ3w5mMkjkIjO6O9/qdx0ntu48byCSgF96Q==}
+
+  remark-directive@3.0.1:
+    resolution: {integrity: sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==}
+
   remark-footnotes@3.0.0:
     resolution: {integrity: sha512-ZssAvH9FjGYlJ/PBVKdSmfyPc3Cz4rTWgZLI4iE/SX8Nt5l3o3oEjv3wwG5VD7xOjktzdwp5coac+kJV9l4jgg==}
 
   remark-gfm@1.0.0:
     resolution: {integrity: sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==}
 
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
   remark-parse@6.0.3:
     resolution: {integrity: sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==}
 
   remark-parse@9.0.0:
     resolution: {integrity: sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   remark-rehype@4.0.1:
     resolution: {integrity: sha512-k1GzhtRhXr1sZjX86OS7H4asQu5uOM9Tro//SpOdRaxax6o43mr7M7Np20ubJ+GM6eYjlEHtPv1rDN2hXs2plw==}
@@ -10543,6 +10856,9 @@ packages:
 
   remark-retext@4.0.0:
     resolution: {integrity: sha512-cYCchalpf25bTtfXF24ribYvqytPKq0TiEhqQDBHvVEEsApebwruPWP1cTcvTFBidmpXyqzycm+y8ng7Kmvc8Q==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   remark-stringify@6.0.4:
     resolution: {integrity: sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==}
@@ -11061,6 +11377,9 @@ packages:
   space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -11206,6 +11525,9 @@ packages:
 
   stringify-entities@3.1.0:
     resolution: {integrity: sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@3.0.1:
     resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
@@ -11533,6 +11855,9 @@ packages:
   trim-lines@1.1.3:
     resolution: {integrity: sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   trim-trailing-lines@1.1.4:
     resolution: {integrity: sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==}
 
@@ -11542,6 +11867,9 @@ packages:
 
   trough@1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   true-case-path@2.2.1:
     resolution: {integrity: sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==}
@@ -11713,6 +12041,9 @@ packages:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unified@9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
 
@@ -11741,11 +12072,17 @@ packages:
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
   unist-util-modify-children@2.0.0:
     resolution: {integrity: sha512-HGrj7JQo9DwZt8XFsX8UD4gGqOsIlCih9opG6Y+N11XqkBGKzHo8cvDi+MfQQgiZ7zXRUiQREYHhjOBHERTMdg==}
 
   unist-util-position@3.1.0:
     resolution: {integrity: sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
 
   unist-util-remove-position@1.1.4:
     resolution: {integrity: sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==}
@@ -11759,6 +12096,9 @@ packages:
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
 
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
   unist-util-visit-children@1.1.4:
     resolution: {integrity: sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ==}
 
@@ -11768,11 +12108,17 @@ packages:
   unist-util-visit-parents@3.1.1:
     resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
 
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
   unist-util-visit@1.4.1:
     resolution: {integrity: sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==}
 
   unist-util-visit@2.0.3:
     resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -11956,8 +12302,14 @@ packages:
   vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
 
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
   vfile@4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.12:
     resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
@@ -12478,6 +12830,9 @@ packages:
 
   zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -16281,7 +16636,7 @@ snapshots:
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.106.2)
       webpack-hot-middleware: 2.26.1
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(postcss@8.5.15))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.49.0
@@ -16291,10 +16646,10 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.98.0(postcss@8.5.15)
     optionalDependencies:
       type-fest: 4.41.0
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15))
       webpack-hot-middleware: 2.26.1
 
   '@pnpm/config.env-replace@1.1.0': {}
@@ -16883,6 +17238,10 @@ snapshots:
     dependencies:
       '@types/node': 25.8.0
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -16925,6 +17284,10 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/hoist-non-react-statics@3.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
@@ -16952,9 +17315,15 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/mdx@2.0.13': {}
 
   '@types/mime@1.3.5': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@16.9.1': {}
 
@@ -17053,6 +17422,8 @@ snapshots:
     optional: true
 
   '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -17177,6 +17548,8 @@ snapshots:
       - '@types/react'
 
   '@udecode/utils@47.2.7': {}
+
+  '@ungap/structured-clone@1.3.1': {}
 
   '@uploadcare/cname-prefix@6.18.4': {}
 
@@ -17822,12 +18195,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
 
   babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
@@ -17844,6 +18217,14 @@ snapshots:
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.0
       gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
+      gatsby-core-utils: 4.16.0
+
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@babel/types': 7.29.0
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
@@ -17911,6 +18292,8 @@ snapshots:
       regenerator-runtime: 0.11.1
 
   bail@1.0.5: {}
+
+  bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
@@ -18299,6 +18682,8 @@ snapshots:
 
   ccount@1.1.0: {}
 
+  ccount@2.0.1: {}
+
   centra@2.7.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
@@ -18371,11 +18756,19 @@ snapshots:
 
   character-entities-html4@1.1.4: {}
 
+  character-entities-html4@2.1.0: {}
+
   character-entities-legacy@1.1.4: {}
+
+  character-entities-legacy@3.0.0: {}
 
   character-entities@1.2.4: {}
 
+  character-entities@2.0.2: {}
+
   character-reference-invalid@1.1.4: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@0.7.0: {}
 
@@ -18520,6 +18913,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@1.0.8: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@12.1.0: {}
 
@@ -20075,6 +20470,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decode-uri-component@0.2.2: {}
 
   decompress-response@6.0.0:
@@ -20155,6 +20554,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   diacritics@1.3.0: {}
 
@@ -21416,13 +21819,13 @@ snapshots:
       '@parcel/transformer-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-json': 2.8.3(@parcel/core@2.8.3)
 
-  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       lodash.merge: 4.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -21433,7 +21836,7 @@ snapshots:
       - graphql
       - react-native-b4a
 
-  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.0
@@ -21441,10 +21844,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-page-utils: 3.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       globby: 11.1.0
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -21496,30 +21899,51 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-sass@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      '@babel/traverse': 7.29.0
+      '@sindresorhus/slugify': 1.1.2
+      chokidar: 3.6.0
+      fs-exists-cached: 1.0.0
+      fs-extra: 11.3.5
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby-core-utils: 4.16.0
+      gatsby-page-utils: 3.16.0
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      globby: 11.1.0
+      lodash: 4.18.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - graphql
+      - react-native-b4a
+      - supports-color
+
+  gatsby-plugin-sass@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0)):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       resolve-url-loader: 3.1.5
       sass: 1.99.0
-      sass-loader: 16.0.8(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
+      sass-loader: 16.0.8(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@rspack/core'
       - node-sass
       - sass-embedded
       - webpack
 
-  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       minimatch: 3.1.5
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       sitemap: 7.1.3
 
-  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
@@ -21527,8 +21951,8 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21558,12 +21982,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/runtime': 7.29.2
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       fastq: 1.20.1
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.14.0
@@ -21612,6 +22049,24 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      fastq: 1.20.1
+      fs-extra: 11.3.5
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby-core-utils: 4.16.0
+      gatsby-sharp: 1.16.0
+      graphql: 16.14.0
+      graphql-compose: 9.1.0(graphql@16.14.0)
+      import-from: 4.0.0
+      joi: 17.13.3
+      mime: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   gatsby-plugin-web-font-loader@1.0.4:
     dependencies:
       babel-runtime: 6.26.0
@@ -21633,13 +22088,13 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  gatsby-remark-embed-gist@1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react@18.3.1):
+  gatsby-remark-embed-gist@1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       async-unist-util-visit: 1.0.0
       cheerio: 1.2.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
-      gatsby-transformer-remark: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-transformer-remark: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       node-fetch: 2.7.0(encoding@0.1.13)
       parse-numeric-range: 1.3.0
       react: 18.3.1
@@ -21652,17 +22107,17 @@ snapshots:
       remark-burger: 1.0.1
       unist-util-visit: 2.0.3
 
-  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0):
+  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       parse-numeric-range: 1.3.0
       prismjs: 1.30.0
       unist-util-visit: 2.0.3
 
-  gatsby-remark-twitter-cards@0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+  gatsby-remark-twitter-cards@0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       jimp: 0.16.13
       path: 0.12.7
       wasm-twitter-card: 0.3.0
@@ -21702,10 +22157,38 @@ snapshots:
       valid-url: 1.0.9
       xstate: 4.38.3
 
-  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby-core-utils: 4.16.0
+      gray-matter: 4.0.3
+      hast-util-raw: 6.1.0
+      hast-util-to-html: 7.1.3
+      lodash: 4.18.1
+      mdast-util-to-hast: 10.2.0
+      mdast-util-to-string: 2.0.0
+      mdast-util-toc: 5.1.0
+      remark: 13.0.0
+      remark-footnotes: 3.0.0
+      remark-gfm: 1.0.0
+      remark-parse: 9.0.0
+      remark-retext: 4.0.0
+      remark-stringify: 9.0.1
+      retext-english: 3.0.4
+      sanitize-html: 2.17.4
+      underscore.string: 3.3.6
+      unified: 9.2.2
+      unist-util-remove-position: 3.0.0
+      unist-util-select: 3.0.4
+      unist-util-visit: 2.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gray-matter: 4.0.3
       hast-util-raw: 6.1.0
@@ -21739,7 +22222,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1):
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -21764,7 +22247,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       '@parcel/cache': 2.8.3(@parcel/core@2.8.3)
       '@parcel/core': 2.8.3
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       '@sigmacomputing/babel-plugin-lodash': 3.3.5
       '@types/http-proxy': 1.17.17
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
@@ -21780,7 +22263,7 @@ snapshots:
       babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -21829,9 +22312,9 @@ snapshots:
       gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-page-utils: 3.16.0
       gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
-      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-worker: 2.16.0
@@ -22357,6 +22840,212 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@7.32.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/parser': 7.29.3
+      '@babel/runtime': 7.29.2
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@builder.io/partytown': 0.7.6
+      '@expo/devcert': 1.2.1
+      '@gatsbyjs/reach-router': 2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@gatsbyjs/webpack-hot-middleware': 2.25.3
+      '@graphql-codegen/add': 3.2.3(graphql@16.14.0)
+      '@graphql-codegen/core': 2.6.8(graphql@16.14.0)
+      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@16.14.0)
+      '@graphql-codegen/typescript': 2.8.8(encoding@0.1.13)(graphql@16.14.0)
+      '@graphql-codegen/typescript-operations': 2.5.13(encoding@0.1.13)(graphql@16.14.0)
+      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.29.0)(graphql@16.14.0)
+      '@graphql-tools/load': 7.8.14(graphql@16.14.0)
+      '@jridgewell/trace-mapping': 0.3.31
+      '@nodelib/fs.walk': 1.2.8
+      '@parcel/cache': 2.8.3(@parcel/core@2.8.3)
+      '@parcel/core': 2.8.3
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(postcss@8.5.15))
+      '@sigmacomputing/babel-plugin-lodash': 3.3.5
+      '@types/http-proxy': 1.17.17
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@vercel/webpack-asset-relocator-loader': 1.7.3
+      acorn-loose: 8.5.2
+      acorn-walk: 8.3.5
+      address: 1.2.2
+      anser: 2.3.5
+      autoprefixer: 10.5.0(postcss@8.5.15)
+      axios: 1.16.1(debug@4.4.3)
+      babel-jsx-utils: 1.1.0
+      babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0(postcss@8.5.15))
+      babel-plugin-add-module-exports: 1.0.4
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+      babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
+      better-opn: 2.1.1
+      bluebird: 3.7.2
+      body-parser: 2.2.2
+      browserslist: 4.28.2
+      cache-manager: 2.11.1
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      common-tags: 1.8.2
+      compression: 1.8.1
+      cookie: 0.5.0
+      core-js: 3.49.0
+      cors: 2.8.6
+      css-loader: 5.2.7(webpack@5.98.0(postcss@8.5.15))
+      css-minimizer-webpack-plugin: 2.0.0(webpack@5.98.0(postcss@8.5.15))
+      css.escape: 1.5.1
+      date-fns: 2.30.0
+      debug: 4.4.3
+      deepmerge: 4.3.1
+      detect-port: 1.6.1
+      dotenv: 8.6.0
+      enhanced-resolve: 5.21.2
+      error-stack-parser: 2.1.4
+      eslint: 7.32.0
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
+      eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
+      eslint-plugin-react: 7.37.5(eslint@7.32.0)
+      eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
+      eslint-webpack-plugin: 2.7.0(eslint@7.32.0)(webpack@5.98.0(postcss@8.5.15))
+      event-source-polyfill: 1.0.31
+      execa: 5.1.1
+      express: 4.22.2
+      express-http-proxy: 1.6.3
+      fastest-levenshtein: 1.0.16
+      fastq: 1.20.1
+      file-loader: 6.2.0(webpack@5.98.0(postcss@8.5.15))
+      find-cache-dir: 3.3.2
+      fs-exists-cached: 1.0.0
+      fs-extra: 11.3.5
+      gatsby-cli: 5.16.0(encoding@0.1.13)
+      gatsby-core-utils: 4.16.0
+      gatsby-graphiql-explorer: 3.16.0
+      gatsby-legacy-polyfills: 3.16.0
+      gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      gatsby-page-utils: 3.16.0
+      gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      gatsby-worker: 2.16.0
+      glob: 7.2.3
+      globby: 11.1.0
+      got: 11.8.6
+      graphql: 16.14.0
+      graphql-compose: 9.1.0(graphql@16.14.0)
+      graphql-http: 1.22.4(graphql@16.14.0)
+      graphql-tag: 2.12.6(graphql@16.14.0)
+      hasha: 5.2.2
+      invariant: 2.2.4
+      is-relative: 1.0.0
+      is-relative-url: 3.0.0
+      joi: 17.13.3
+      json-loader: 0.5.7
+      latest-version: 7.0.0
+      linkfs: 2.1.0
+      lmdb: 2.5.3
+      lodash: 4.18.1
+      meant: 1.0.3
+      memoizee: 0.4.17
+      micromatch: 4.0.8
+      mime: 3.0.0
+      mini-css-extract-plugin: 1.6.2(webpack@5.98.0(postcss@8.5.15))
+      mitt: 1.2.0
+      moment: 2.30.1
+      multer: 2.1.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      node-html-parser: 5.4.2
+      normalize-path: 3.0.0
+      null-loader: 4.0.1(webpack@5.98.0(postcss@8.5.15))
+      opentracing: 0.14.7
+      p-defer: 3.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      physical-cpu-count: 2.0.0
+      platform: 1.3.6
+      postcss: 8.5.15
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.5.15)
+      postcss-loader: 5.3.0(postcss@8.5.15)(webpack@5.98.0(postcss@8.5.15))
+      prompts: 2.4.2
+      prop-types: 15.8.1
+      query-string: 6.14.1
+      raw-loader: 4.0.2(webpack@5.98.0(postcss@8.5.15))
+      react: 19.2.6
+      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(postcss@8.5.15))
+      react-dom: 19.2.6(react@19.2.6)
+      react-refresh: 0.14.2
+      react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@19.2.6)(webpack@5.98.0(postcss@8.5.15))
+      redux: 4.2.1
+      redux-thunk: 2.4.2(redux@4.2.1)
+      resolve-from: 5.0.0
+      semver: 7.8.1
+      shallow-compare: 1.2.2
+      signal-exit: 3.0.7
+      slugify: 1.6.9
+      socket.io: 4.8.3
+      socket.io-client: 4.8.3
+      stack-trace: 0.0.10
+      string-similarity: 1.2.2
+      strip-ansi: 6.0.1
+      style-loader: 2.0.0(webpack@5.98.0(postcss@8.5.15))
+      style-to-object: 0.4.4
+      terser-webpack-plugin: 5.6.0(postcss@8.5.15)(webpack@5.98.0(postcss@8.5.15))
+      tmp: 0.2.5
+      true-case-path: 2.2.1
+      type-of: 2.0.1
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.98.0(postcss@8.5.15)))(webpack@5.98.0(postcss@8.5.15))
+      uuid: 8.3.2
+      webpack: 5.98.0(postcss@8.5.15)
+      webpack-dev-middleware: 5.3.4(webpack@5.98.0(postcss@8.5.15))
+      webpack-merge: 5.10.0
+      webpack-stats-plugin: 1.1.3
+      webpack-virtual-modules: 0.6.2
+      xstate: 4.38.3
+      yaml-loader: 0.8.1
+    optionalDependencies:
+      gatsby-sharp: 1.16.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - '@types/webpack'
+      - babel-eslint
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - clean-css
+      - cssnano
+      - csso
+      - encoding
+      - esbuild
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - eslint-plugin-jest
+      - eslint-plugin-testing-library
+      - html-minifier-terser
+      - lightningcss
+      - react-native-b4a
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
   gel@2.2.0:
     dependencies:
       '@petamoriken/float16': 3.9.3
@@ -22656,6 +23345,20 @@ snapshots:
       unist-util-is: 4.1.0
       xtend: 4.0.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-mdast@7.1.3:
     dependencies:
       extend: 3.0.2
@@ -22686,6 +23389,10 @@ snapshots:
       unist-util-find-after: 3.0.0
 
   hast-util-whitespace@1.0.4: {}
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hastscript@5.1.2:
     dependencies:
@@ -22760,6 +23467,8 @@ snapshots:
       terser: 5.47.1
 
   html-void-elements@1.0.5: {}
+
+  html-void-elements@3.0.0: {}
 
   html-webpack-plugin@5.6.7(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
@@ -22972,12 +23681,19 @@ snapshots:
 
   is-alphabetical@1.0.4: {}
 
+  is-alphabetical@2.0.1: {}
+
   is-alphanumeric@1.0.0: {}
 
   is-alphanumerical@1.0.4:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -23035,6 +23751,8 @@ snapshots:
 
   is-decimal@1.0.4: {}
 
+  is-decimal@2.0.1: {}
+
   is-docker@2.2.1: {}
 
   is-docker@3.0.0: {}
@@ -23071,6 +23789,8 @@ snapshots:
 
   is-hexadecimal@1.0.4: {}
 
+  is-hexadecimal@2.0.1: {}
+
   is-hotkey@0.2.0: {}
 
   is-inside-container@1.0.0:
@@ -23103,6 +23823,8 @@ snapshots:
   is-plain-obj@2.1.0: {}
 
   is-plain-obj@3.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-plain-object@2.0.4:
     dependencies:
@@ -23607,6 +24329,8 @@ snapshots:
 
   longest-streak@2.0.4: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -23694,6 +24418,28 @@ snapshots:
     dependencies:
       unist-util-visit: 2.0.3
 
+  mdast-util-directive@1.0.1:
+    dependencies:
+      mdast-util-to-markdown: 0.6.5
+      parse-entities: 2.0.0
+      repeat-string: 1.6.1
+      stringify-entities: 3.1.0
+      unist-util-visit-parents: 3.1.1
+
+  mdast-util-directive@3.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-find-and-replace@1.1.1:
     dependencies:
       escape-string-regexp: 4.0.0
@@ -23714,6 +24460,23 @@ snapshots:
       micromark: 2.11.4
       parse-entities: 2.0.0
       unist-util-stringify-position: 2.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -23752,6 +24515,11 @@ snapshots:
     dependencies:
       unist-util-is: 4.1.0
 
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
   mdast-util-to-hast@10.2.0:
     dependencies:
       '@types/mdast': 3.0.15
@@ -23762,6 +24530,18 @@ snapshots:
       unist-util-generated: 1.1.6
       unist-util-position: 3.1.0
       unist-util-visit: 2.0.3
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
 
   mdast-util-to-hast@4.0.0:
     dependencies:
@@ -23786,6 +24566,18 @@ snapshots:
       repeat-string: 1.6.1
       zwitch: 1.0.5
 
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+
   mdast-util-to-nlcst@4.0.1:
     dependencies:
       nlcst-to-string: 2.0.4
@@ -23796,6 +24588,10 @@ snapshots:
   mdast-util-to-string@1.1.0: {}
 
   mdast-util-to-string@2.0.0: {}
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdast-util-toc@5.1.0:
     dependencies:
@@ -23867,6 +24663,42 @@ snapshots:
 
   micro-api-client@3.3.0: {}
 
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-directive@1.4.0:
+    dependencies:
+      micromark: 2.11.4
+      parse-entities: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  micromark-extension-directive@3.0.2:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
+
   micromark-extension-footnote@0.3.2:
     dependencies:
       micromark: 2.11.4
@@ -23910,10 +24742,124 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
   micromark@2.11.4:
     dependencies:
       debug: 4.4.3
       parse-entities: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -24461,6 +25407,16 @@ snapshots:
       is-decimal: 1.0.4
       is-hexadecimal: 1.0.4
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-filepath@1.0.2:
     dependencies:
       is-absolute: 1.0.0
@@ -25004,6 +25960,8 @@ snapshots:
   property-information@5.6.0:
     dependencies:
       xtend: 4.0.2
+
+  property-information@7.2.0: {}
 
   proto-list@1.2.4: {}
 
@@ -25860,6 +26818,12 @@ snapshots:
       hast-util-is-conditional-comment: 1.0.4
       unist-util-filter: 2.0.3
 
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
+
   rehype-stringify@7.0.0:
     dependencies:
       hast-util-to-html: 7.1.3
@@ -25877,6 +26841,22 @@ snapshots:
 
   remark-burger@1.0.1: {}
 
+  remark-directive@1.0.1:
+    dependencies:
+      mdast-util-directive: 1.0.1
+      micromark-extension-directive: 1.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-directive@3.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-directive: 3.1.0
+      micromark-extension-directive: 3.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-footnotes@3.0.0:
     dependencies:
       mdast-util-footnote: 0.1.7
@@ -25888,6 +26868,15 @@ snapshots:
     dependencies:
       mdast-util-gfm: 0.1.2
       micromark-extension-gfm: 0.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -25915,6 +26904,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
   remark-rehype@4.0.1:
     dependencies:
       mdast-util-to-hast: 4.0.0
@@ -25926,6 +26923,12 @@ snapshots:
   remark-retext@4.0.0:
     dependencies:
       mdast-util-to-nlcst: 4.0.1
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   remark-stringify@6.0.4:
     dependencies:
@@ -26201,13 +27204,6 @@ snapshots:
     optionalDependencies:
       sass: 1.99.0
       webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
-
-  sass-loader@16.0.8(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
-    dependencies:
-      neo-async: 2.6.2
-    optionalDependencies:
-      sass: 1.99.0
-      webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.15)
 
   sass@1.99.0:
     dependencies:
@@ -26648,6 +27644,8 @@ snapshots:
 
   space-separated-tokens@1.1.5: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -26856,6 +27854,11 @@ snapshots:
       character-entities-html4: 1.1.4
       character-entities-legacy: 1.1.4
       xtend: 4.0.2
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@3.0.1:
     dependencies:
@@ -27189,11 +28192,15 @@ snapshots:
 
   trim-lines@1.1.3: {}
 
+  trim-lines@3.0.1: {}
+
   trim-trailing-lines@1.1.4: {}
 
   trim@0.0.1: {}
 
   trough@1.0.5: {}
+
+  trough@2.2.0: {}
 
   true-case-path@2.2.1: {}
 
@@ -27374,6 +28381,16 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unified@9.2.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -27408,11 +28425,19 @@ snapshots:
 
   unist-util-is@4.1.0: {}
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
   unist-util-modify-children@2.0.0:
     dependencies:
       array-iterate: 1.1.4
 
   unist-util-position@3.1.0: {}
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
 
   unist-util-remove-position@1.1.4:
     dependencies:
@@ -27434,6 +28459,10 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
 
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
   unist-util-visit-children@1.1.4: {}
 
   unist-util-visit-parents@2.1.2:
@@ -27445,6 +28474,11 @@ snapshots:
       '@types/unist': 2.0.11
       unist-util-is: 4.1.0
 
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
   unist-util-visit@1.4.1:
     dependencies:
       unist-util-visit-parents: 2.1.2
@@ -27454,6 +28488,12 @@ snapshots:
       '@types/unist': 2.0.11
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universal-user-agent@7.0.3: {}
 
@@ -27649,12 +28689,22 @@ snapshots:
       '@types/unist': 2.0.11
       unist-util-stringify-position: 2.0.3
 
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
   vfile@4.2.1:
     dependencies:
       '@types/unist': 2.0.11
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4):
     dependencies:
@@ -27865,7 +28915,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.2(tslib@2.8.1)
@@ -27874,7 +28924,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.98.0(postcss@8.5.15)
     transitivePeerDependencies:
       - tslib
     optional: true
@@ -27999,7 +29049,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -28027,10 +29077,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.98.0(postcss@8.5.15))
       ws: 8.20.1
     optionalDependencies:
-      webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.98.0(postcss@8.5.15)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -28587,3 +29637,5 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
 
   zwitch@1.0.5: {}
+
+  zwitch@2.0.4: {}

--- a/services/cms/client/config.yml
+++ b/services/cms/client/config.yml
@@ -19,6 +19,11 @@ media_folder: pictures
 
 display_url: https://alexwilson.tech/
 
+i18n:
+  structure: single_file
+  locales: ["en", "ja"]
+  default_locale: en
+
 collections:
   - name: "content"
     label: "Content"

--- a/services/cms/client/main.ts
+++ b/services/cms/client/main.ts
@@ -5,6 +5,8 @@ import styles from "./main.css";
 
 import { Uuid } from "./widgets/uuid";
 import { ArticlePreview, ArticlePreviewStyles } from "./preview/article";
+import { makeColumnsEditorComponent } from "./widgets/editor/columns";
+import columnsStyles from "@alexwilson/ds-columns/src/columns.scss";
 import { BrokeredGitHubBackend } from "./backends/brokered-github";
 
 export default function init() {
@@ -13,6 +15,9 @@ export default function init() {
   const mutableConfig = config as Record<string, unknown>;
   delete mutableConfig.__constants;
 
+  const locales = (config as { i18n?: { locales?: string[] } }).i18n
+    ?.locales ?? ["en"];
+
   if (useTestBackend) {
     mutableConfig.backend = { name: "test-repo" };
   }
@@ -20,8 +25,10 @@ export default function init() {
   CMS.registerBackend("github-app", BrokeredGitHubBackend);
   CMS.init({ config: mutableConfig as unknown as CmsConfig });
   CMS.registerWidget("uuid", Uuid);
+  CMS.registerEditorComponent(makeColumnsEditorComponent(locales));
   CMS.registerPreviewTemplate("content", ArticlePreview);
   CMS.registerPreviewStyle(ArticlePreviewStyles.toString(), { raw: true });
+  CMS.registerPreviewStyle(columnsStyles.toString(), { raw: true });
 }
 
 document.addEventListener("DOMContentLoaded", init);

--- a/services/cms/client/widgets/editor/columns.tsx
+++ b/services/cms/client/widgets/editor/columns.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import remarkDirective from "remark-directive";
+import remarkRehype from "remark-rehype";
+import rehypeStringify from "rehype-stringify";
+
+import {
+  SPLIT_NAMES,
+  COLUMNS_DIRECTIVE,
+  COLUMN_DIRECTIVE,
+  type SplitName,
+} from "@alexwilson/content";
+import { Columns, Column } from "@alexwilson/ds-columns/src";
+
+interface ColumnData {
+  content: string;
+  options?: { lang?: string };
+}
+interface ColumnsData {
+  split: string;
+  columns: ColumnData[];
+}
+
+const parseMarkdown = unified().use(remarkParse).use(remarkDirective);
+const stringifyMarkdown = unified().use(remarkStringify).use(remarkDirective);
+
+const renderHtml = unified().use(remarkParse).use(remarkRehype).use(rehypeStringify);
+function renderColumn(content: string): string {
+  return String(renderHtml.processSync(content || ""));
+}
+
+export function makeColumnsEditorComponent(locales: string[]) {
+  return {
+    id: COLUMNS_DIRECTIVE,
+    label: "Columns",
+    fields: [
+      {
+        name: "split",
+        label: "Split",
+        widget: "select",
+        default: "two-equal",
+        options: SPLIT_NAMES,
+      },
+      {
+        name: "columns",
+        label: "Columns",
+        widget: "list",
+        max: 3,
+        collapsed: true,
+        fields: [
+          { name: "content", label: "Content", widget: "richtext" },
+          {
+            name: "options",
+            label: "Options",
+            widget: "object",
+            collapsed: true,
+            fields: [
+              {
+                name: "lang",
+                label: "Language",
+                widget: "select",
+                options: locales,
+                required: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+
+    // No `m` flag — Decap forbids it.
+    pattern: /^(:{4,})columns\{[^}\n]*\}\n[\s\S]*?\n\1(?=\n|$)/,
+
+    fromBlock(match: RegExpMatchArray): ColumnsData {
+      const tree = parseMarkdown.parse(match[0]) as unknown as {
+        children: Array<Record<string, unknown>>;
+      };
+      const block = tree.children.find(
+        (n) => n.type === "containerDirective" && n.name === COLUMNS_DIRECTIVE,
+      );
+      const children = (block?.children as Array<Record<string, unknown>>) || [];
+      const columns = children
+        .filter((c) => c.type === "containerDirective" && c.name === COLUMN_DIRECTIVE)
+        .map((column) => ({
+          content: stringifyMarkdown
+            .stringify({ type: "root", children: column.children } as never)
+            .trimEnd(),
+          options: { lang: ((column.attributes as Record<string, string>) || {}).lang || "" },
+        }));
+      const attributes = (block?.attributes as Record<string, string>) || {};
+      return { split: attributes.split || "two-equal", columns };
+    },
+
+    toBlock(data: ColumnsData): string {
+      const tree = {
+        type: "root",
+        children: [
+          {
+            type: "containerDirective",
+            name: COLUMNS_DIRECTIVE,
+            attributes: { split: data.split || "two-equal" },
+            children: (data.columns || []).map((c) => ({
+              type: "containerDirective",
+              name: COLUMN_DIRECTIVE,
+              attributes: c.options?.lang ? { lang: c.options.lang } : {},
+              children: parseMarkdown.parse(c.content || "").children,
+            })),
+          },
+        ],
+      };
+      return stringifyMarkdown.stringify(tree as never).trimEnd();
+    },
+
+    toPreview(data: ColumnsData) {
+      const columns = data.columns || [];
+      return (
+        <Columns split={(data.split || "two-equal") as SplitName}>
+          {columns.map((c, i) => (
+            <Column key={i} lang={c.options?.lang || undefined}>
+              <div dangerouslySetInnerHTML={{ __html: renderColumn(c.content) }} />
+            </Column>
+          ))}
+        </Columns>
+      );
+    },
+  };
+}

--- a/services/cms/package.json
+++ b/services/cms/package.json
@@ -11,7 +11,8 @@
     "deploy": "npm-run-all build:* deploy:*",
     "test": "NODE_ENV=test vitest run",
     "test:watch": "NODE_ENV=test vitest",
-    "start": "webpack serve --config webpack.client.cjs",
+    "develop": "webpack serve --config webpack.client.cjs",
+    "start": "NODE_ENV=production PROFILE=true webpack serve --config webpack.client.cjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json"
   },
   "author": "Alex Wilson <alex@alexwilson.tech>",
@@ -52,6 +53,8 @@
     "wrangler": "4.93.0"
   },
   "dependencies": {
+    "@alexwilson/content": "workspace:*",
+    "@alexwilson/ds-columns": "workspace:*",
     "@alexwilson/ds-legacy-components": "workspace:*",
     "better-auth": "1.6.11",
     "date-fns": "4.4.0",
@@ -62,6 +65,12 @@
     "decap-cms-ui-default": "3.8.0",
     "jose": "6.2.3",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "rehype-stringify": "10.0.1",
+    "remark-directive": "3.0.1",
+    "remark-parse": "11.0.0",
+    "remark-rehype": "11.1.2",
+    "remark-stringify": "11.0.0",
+    "unified": "11.0.5"
   }
 }

--- a/services/cms/webpack.client.cjs
+++ b/services/cms/webpack.client.cjs
@@ -15,6 +15,11 @@ module.exports = {
         alias: {
           'clean-stack': false,
           ajv$: path.resolve(__dirname, 'node_modules/ajv'),
+          // PROFILE=true swaps in React's production *profiling* build, so the
+          // React DevTools profiler works against a production-speed bundle.
+          ...(process.env.PROFILE === 'true' && {
+            'react-dom$': 'react-dom/profiling',
+          }),
         },
         fallback: {
           path: require.resolve("path-browserify"),
@@ -81,7 +86,9 @@ module.exports = {
         }),
         new HtmlWebpackPlugin({
             title: 'Alex CMS',
-            publicPath: isProduction ? 'https://static.alexwilson.tech/cms/' : 'auto'
+            // PROFILE builds are served locally, so use a relative path; real
+            // production deploys to the CDN.
+            publicPath: (isProduction && process.env.PROFILE !== 'true') ? 'https://static.alexwilson.tech/cms/' : 'auto'
         }),
         new BundleAnalyzerPlugin({
             analyzerMode: 'static',

--- a/services/personal-website/gatsby-config.ts
+++ b/services/personal-website/gatsby-config.ts
@@ -31,6 +31,7 @@ const config: GatsbyConfig = {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [
+          `@alexwilson/gatsby-remark-content-blocks`,
           {
             resolve: "gatsby-remark-embed-video",
             options: {

--- a/services/personal-website/package.json
+++ b/services/personal-website/package.json
@@ -24,7 +24,9 @@
   },
   "homepage": "https://github.com/alexwilson/personal-website#readme",
   "dependencies": {
+    "@alexwilson/ds-columns": "workspace:*",
     "@alexwilson/ds-legacy-components": "workspace:*",
+    "@alexwilson/gatsby-remark-content-blocks": "workspace:*",
     "@alexwilson/gatsby-remark-rewrite-images": "workspace:*",
     "date-fns": "4.4.0",
     "gatsby": "5.16.1",

--- a/services/personal-website/src/scss/main.scss
+++ b/services/personal-website/src/scss/main.scss
@@ -3,6 +3,7 @@
 @use "~@alexwilson/ds-legacy-components/src/util-palette/palette" as *;
 @use "~@alexwilson/ds-legacy-components/src/util-typography/typography" as *;
 @use "layout" as *;
+@use "~@alexwilson/ds-columns/src/columns";
 
 // Plain CSS imports — pass through, not the deprecated Sass @import.
 @import "~prismjs/themes/prism-okaidia.css";


### PR DESCRIPTION
# Why?
Adds a columns block so articles can lay content out side by side.

# What?
A `::::columns` Markdown block, authored in the CMS and rendered by the site:

* The block is tracked as a content schema
* It includes both a a remark transform, and a Gatsby wrapper for that remark transform.
* It also includes a new `Column` component
* Lastly a horrible way of wiring it into Decap using all of the above.

The stored Markdown is the contract, so the site and the CMS preview render from the same source.

# Anything else?
It looks like this:
<img width="1590" height="894" alt="image" src="https://github.com/user-attachments/assets/1025e8eb-ce08-4039-bde0-a3e931200cc5" />
