### PR TITLE
Overhaul Fonts

### DIFF
--- a/components/legacy-components/src/article-card/article-card.scss
+++ b/components/legacy-components/src/article-card/article-card.scss
@@ -38,6 +38,10 @@
 		h3 {
 			margin: 0;
 		}
+
+		a {
+			font-family: inherit;
+		}
 	}
 
 	&__abstract {

--- a/components/legacy-components/src/header/header.scss
+++ b/components/legacy-components/src/header/header.scss
@@ -232,7 +232,7 @@
 
   &__name {
     color: white;
-    font-weight: 700;
+    font-weight: 800;
     text-transform: initial;
     font-size: 40pt;
     white-space: nowrap;

--- a/components/legacy-components/src/header/header.scss
+++ b/components/legacy-components/src/header/header.scss
@@ -240,6 +240,8 @@
   }
 
   &__surname {
+    font-family: inherit;
+
     @include media("<phone") {
       display: none;
     }

--- a/components/legacy-components/src/util-typography/type/_variables.scss
+++ b/components/legacy-components/src/util-typography/type/_variables.scss
@@ -5,7 +5,7 @@
 // Add weight and style details too.
 // ! Set cap height to set to the baseline.
 $bodytype: (
-  font-family: 'Georgia, serif',
+  font-family: 'Georgia, "BIZ UDPMincho", serif',
   regular: 400,
   bold: 700,
   italic: italic,
@@ -13,9 +13,9 @@ $bodytype: (
 ) !default;
 
 $headingtype: (
-  font-family: 'Helvetica, sans-serif',
+  font-family: '"Latin Dash", "M PLUS 2", Helvetica, sans-serif',
   regular: 400,
-  bold: 700,
+  bold: 750,
   cap-height: 0.66
 ) !default;
 

--- a/components/legacy-components/src/util-typography/typography.scss
+++ b/components/legacy-components/src/util-typography/typography.scss
@@ -1,16 +1,29 @@
 @forward "../util-palette/palette";
 @forward "./type/main";
+@use "sass:map";
+@use "sass:string";
 @use "../util-palette/palette" as *;
 @use "./type/main" as *;
 
-* {
-    font-family: "Avenir Next", Avenir, Arial, sans-serif;
+// Virtual font to render nicer emdashes.
+@font-face {
+    font-family: 'Latin Dash';
+    src: local('Helvetica Neue'), local('Helvetica'), local('Arial');
+    unicode-range: U+2013, U+2014;
+}
+
+body {
+    font-family: 'Latin Dash', 'M PLUS 2', Arial, sans-serif;
+    font-weight: 400;
+}
+
+button, input, select, textarea {
+    font-family: inherit;
 }
 
 @mixin heading {
-    .wf-active & {
-        font-family: 'Overpass', sans-serif;
-    }
+    font-family: string.unquote(map.get($headingtype, font-family));
+    font-weight: map.get($headingtype, bold);
 }
 
 .alex-article {

--- a/services/cms/client/main.ts
+++ b/services/cms/client/main.ts
@@ -27,6 +27,7 @@ export default function init() {
   CMS.registerWidget("uuid", Uuid);
   CMS.registerEditorComponent(makeColumnsEditorComponent(locales));
   CMS.registerPreviewTemplate("content", ArticlePreview);
+  CMS.registerPreviewStyle("https://fonts.googleapis.com/css2?family=BIZ+UDPMincho:wght@400;700&family=M+PLUS+2:wght@100..900&display=swap");
   CMS.registerPreviewStyle(ArticlePreviewStyles.toString(), { raw: true });
   CMS.registerPreviewStyle(columnsStyles.toString(), { raw: true });
 }

--- a/services/personal-website/gatsby-config.ts
+++ b/services/personal-website/gatsby-config.ts
@@ -223,7 +223,15 @@ const config: GatsbyConfig = {
       resolve: `gatsby-plugin-web-font-loader`,
       options: {
         google: {
-          families: ["Overpass:400,600,800"],
+          families: [
+            "BIZ UDPMincho:400,700",
+          ],
+        },
+        custom: {
+          families: ["M PLUS 2"],
+          urls: [
+            "https://fonts.googleapis.com/css2?family=M+PLUS+2:wght@100..900&display=swap",
+          ],
         },
       },
     },

--- a/services/reader/client/index.html
+++ b/services/reader/client/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Reader</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=BIZ+UDPMincho:wght@400;700&family=M+PLUS+2:wght@100..900&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/services/storybook/.storybook/preview-head.html
+++ b/services/storybook/.storybook/preview-head.html
@@ -1,3 +1,3 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Overpass:wght@400;600;800&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=BIZ+UDPMincho:wght@400;700&family=M+PLUS+2:wght@100..900&display=swap" rel="stylesheet">


### PR DESCRIPTION
# Why?
Typography was a bit inconsistent across the site, partly because I hacked custom headings and site UI on top of Sassline.  

# What?
1. Move headings back to be handled by Sassline, and use its design tokens.
2. Implement M Plus 2 as the new font for headings _and_ site UI.  It replaces both Overpass and Avenir Next, where I didn't originally realize that Avenir Next did not render on most devices!
3. Use the space saved by consolidating fonts to add BIZ UDPMincho as a new body style for Japanese text.
4. Add this to all the apps.

# Anything else?
I don't like how emdashes are rendered, so have added `Latin Dash` as a virtual font which picks only dashes from Helvetica.

|Before|After|
|-------|-----|
|<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/8d5c275f-ba35-496f-82f2-6a895ced7401" />|<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/ae630a02-19b4-4a15-8a1e-b6acb06d6244" />|
|<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/a04c89cd-936b-44ab-ad54-965fac6edee7" />|<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/9a606aee-3847-4f55-98da-a36f9055db16" />|

