### PR TITLE
chore: update csp for reader & cms

### DIFF
--- a/services/cms/worker/index.ts
+++ b/services/cms/worker/index.ts
@@ -19,9 +19,9 @@ import index from "../dist/index.html";
 const CSP = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.alexwilson.tech",
-  "style-src 'self' 'unsafe-inline' https://static.alexwilson.tech",
+  "style-src 'self' 'unsafe-inline' https://static.alexwilson.tech https://fonts.googleapis.com",
   "img-src 'self' data: blob: https:",
-  "font-src 'self' data: https://static.alexwilson.tech",
+  "font-src 'self' data: https://static.alexwilson.tech https://fonts.gstatic.com",
   "connect-src 'self' https://alexwilson.tech https://static.alexwilson.tech https://api.github.com https://uploads.github.com https://raw.githubusercontent.com",
   "frame-ancestors 'none'",
   "form-action 'self' https://github.com",

--- a/services/reader/worker/index.ts
+++ b/services/reader/worker/index.ts
@@ -8,10 +8,10 @@ import { resolveRepoPath } from "./routes"
 const CSP = [
   "default-src 'self'",
   "script-src 'self' https://static.alexwilson.tech",
-  "style-src 'self' 'unsafe-inline' https://static.alexwilson.tech",
+  "style-src 'self' 'unsafe-inline' https://static.alexwilson.tech https://fonts.googleapis.com",
   "img-src 'self' data: https:",
-  "font-src 'self' data: https://static.alexwilson.tech",
-  "connect-src 'self'",
+  "font-src 'self' data: https://static.alexwilson.tech https://fonts.gstatic.com",
+  "connect-src 'self' https://alexwilson.tech https://images.unsplash.com",
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",


### PR DESCRIPTION
# Why?
CSP blocks Google Fonts and Unsplash CDN.

# What?
Explicitly allow them.