### PR TITLE
Reader fixes

### DIFF
--- a/components/legacy-components/src/timeline-scroll/index.ts
+++ b/components/legacy-components/src/timeline-scroll/index.ts
@@ -1,0 +1,7 @@
+import "./timeline-scroll.scss"
+import TimelineScroll from "./timeline-scroll"
+export type { TimelineScrollProps } from "./timeline-scroll"
+export type { TimelineLevel, TimelineBucket } from "./timeline-scroll.logic"
+export { bucketKey, buildBuckets } from "./timeline-scroll.logic"
+export { TimelineScroll }
+export default TimelineScroll

--- a/components/legacy-components/src/timeline-scroll/timeline-scroll.logic.ts
+++ b/components/legacy-components/src/timeline-scroll/timeline-scroll.logic.ts
@@ -1,0 +1,69 @@
+import { format, startOfDay, startOfMonth, startOfYear } from "date-fns"
+
+export type TimelineLevel = "day" | "month" | "year"
+
+export type TimelineBucket = {
+  key: string
+  date: Date
+  count: number
+}
+
+const KEY_FORMAT: Record<TimelineLevel, string> = {
+  day: "yyyy-MM-dd",
+  month: "yyyy-MM",
+  year: "yyyy",
+}
+
+const START_OF: Record<TimelineLevel, (date: Date) => Date> = {
+  day: startOfDay,
+  month: startOfMonth,
+  year: startOfYear,
+}
+
+export const bucketKey = (date: Date, level: TimelineLevel): string =>
+  format(date, KEY_FORMAT[level])
+
+export const bucketStart = (date: Date, level: TimelineLevel): Date =>
+  START_OF[level](date)
+
+// Newest-first, to mirror the reader's reverse-chronological feed.
+export const buildBuckets = (dates: Date[], level: TimelineLevel): TimelineBucket[] => {
+  const byKey = new Map<string, TimelineBucket>()
+  for (const date of dates) {
+    const key = bucketKey(date, level)
+    const existing = byKey.get(key)
+    if (existing) existing.count += 1
+    else byKey.set(key, { key, date: bucketStart(date, level), count: 1 })
+  }
+  return [...byKey.values()].sort((a, b) => b.date.getTime() - a.date.getTime())
+}
+
+// visibleRange is [oldest, newest]; reduced to the bucket keys at its endpoints.
+// Fixed-width keys (yyyy-MM-dd etc.) compare lexicographically in date order, so
+// a bucket is highlighted when lo <= key <= hi.
+export type ActiveRange = { lo: string; hi: string }
+
+export const activeRange = (
+  visibleRange: [Date, Date] | null,
+  level: TimelineLevel,
+): ActiveRange | null => {
+  if (!visibleRange) return null
+  const [oldest, newest] = visibleRange
+  return { lo: bucketKey(oldest, level), hi: bucketKey(newest, level) }
+}
+
+export const isActive = (key: string, range: ActiveRange | null): boolean =>
+  !!range && key >= range.lo && key <= range.hi
+
+export const detectLevels = (dates: Date[]): TimelineLevel[] => {
+  const months = new Set<string>()
+  const years = new Set<string>()
+  for (const date of dates) {
+    months.add(bucketKey(date, "month"))
+    years.add(bucketKey(date, "year"))
+  }
+  const levels: TimelineLevel[] = ["day"]
+  if (months.size > 1) levels.push("month")
+  if (years.size > 1) levels.push("year")
+  return levels
+}

--- a/components/legacy-components/src/timeline-scroll/timeline-scroll.scss
+++ b/components/legacy-components/src/timeline-scroll/timeline-scroll.scss
@@ -1,0 +1,176 @@
+@use "../util-palette/palette" as *;
+
+.alex-timeline-scroll {
+  display: flex;
+  flex-direction: column;
+  user-select: none;
+  font-size: 0.75rem;
+
+  &__levels {
+    display: flex;
+    gap: 0.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  &__level {
+    flex: 1;
+    font: inherit;
+    font-size: 0.7rem;
+    padding: 0.15rem 0;
+    background: none;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    color: $grey-4;
+    cursor: pointer;
+
+    &:hover {
+      color: $grey-5;
+    }
+
+    &--active {
+      color: $grey-5;
+      font-weight: 600;
+      border-bottom-color: $grey-5;
+    }
+  }
+
+  &__body {
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  &__section {
+    margin-bottom: 0;
+  }
+
+  // Single weekday header, sticky over the continuous scroll. Same 7 columns as
+  // the day grids so everything lines up.
+  &__weekdays {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 2px;
+    padding-bottom: 2px;
+    background: $white;
+  }
+
+  // Off-screen months skip layout/paint; the browser remembers each section's
+  // real size after first render, so the scrollbar stays stable.
+  &--virtualized &__section {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 12rem;
+  }
+
+  &__heading {
+    margin: 0.4rem 0 0.25rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: $grey-5;
+  }
+
+  &__grid {
+    display: grid;
+    gap: 2px;
+
+    &--days {
+      grid-template-columns: repeat(7, 1fr);
+    }
+
+    &--months {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    &--years {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__weekday {
+    text-align: center;
+    font-size: 0.6rem;
+    color: $grey-4;
+    padding-bottom: 2px;
+  }
+
+  &__cell {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font: inherit;
+    font-size: 0.65rem;
+    border: 0;
+    border-radius: 3px;
+    padding: 0;
+    margin: 0;
+    background: $grey-1;
+    color: $grey-4;
+
+    &--blank {
+      background: none;
+    }
+
+    &--empty {
+      background: none;
+      color: $grey-3;
+    }
+
+    &--filled {
+      color: $grey-5;
+      cursor: pointer;
+
+      &:hover {
+        outline: 1px solid $grey-4;
+      }
+    }
+
+    &--active {
+      outline: 2px solid $grey-5;
+      outline-offset: -1px;
+      color: $grey-6;
+      font-weight: 600;
+    }
+  }
+
+  // Compact day cells, but tall enough to be reasonable tap targets.
+  &__grid--days &__cell {
+    height: 1.4rem;
+    font-size: 0.7rem;
+  }
+
+  &__grid--months &__cell {
+    padding: 0.5rem 0;
+  }
+
+  &__grid--years &__cell {
+    justify-content: flex-start;
+    padding: 0.3rem 0.5rem;
+  }
+
+  &__fill {
+    position: absolute;
+    inset: 0;
+    border-radius: 3px;
+    background: $grey-5;
+    pointer-events: none;
+  }
+
+  &__num {
+    position: relative;
+  }
+}
+
+// Scrollbar selectors must stay top-level (not nested) for macOS to switch
+// between overlay and legacy scrollbars correctly.
+.alex-timeline-scroll__body::-webkit-scrollbar {
+  -webkit-appearance: none;
+  width: 7px;
+}
+
+.alex-timeline-scroll__body::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background-color: rgba(0, 0, 0, 0.4);
+  -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+}

--- a/components/legacy-components/src/timeline-scroll/timeline-scroll.stories.tsx
+++ b/components/legacy-components/src/timeline-scroll/timeline-scroll.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { subDays } from "date-fns"
+import React from "react"
+import TimelineScroll from "."
+
+const today = new Date()
+const dates = [
+  ...Array.from({ length: 200 }, (_, i) => subDays(today, Math.floor(i / 3))),
+  ...Array.from({ length: 120 }, (_, i) => subDays(today, 70 + i * 7)),
+]
+
+const meta: Meta<typeof TimelineScroll> = {
+  title: "Legacy/Molecules/TimelineScroll",
+  component: TimelineScroll,
+  args: {
+    dates,
+    visibleRange: [subDays(today, 12), subDays(today, 7)],
+    onJump: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "80vh", width: "16rem" }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Levels auto-detect from the content.
+export const Days: Story = {}
+export const Months: Story = { args: { defaultLevel: "month" } }
+export const Years: Story = { args: { defaultLevel: "year" } }
+
+// A short span auto-detects to Days only (no switcher).
+export const SingleMonth: Story = {
+  args: { dates: Array.from({ length: 40 }, (_, i) => subDays(today, i)) },
+}
+
+// An explicit `levels` forces them regardless of content.
+export const ForcedLevels: Story = {
+  args: { levels: ["month", "year"], defaultLevel: "month" },
+}

--- a/components/legacy-components/src/timeline-scroll/timeline-scroll.tsx
+++ b/components/legacy-components/src/timeline-scroll/timeline-scroll.tsx
@@ -1,0 +1,254 @@
+import {
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  format,
+  getDay,
+  startOfMonth,
+  startOfYear,
+  subMonths,
+  subYears,
+} from "date-fns"
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import {
+  TimelineLevel,
+  activeRange,
+  bucketKey,
+  buildBuckets,
+  detectLevels,
+  isActive,
+} from "./timeline-scroll.logic"
+
+const LEVEL_LABEL: Record<TimelineLevel, string> = {
+  day: "Days",
+  month: "Months",
+  year: "Years",
+}
+
+// Monday-first weekday headers for the day grid.
+const WEEKDAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+
+type DaySlot = { day: Date } | { blank: string }
+
+const plural = (n: number) => `${n} ${n === 1 ? "item" : "items"}`
+
+export type TimelineScrollProps = {
+  /** Every date that has content. Bucketed by the active level. */
+  dates: Date[]
+  /** The slice currently on screen as [oldest, newest]; its cells are highlighted. */
+  visibleRange?: [Date, Date] | null
+  /** A cell was clicked — jump the host's scroll to content at this date. */
+  onJump: (date: Date) => void
+  /** Zoom levels to offer. Omit to auto-detect from the content (days always,
+   *  months/years once it spans more than one). */
+  levels?: TimelineLevel[]
+  /** Controlled active level; omit to let the component manage it. */
+  level?: TimelineLevel
+  defaultLevel?: TimelineLevel
+  onLevelChange?: (level: TimelineLevel) => void
+  /** Skip layout/paint for off-screen month sections (content-visibility) so
+   *  large collections scroll smoothly. Defaults to true. */
+  virtualize?: boolean
+  className?: string
+}
+
+export default function TimelineScroll({
+  dates,
+  visibleRange = null,
+  onJump,
+  levels: levelsProp,
+  level: controlledLevel,
+  defaultLevel,
+  onLevelChange,
+  virtualize = true,
+  className,
+}: TimelineScrollProps) {
+  // Without an explicit list, offer only the levels the content fills.
+  const levels = useMemo(() => levelsProp ?? detectLevels(dates), [levelsProp, dates])
+  const [internalLevel, setInternalLevel] = useState<TimelineLevel>(
+    defaultLevel ?? levels[0],
+  )
+  const requestedLevel = controlledLevel ?? internalLevel
+  // Guard against an active level the current content no longer offers.
+  const level = levels.includes(requestedLevel) ? requestedLevel : levels[0]
+  const changeLevel = (next: TimelineLevel) => {
+    if (controlledLevel === undefined) setInternalLevel(next)
+    onLevelChange?.(next)
+  }
+
+  const buckets = useMemo(() => buildBuckets(dates, level), [dates, level])
+  const counts = useMemo(
+    () => new Map(buckets.map((b) => [b.key, b.count])),
+    [buckets],
+  )
+  const maxCount = useMemo(
+    () => buckets.reduce((max, b) => Math.max(max, b.count), 0),
+    [buckets],
+  )
+
+  const range = useMemo(() => activeRange(visibleRange, level), [visibleRange, level])
+  // The newest highlighted cell — anchors the auto-scroll as the feed moves.
+  const anchorKey = range?.hi ?? null
+
+  const anchorRef = useRef<HTMLButtonElement>(null)
+  useEffect(() => {
+    anchorRef.current?.scrollIntoView({ block: "nearest" })
+  }, [anchorKey])
+
+  // Render one cell for a date at the active level: an interactive, shaded cell
+  // when it has content, otherwise a muted placeholder.
+  const cell = (date: Date, label: string) => {
+    const key = bucketKey(date, level)
+    const count = counts.get(key) ?? 0
+    if (count === 0) {
+      return (
+        <span
+          key={key}
+          className="alex-timeline-scroll__cell alex-timeline-scroll__cell--empty"
+        >
+          {label}
+        </span>
+      )
+    }
+    const active = isActive(key, range)
+    const intensity = maxCount > 0 ? 0.1 + 0.35 * (count / maxCount) : 0
+    return (
+      <button
+        key={key}
+        ref={key === anchorKey ? anchorRef : undefined}
+        type="button"
+        className={`alex-timeline-scroll__cell alex-timeline-scroll__cell--filled${
+          active ? " alex-timeline-scroll__cell--active" : ""
+        }`}
+        aria-current={active ? "true" : undefined}
+        aria-label={`${format(date, ariaFormat(level))} — ${plural(count)}`}
+        onClick={() => onJump(date)}
+      >
+        <span className="alex-timeline-scroll__fill" style={{ opacity: intensity }} />
+        <span className="alex-timeline-scroll__num">{label}</span>
+      </button>
+    )
+  }
+
+  const newest = buckets[0]?.date
+  const oldest = buckets[buckets.length - 1]?.date
+
+  let body: React.ReactNode = null
+  if (newest && oldest && level === "day") {
+    // One sticky weekday header for the whole scroll (every month aligns to the
+    // same Monday-first columns), then the months flow continuously beneath it.
+    body = (
+      <>
+        <div className="alex-timeline-scroll__weekdays">
+          {WEEKDAYS.map((day) => (
+            <span key={day} className="alex-timeline-scroll__weekday">
+              {day}
+            </span>
+          ))}
+        </div>
+        {descendingMonths(newest, oldest).map((month) => {
+          const lead = (getDay(month) + 6) % 7 // Monday-first offset
+          const days = eachDayOfInterval({ start: month, end: endOfMonth(month) })
+          // Pad to whole weeks, then reverse the week order so the most recent
+          // week sits at the top — matching the feed's newest-first direction.
+          const slots: DaySlot[] = [
+            ...Array.from({ length: lead }, (_, i): DaySlot => ({ blank: `lead-${i}` })),
+            ...days.map((day): DaySlot => ({ day })),
+          ]
+          const trailing = (7 - (slots.length % 7)) % 7
+          for (let i = 0; i < trailing; i++) slots.push({ blank: `trail-${i}` })
+          const weeks: DaySlot[][] = []
+          for (let i = 0; i < slots.length; i += 7) weeks.push(slots.slice(i, i + 7))
+          weeks.reverse()
+          return (
+            <section key={month.toISOString()} className="alex-timeline-scroll__section">
+              <h3 className="alex-timeline-scroll__heading">{format(month, "MMMM yyyy")}</h3>
+              <div className="alex-timeline-scroll__grid alex-timeline-scroll__grid--days">
+                {weeks.flat().map((slot) =>
+                  "day" in slot ? (
+                    cell(slot.day, String(slot.day.getDate()))
+                  ) : (
+                    <span key={slot.blank} className="alex-timeline-scroll__cell--blank" />
+                  ),
+                )}
+              </div>
+            </section>
+          )
+        })}
+      </>
+    )
+  } else if (newest && oldest && level === "month") {
+    body = descendingYears(newest, oldest).map((year) => (
+      <section key={year.toISOString()} className="alex-timeline-scroll__section">
+        <h3 className="alex-timeline-scroll__heading">{format(year, "yyyy")}</h3>
+        <div className="alex-timeline-scroll__grid alex-timeline-scroll__grid--months">
+          {Array.from({ length: 12 }, (_, i) => {
+            const month = addMonths(year, 11 - i) // Dec → Jan, newest first
+            return cell(month, format(month, "MMM"))
+          })}
+        </div>
+      </section>
+    ))
+  } else if (newest && oldest) {
+    body = (
+      <div className="alex-timeline-scroll__grid alex-timeline-scroll__grid--years">
+        {descendingYears(newest, oldest).map((year) => cell(year, format(year, "yyyy")))}
+      </div>
+    )
+  }
+
+  if (buckets.length === 0) return null
+
+  const classes = [
+    "alex-timeline-scroll",
+    virtualize && "alex-timeline-scroll--virtualized",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  return (
+    <nav className={classes} aria-label="Calendar">
+      {levels.length > 1 && (
+        <div className="alex-timeline-scroll__levels" role="group" aria-label="Zoom level">
+          {levels.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={`alex-timeline-scroll__level${
+                option === level ? " alex-timeline-scroll__level--active" : ""
+              }`}
+              aria-pressed={option === level}
+              onClick={() => changeLevel(option)}
+            >
+              {LEVEL_LABEL[option]}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="alex-timeline-scroll__body">{body}</div>
+    </nav>
+  )
+}
+
+const ariaFormat = (level: TimelineLevel): string =>
+  level === "day" ? "d MMMM yyyy" : level === "month" ? "MMMM yyyy" : "yyyy"
+
+// Month starts from newest to oldest, inclusive — to mirror a reverse-chron feed.
+const descendingMonths = (newest: Date, oldest: Date): Date[] => {
+  const months: Date[] = []
+  const last = startOfMonth(oldest).getTime()
+  for (let m = startOfMonth(newest); m.getTime() >= last; m = subMonths(m, 1)) {
+    months.push(m)
+  }
+  return months
+}
+
+const descendingYears = (newest: Date, oldest: Date): Date[] => {
+  const years: Date[] = []
+  const last = startOfYear(oldest).getTime()
+  for (let y = startOfYear(newest); y.getTime() >= last; y = subYears(y, 1)) {
+    years.push(y)
+  }
+  return years
+}

--- a/services/reader/client/src/components/feed-list.tsx
+++ b/services/reader/client/src/components/feed-list.tsx
@@ -1,8 +1,16 @@
-import React, { useEffect, useMemo, useRef } from "react"
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from "react"
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso"
 import { FeedEntry } from "../lib/entries"
 import { loadSnapshot, saveSnapshot } from "../lib/scroll-state"
 import { ReaderItem } from "./reader-item"
+
+export type FeedListHandle = { scrollToIndex: (index: number) => void }
 
 type Props = {
   entries: FeedEntry[]
@@ -11,19 +19,32 @@ type Props = {
   restoreKey?: string
   onOpen: (id: string) => void
   onToggle: (id: string, read: boolean) => void
+  onRangeChange?: (range: { startIndex: number; endIndex: number }) => void
   empty?: string
 }
 
-export const FeedList = ({
-  entries,
-  readIds,
-  showSummary = true,
-  restoreKey,
-  onOpen,
-  onToggle,
-  empty = "Nothing to read.",
-}: Props) => {
+export const FeedList = forwardRef<FeedListHandle, Props>(function FeedList(
+  {
+    entries,
+    readIds,
+    showSummary = true,
+    restoreKey,
+    onOpen,
+    onToggle,
+    onRangeChange,
+    empty = "Nothing to read.",
+  },
+  handle,
+) {
   const ref = useRef<VirtuosoHandle>(null)
+  useImperativeHandle(
+    handle,
+    () => ({
+      scrollToIndex: (index) =>
+        ref.current?.scrollToIndex({ index, align: "start", behavior: "smooth" }),
+    }),
+    [],
+  )
   // Snapshot for this filter/view, read once so Virtuoso can restore scroll.
   const initialState = useMemo(() => loadSnapshot(restoreKey), [restoreKey])
 
@@ -45,6 +66,7 @@ export const FeedList = ({
       data={entries}
       restoreStateFrom={initialState}
       initialItemCount={Math.min(8, entries.length)}
+      rangeChanged={onRangeChange}
       // A restored scroll snapshot can reference indices past a now-shorter list
       // (different/stale capture), so tolerate an out-of-range entry rather than
       // crash; Virtuoso self-corrects on the next layout.
@@ -62,6 +84,6 @@ export const FeedList = ({
       }
     />
   )
-}
+})
 
 export default FeedList

--- a/services/reader/client/src/scss/main.scss
+++ b/services/reader/client/src/scss/main.scss
@@ -173,6 +173,57 @@ html, body {
   }
 }
 
+// The calendar sits at the top of the sticky sidebar. Fix its height to roughly
+// one month so every feed reserves the same space — a dense firehose (~1 month)
+// fills it, a sparse feed spanning many months scrolls within it — and the
+// filters below stay reachable.
+.reader-calendar {
+  margin-bottom: 1.5rem;
+
+  // Collapsed by default on mobile (where the sidebar stacks above the feed);
+  // a tappable disclosure row.
+  > summary {
+    font-family: inherit;
+    font-size: 0.9rem;
+    color: $grey-5;
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    padding: 0.25rem 0;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &::after {
+      content: "▶";
+      font-size: 0.6em;
+      color: $grey-4;
+      transition: transform 0.2s ease;
+    }
+  }
+
+  &[open] > summary::after {
+    transform: rotate(90deg);
+  }
+
+  .alex-timeline-scroll__body {
+    height: 20rem;
+  }
+}
+
+@include media(">tablet") {
+  .reader-calendar > summary {
+    display: none;
+  }
+
+  .reader-calendar:not([open])::details-content {
+    content-visibility: visible;
+  }
+}
+
 .reader-filter__toggle {
   display: flex;
   align-items: center;

--- a/services/reader/client/src/scss/main.scss
+++ b/services/reader/client/src/scss/main.scss
@@ -149,6 +149,28 @@ html, body {
     top: calc(48px + 0.5rem);
     align-self: start;
   }
+
+  // Filter sections render collapsed so they start closed on mobile (where the
+  // sidebar stacks above the list and eats the screen). CSS can't set a
+  // <details>'s open attribute, so instead we reveal any still-collapsed
+  // section here — above tablet the filters are always shown.
+  .reader-stream .alex-stream__filter-section:not([open]) {
+    > summary {
+      pointer-events: none;
+
+      &::after {
+        transform: rotate(90deg);
+      }
+    }
+
+    > .alex-stream__topics-list {
+      display: block;
+    }
+
+    &::details-content {
+      content-visibility: visible;
+    }
+  }
 }
 
 .reader-filter__toggle {

--- a/services/reader/client/src/views/feed.tsx
+++ b/services/reader/client/src/views/feed.tsx
@@ -1,9 +1,13 @@
-import React, { useEffect, useMemo, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useLoaderData, type LoaderFunctionArgs } from "react-router-dom"
 
 import Stream from "@alexwilson/ds-legacy-components/src/stream"
+import TimelineScroll, {
+  TimelineLevel,
+  bucketKey,
+} from "@alexwilson/ds-legacy-components/src/timeline-scroll"
 
-import { FeedList } from "../components/feed-list"
+import { FeedList, FeedListHandle } from "../components/feed-list"
 import { byPublishedDesc, type FeedEntry } from "../lib/entries"
 import { useReadState } from "../lib/read-state"
 import { getFeed, getIndex, type Index } from "../lib/api"
@@ -56,6 +60,35 @@ function FeedView({
     [entries, readIds],
   )
 
+  // Calendar rail: track the on-screen range and jump to a clicked date. The
+  // feed is reverse-chronological, so startIndex is newest and endIndex oldest.
+  const listRef = useRef<FeedListHandle>(null)
+  const [range, setRange] = useState<{ startIndex: number; endIndex: number } | null>(null)
+  const [level, setLevel] = useState<TimelineLevel>("day")
+
+  const timelineDates = useMemo(
+    () => visible.map((e) => new Date(e.publishedAt)),
+    [visible],
+  )
+  const visibleRange = useMemo<[Date, Date] | null>(() => {
+    if (!range || visible.length === 0) return null
+    const newest = visible[Math.min(range.startIndex, visible.length - 1)]
+    const oldest = visible[Math.min(range.endIndex, visible.length - 1)]
+    if (!newest || !oldest) return null
+    return [new Date(oldest.publishedAt), new Date(newest.publishedAt)]
+  }, [range, visible])
+
+  const jumpToDate = useCallback(
+    (date: Date) => {
+      const target = bucketKey(date, level)
+      const idx = visible.findIndex(
+        (e) => bucketKey(new Date(e.publishedAt), level) === target,
+      )
+      if (idx >= 0) listRef.current?.scrollToIndex(idx)
+    },
+    [visible, level],
+  )
+
   return (
     <Stream
       className="reader-stream"
@@ -66,6 +99,16 @@ function FeedView({
       }
       sidebar={
         <>
+          <details className="reader-calendar">
+            <summary className="reader-calendar__summary">Calendar</summary>
+            <TimelineScroll
+              dates={timelineDates}
+              visibleRange={visibleRange}
+              onJump={jumpToDate}
+              level={level}
+              onLevelChange={setLevel}
+            />
+          </details>
           <p className="reader-sidebar-count">{unread} unread</p>
           <label className="reader-filter__toggle">
             <input
@@ -85,11 +128,13 @@ function FeedView({
       }
     >
       <FeedList
+        ref={listRef}
         entries={visible}
         readIds={readIds}
         restoreKey={`feed:${feedId}:${unreadOnly ? 1 : 0}`}
         onOpen={(id) => setRead(id, true)}
         onToggle={setRead}
+        onRangeChange={setRange}
         empty="No posts."
       />
     </Stream>

--- a/services/reader/client/src/views/reader.tsx
+++ b/services/reader/client/src/views/reader.tsx
@@ -229,7 +229,6 @@ function ReaderView({ entries, feeds, generatedAt }: ReaderViewProps) {
     () => [
       {
         title: "Sources",
-        defaultOpen: true,
         selected: [source],
         onSelect: changeSource,
         options: [
@@ -243,7 +242,6 @@ function ReaderView({ entries, feeds, generatedAt }: ReaderViewProps) {
       },
       {
         title: "Categories",
-        defaultOpen: true,
         selected: [category],
         onSelect: changeCategory,
         options: [

--- a/services/reader/client/src/views/reader.tsx
+++ b/services/reader/client/src/views/reader.tsx
@@ -1,12 +1,16 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useLoaderData, useRevalidator } from "react-router-dom"
 
 import Stream from "@alexwilson/ds-legacy-components/src/stream"
 import StreamFilters, {
   FilterSection,
 } from "@alexwilson/ds-legacy-components/src/stream-filters"
+import TimelineScroll, {
+  TimelineLevel,
+  bucketKey,
+} from "@alexwilson/ds-legacy-components/src/timeline-scroll"
 
-import { FeedList } from "../components/feed-list"
+import { FeedList, FeedListHandle } from "../components/feed-list"
 import { FeedEntry, byPublishedDesc, relativeTime } from "../lib/entries"
 import { useReadState } from "../lib/read-state"
 import { getIndex, getRiver, type Feed, type Index, type River } from "../lib/api"
@@ -202,6 +206,36 @@ function ReaderView({ entries, feeds, generatedAt }: ReaderViewProps) {
     [arranged, readIds],
   )
 
+  // Timeline rail: track which entries are on screen and let the rail jump to a
+  // date. Virtuoso's rendered range is reverse-chronological, so startIndex is
+  // the newest visible entry and endIndex the oldest.
+  const listRef = useRef<FeedListHandle>(null)
+  const [range, setRange] = useState<{ startIndex: number; endIndex: number } | null>(null)
+  const [level, setLevel] = useState<TimelineLevel>("day")
+
+  const timelineDates = useMemo(
+    () => visible.map((e) => new Date(e.publishedAt)),
+    [visible],
+  )
+  const visibleRange = useMemo<[Date, Date] | null>(() => {
+    if (!range || visible.length === 0) return null
+    const newest = visible[Math.min(range.startIndex, visible.length - 1)]
+    const oldest = visible[Math.min(range.endIndex, visible.length - 1)]
+    if (!newest || !oldest) return null
+    return [new Date(oldest.publishedAt), new Date(newest.publishedAt)]
+  }, [range, visible])
+
+  const jumpToDate = useCallback(
+    (date: Date) => {
+      const target = bucketKey(date, level)
+      const idx = visible.findIndex(
+        (e) => bucketKey(new Date(e.publishedAt), level) === target,
+      )
+      if (idx >= 0) listRef.current?.scrollToIndex(idx)
+    },
+    [visible, level],
+  )
+
   const unreadTotal = useMemo(
     () => river.filter((e) => !readIds.has(e.id)).length,
     [river, readIds],
@@ -303,6 +337,16 @@ function ReaderView({ entries, feeds, generatedAt }: ReaderViewProps) {
       }
       sidebar={
         <>
+          <details className="reader-calendar">
+            <summary className="reader-calendar__summary">Calendar</summary>
+            <TimelineScroll
+              dates={timelineDates}
+              visibleRange={visibleRange}
+              onJump={jumpToDate}
+              level={level}
+              onLevelChange={setLevel}
+            />
+          </details>
           <StreamFilters sections={sections} />
           <label className="reader-filter__toggle">
             <input
@@ -331,12 +375,14 @@ function ReaderView({ entries, feeds, generatedAt }: ReaderViewProps) {
       }
     >
       <FeedList
+        ref={listRef}
         entries={visible}
         readIds={readIds}
         showSummary={showSummary}
         restoreKey={`${view}:${source}:${category}:${unreadOnly ? 1 : 0}`}
         onOpen={(id) => setRead(id, true)}
         onToggle={setRead}
+        onRangeChange={setRange}
       />
     </Stream>
   )

--- a/services/reader/worker/env.ts
+++ b/services/reader/worker/env.ts
@@ -1,4 +1,5 @@
 export interface Env {
+  AUTH?: Fetcher // service binding to the auth worker (JWKS fetch); absent in dev
   AUTH_BASE_URL: string
   FEEDS_OWNER: string
   FEEDS_REPO: string

--- a/services/reader/worker/index.test.ts
+++ b/services/reader/worker/index.test.ts
@@ -5,6 +5,7 @@ vi.mock("./github", () => ({ fetchFeed: vi.fn() }))
 vi.mock("jose", () => ({
   createRemoteJWKSet: vi.fn(() => ({})),
   jwtVerify: vi.fn(),
+  customFetch: Symbol("customFetch"),
 }))
 
 import worker from "./index"

--- a/services/reader/worker/index.ts
+++ b/services/reader/worker/index.ts
@@ -1,4 +1,4 @@
-import { createRemoteJWKSet, jwtVerify } from "jose"
+import { createRemoteJWKSet, customFetch, jwtVerify } from "jose"
 
 import index from "../dist/index.html"
 import type { Env } from "./env"
@@ -70,7 +70,12 @@ async function authorized(request: Request, env: Env): Promise<boolean> {
   const token = bearer(request)
   if (!token) return false
 
-  jwks ??= createRemoteJWKSet(new URL("/auth/jwks", env.AUTH_BASE_URL))
+  jwks ??= createRemoteJWKSet(new URL("/auth/jwks", env.AUTH_BASE_URL), {
+    [customFetch]: (async (url, options) => {
+      const viaBinding = await env.AUTH?.fetch(url, options).catch(() => null)
+      return viaBinding?.ok ? viaBinding : fetch(url, options)
+    }) as typeof fetch,
+  })
   try {
     await jwtVerify(token, jwks, { issuer: env.AUTH_BASE_URL, audience: env.AUTH_BASE_URL })
     return true

--- a/services/reader/wrangler.toml
+++ b/services/reader/wrangler.toml
@@ -9,6 +9,10 @@ type = "Text"
 globs = ["**/*.html"]
 fallthrough = true
 
+[[services]]
+binding = "AUTH"
+service = "auth"
+
 [vars]
 AUTH_BASE_URL = "https://alexwilson.tech"
 FEEDS_OWNER = "alexwilson"


### PR DESCRIPTION
# Why?
A few gripes about usability while on mobile: Navigating long feeds can be annoying, and I don't need to always show filters.

# What?
Add new TimelineScroll component, and hide scroll by default.
