### PR TITLE
Replace filter with calendar

### DIFF
--- a/components/legacy-components/src/header/header.tsx
+++ b/components/legacy-components/src/header/header.tsx
@@ -152,8 +152,12 @@ class Header extends Component<HeaderProps, HeaderState> {
 
   componentDidMount() {
     if (this.header.current && this.headerNav.current) {
-      this.header.current.style.top = `-${this.header.current.offsetHeight - this.headerNav.current.offsetHeight}px`
+      const navHeight = this.headerNav.current.offsetHeight
+      this.header.current.style.top = `-${this.header.current.offsetHeight - navHeight}px`
       this.header.current.style.position = "sticky"
+      // The nav stays pinned once the header shrinks; publish its height so
+      // sticky page content can offset itself to clear it.
+      document.documentElement.style.setProperty("--header-pinned-height", `${navHeight}px`)
     }
 
     if (!this.state.backgroundImage || this.state.backgroundImage === null) {

--- a/components/legacy-components/src/timeline-scroll/timeline-scroll.scss
+++ b/components/legacy-components/src/timeline-scroll/timeline-scroll.scss
@@ -121,14 +121,17 @@
       color: $grey-5;
       cursor: pointer;
 
+      // Draw the ring inside the cell; an outward outline is clipped by the
+      // paint containment on each (content-visibility) section.
       &:hover {
         outline: 1px solid $grey-4;
+        outline-offset: -1px;
       }
     }
 
     &--active {
       outline: 2px solid $grey-5;
-      outline-offset: -1px;
+      outline-offset: -2px;
       color: $grey-6;
       font-weight: 600;
     }

--- a/components/legacy-components/src/timeline-scroll/timeline-scroll.tsx
+++ b/components/legacy-components/src/timeline-scroll/timeline-scroll.tsx
@@ -87,13 +87,22 @@ export default function TimelineScroll({
   )
 
   const range = useMemo(() => activeRange(visibleRange, level), [visibleRange, level])
-  // The newest highlighted cell — anchors the auto-scroll as the feed moves.
-  const anchorKey = range?.hi ?? null
 
-  const anchorRef = useRef<HTMLButtonElement>(null)
+  // Keep the highlighted span centred as the feed moves. The newest cell (hi)
+  // sits at the top of the rail, the oldest (lo) below it; we recentre on the
+  // midpoint so a range spread across weeks or months stays framed.
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const hiRef = useRef<HTMLButtonElement>(null)
+  const loRef = useRef<HTMLButtonElement>(null)
   useEffect(() => {
-    anchorRef.current?.scrollIntoView({ block: "nearest" })
-  }, [anchorKey])
+    const body = bodyRef.current
+    const hi = hiRef.current
+    if (!body || !hi) return
+    const lo = loRef.current ?? hi
+    const bodyRect = body.getBoundingClientRect()
+    const spanCenter = (hi.getBoundingClientRect().top + lo.getBoundingClientRect().bottom) / 2
+    body.scrollTop += spanCenter - (bodyRect.top + bodyRect.height / 2)
+  }, [range?.lo, range?.hi])
 
   // Render one cell for a date at the active level: an interactive, shaded cell
   // when it has content, otherwise a muted placeholder.
@@ -115,7 +124,7 @@ export default function TimelineScroll({
     return (
       <button
         key={key}
-        ref={key === anchorKey ? anchorRef : undefined}
+        ref={key === range?.hi ? hiRef : key === range?.lo ? loRef : undefined}
         type="button"
         className={`alex-timeline-scroll__cell alex-timeline-scroll__cell--filled${
           active ? " alex-timeline-scroll__cell--active" : ""
@@ -226,7 +235,7 @@ export default function TimelineScroll({
           ))}
         </div>
       )}
-      <div className="alex-timeline-scroll__body">{body}</div>
+      <div ref={bodyRef} className="alex-timeline-scroll__body">{body}</div>
     </nav>
   )
 }

--- a/components/legacy-components/src/timeline-scroll/timeline-scroll.tsx
+++ b/components/legacy-components/src/timeline-scroll/timeline-scroll.tsx
@@ -120,7 +120,8 @@ export default function TimelineScroll({
       )
     }
     const active = isActive(key, range)
-    const intensity = maxCount > 0 ? 0.1 + 0.35 * (count / maxCount) : 0
+    // Gamma curve so quieter periods fade faster, widening the gradient.
+    const intensity = maxCount > 0 ? 0.08 + 0.22 * (count / maxCount) ** 1.5 : 0
     return (
       <button
         key={key}

--- a/services/personal-website/src/pages/blog.tsx
+++ b/services/personal-website/src/pages/blog.tsx
@@ -1,9 +1,13 @@
-import React, { useMemo } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { graphql, PageProps } from "gatsby"
 import Layout from "../components/layout"
 import Stream from "@alexwilson/ds-legacy-components/src/stream"
 import StreamFilters from "@alexwilson/ds-legacy-components/src/stream-filters"
 import ArticleCard from "@alexwilson/ds-legacy-components/src/article-card"
+import TimelineScroll, {
+  TimelineLevel,
+  bucketKey,
+} from "@alexwilson/ds-legacy-components/src/timeline-scroll"
 import Header from "@alexwilson/ds-legacy-components/src/header"
 import SEO from "../components/seo"
 import useStreamFilters from "../hooks/useStreamFilters"
@@ -29,27 +33,82 @@ const BlogPage = ({ data, location }: PageProps<BlogData>) => {
     () => data.content.edges.map(({ node }) => node),
     [data],
   )
-  const {
-    selectedYears,
-    years,
-    topics,
-    toggleYear,
-    filteredItems,
-    clearYears,
-  } = useStreamFilters(allPosts)
+  const { topics, filteredItems } = useStreamFilters(allPosts)
+
+  // Calendar rail: jump the page to the newest post in a clicked bucket. The
+  // feed isn't virtualized, so we scroll the matching card into view directly.
+  const cardRefs = useRef(new Map<string, HTMLDivElement>())
+  const [level, setLevel] = useState<TimelineLevel>("day")
+  const timelineDates = useMemo(
+    () => filteredItems.map((node) => new Date(node.date)),
+    [filteredItems],
+  )
+  const jumpToDate = useCallback(
+    (date: Date) => {
+      const target = bucketKey(date, level)
+      const match = filteredItems.find(
+        (node) => bucketKey(new Date(node.date), level) === target,
+      )
+      const el = match && cardRefs.current.get(match.contentId)
+      if (!el) return
+      // The site header is sticky and overlays the feed, so offset the scroll
+      // by its live height (it shrinks as you scroll) plus a small gap.
+      const header = document.querySelector(".alex-header")
+      const headerBottom = header?.getBoundingClientRect().bottom ?? 0
+      const top = el.getBoundingClientRect().top + window.scrollY - headerBottom - 16
+      window.scrollTo({ top, behavior: "smooth" })
+    },
+    [filteredItems, level],
+  )
+
+  // Highlight the calendar buckets for the posts currently on screen. The page
+  // (not an inner list) scrolls, so we track card visibility directly.
+  const [visibleRange, setVisibleRange] = useState<[Date, Date] | null>(null)
+  const dateById = useMemo(() => {
+    const map = new Map<string, number>()
+    filteredItems.forEach((node) => map.set(node.contentId, new Date(node.date).getTime()))
+    return map
+  }, [filteredItems])
+  useEffect(() => {
+    const onScreen = new Set<string>()
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        const id = (entry.target as HTMLElement).dataset.contentId
+        if (!id) continue
+        if (entry.isIntersecting) onScreen.add(id)
+        else onScreen.delete(id)
+      }
+      let lo = Infinity
+      let hi = -Infinity
+      onScreen.forEach((id) => {
+        const time = dateById.get(id)
+        if (time === undefined) return
+        if (time < lo) lo = time
+        if (time > hi) hi = time
+      })
+      setVisibleRange(lo <= hi ? [new Date(lo), new Date(hi)] : null)
+    })
+    cardRefs.current.forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [dateById])
 
   return (
     <Layout location={location}>
       <Header location={location} section="blog" compact />
       <Stream
+        className="blog-stream"
         sidebar={
-          <StreamFilters
-            years={years}
-            selectedYears={selectedYears}
-            onYearToggle={toggleYear}
-            topics={topics}
-            onClear={clearYears}
-          />
+          <>
+            <StreamFilters topics={topics} />
+            <TimelineScroll
+              className="blog-calendar"
+              dates={timelineDates}
+              visibleRange={visibleRange}
+              onJump={jumpToDate}
+              level={level}
+              onLevelChange={setLevel}
+            />
+          </>
         }
         header={
           <>
@@ -59,7 +118,16 @@ const BlogPage = ({ data, location }: PageProps<BlogData>) => {
         }
       >
         {filteredItems.map((node) => (
-          <ArticleCard key={node.id} article={node} withImage={false} />
+          <div
+            key={node.id}
+            data-content-id={node.contentId}
+            ref={(el) => {
+              if (el) cardRefs.current.set(node.contentId, el)
+              else cardRefs.current.delete(node.contentId)
+            }}
+          >
+            <ArticleCard article={node} withImage={false} />
+          </div>
         ))}
       </Stream>
     </Layout>

--- a/services/personal-website/src/scss/main.scss
+++ b/services/personal-website/src/scss/main.scss
@@ -14,6 +14,21 @@ code[class*="language-"] span, pre[class*="language-"] span {
     font-family: inherit;
 }
 
+.blog-calendar {
+	margin-top: 1.5rem;
+
+	.alex-timeline-scroll__body {
+		height: 20rem;
+	}
+}
+
+@include media(">tablet") {
+	.blog-stream .alex-stream__sidebar {
+		position: sticky;
+		top: calc(var(--header-pinned-height, 4rem) + 1rem);
+	}
+}
+
 .panel {
 	background: $brand;
 }


### PR DESCRIPTION
# Why?
Previously we added a Years filter for the Blog, but for the Feed Reader I created a replacement which works a bit better: A scrolling calendar.

# What?
Replace the Years filter on the blog page with a scrolling calendar.

# Anything else?

Before:
<img width="1545" height="995" alt="image" src="https://github.com/user-attachments/assets/1e65277a-b09b-43f5-8ed3-6d2b5ba9c53d" />


After:
<img width="1545" height="995" alt="image" src="https://github.com/user-attachments/assets/3f5cd9d8-4193-4b2c-8e42-d81b0e512ada" />
