### PR TITLE
fix: freeze storybook for timeline-scroll

### DIFF
--- a/components/legacy-components/src/timeline-scroll/timeline-scroll.stories.tsx
+++ b/components/legacy-components/src/timeline-scroll/timeline-scroll.stories.tsx
@@ -3,10 +3,11 @@ import { subDays } from "date-fns"
 import React from "react"
 import TimelineScroll from "."
 
-const today = new Date()
+// Fixed anchor so snapshots stay deterministic across runs.
+const anchor = new Date(2024, 5, 15)
 const dates = [
-  ...Array.from({ length: 200 }, (_, i) => subDays(today, Math.floor(i / 3))),
-  ...Array.from({ length: 120 }, (_, i) => subDays(today, 70 + i * 7)),
+  ...Array.from({ length: 200 }, (_, i) => subDays(anchor, Math.floor(i / 3))),
+  ...Array.from({ length: 120 }, (_, i) => subDays(anchor, 70 + i * 7)),
 ]
 
 const meta: Meta<typeof TimelineScroll> = {
@@ -14,7 +15,7 @@ const meta: Meta<typeof TimelineScroll> = {
   component: TimelineScroll,
   args: {
     dates,
-    visibleRange: [subDays(today, 12), subDays(today, 7)],
+    visibleRange: [subDays(anchor, 12), subDays(anchor, 7)],
     onJump: () => {},
   },
   decorators: [
@@ -36,7 +37,7 @@ export const Years: Story = { args: { defaultLevel: "year" } }
 
 // A short span auto-detects to Days only (no switcher).
 export const SingleMonth: Story = {
-  args: { dates: Array.from({ length: 40 }, (_, i) => subDays(today, i)) },
+  args: { dates: Array.from({ length: 40 }, (_, i) => subDays(anchor, i)) },
 }
 
 // An explicit `levels` forces them regardless of content.


### PR DESCRIPTION
# Why?
The timeline scroll story used the current date, so the snapshots never matched.

# What?
Freeze the data!