### PR TITLE
Add Gelasio to font-stack for rendering Georgia-like on Linux devices

### DIFF
--- a/components/legacy-components/src/util-typography/type/_variables.scss
+++ b/components/legacy-components/src/util-typography/type/_variables.scss
@@ -5,7 +5,7 @@
 // Add weight and style details too.
 // ! Set cap height to set to the baseline.
 $bodytype: (
-  font-family: 'Georgia, "BIZ UDPMincho", serif',
+  font-family: '"Gelasio", Georgia, "BIZ UDPMincho", serif',
   regular: 400,
   bold: 700,
   italic: italic,

--- a/services/cms/client/main.ts
+++ b/services/cms/client/main.ts
@@ -27,7 +27,7 @@ export default function init() {
   CMS.registerWidget("uuid", Uuid);
   CMS.registerEditorComponent(makeColumnsEditorComponent(locales));
   CMS.registerPreviewTemplate("content", ArticlePreview);
-  CMS.registerPreviewStyle("https://fonts.googleapis.com/css2?family=BIZ+UDPMincho:wght@400;700&family=M+PLUS+2:wght@100..900&display=swap");
+  CMS.registerPreviewStyle("https://fonts.googleapis.com/css2?family=BIZ+UDPMincho:wght@400;700&family=Gelasio:ital,wght@0,400;0,700;1,400;1,700&family=M+PLUS+2:wght@100..900&display=swap");
   CMS.registerPreviewStyle(ArticlePreviewStyles.toString(), { raw: true });
   CMS.registerPreviewStyle(columnsStyles.toString(), { raw: true });
 }

--- a/services/personal-website/gatsby-config.ts
+++ b/services/personal-website/gatsby-config.ts
@@ -228,9 +228,9 @@ const config: GatsbyConfig = {
           ],
         },
         custom: {
-          families: ["M PLUS 2"],
+          families: ["Gelasio", "M PLUS 2"],
           urls: [
-            "https://fonts.googleapis.com/css2?family=M+PLUS+2:wght@100..900&display=swap",
+            "https://fonts.googleapis.com/css2?family=Gelasio:ital,wght@0,400;0,700;1,400;1,700&family=M+PLUS+2:wght@100..900&display=swap",
           ],
         },
       },

--- a/services/reader/client/index.html
+++ b/services/reader/client/index.html
@@ -6,7 +6,7 @@
     <title>Reader</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=BIZ+UDPMincho:wght@400;700&family=M+PLUS+2:wght@100..900&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=BIZ+UDPMincho:wght@400;700&family=Gelasio:ital,wght@0,400;0,700;1,400;1,700&family=M+PLUS+2:wght@100..900&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/services/storybook/.storybook/preview-head.html
+++ b/services/storybook/.storybook/preview-head.html
@@ -1,3 +1,3 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=BIZ+UDPMincho:wght@400;700&family=M+PLUS+2:wght@100..900&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=BIZ+UDPMincho:wght@400;700&family=Gelasio:ital,wght@0,400;0,700;1,400;1,700&family=M+PLUS+2:wght@100..900&display=swap" rel="stylesheet">


### PR DESCRIPTION
# Why?
In https://github.com/alexwilson/frontend/pull/3936 we added UDPMincho as a serif font for rendering body text in Japanese.
However: Linux devices (including Android) do not include Georgia, so it does not render, meaning UDPMincho is used as the serif font which is less readable than their default serif fonts.

# What?
Since Georgia was always intended (and I just didn't test on any Linux devices!), add Gelasio to the font-stack so devices for all devices (falling back to Georgia) which is basically compatible with all existing use-cases of Georgia.
