### PR TITLE
TypeScript 6 migration

### DIFF
--- a/components/columns/package.json
+++ b/components/columns/package.json
@@ -26,6 +26,6 @@
     "@types/react": "18.3.28",
     "react": "18.3.1",
     "sass": "1.99.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/components/legacy-components/package.json
+++ b/components/legacy-components/package.json
@@ -16,7 +16,7 @@
     "@types/react": "18.3.28",
     "react": "18.3.1",
     "sass": "1.99.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "dependencies": {
     "@alexwilson/ds-icons": "workspace:*",

--- a/libraries/content/package.json
+++ b/libraries/content/package.json
@@ -34,7 +34,7 @@
     "mdast-util-directive": "3.1.0"
   },
   "devDependencies": {
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.8"
   }
 }

--- a/libraries/gatsby-source-github-repository/package.json
+++ b/libraries/gatsby-source-github-repository/package.json
@@ -48,7 +48,7 @@
     "@vitest/coverage-v8": "4.1.7",
     "gatsby": "^5.16.1",
     "joi": "^17.0.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/libraries/remark-content-blocks/package.json
+++ b/libraries/remark-content-blocks/package.json
@@ -41,7 +41,7 @@
     "remark-directive": "3.0.1",
     "remark-parse": "11.0.0",
     "remark-rehype": "11.1.2",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "unified": "11.0.5",
     "vfile": "6.0.3",
     "vitest": "4.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: 1.99.0
         version: 1.99.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   components/icons: {}
 
@@ -61,8 +61,8 @@ importers:
         specifier: 1.99.0
         version: 1.99.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   libraries/content:
     dependencies:
@@ -77,8 +77,8 @@ importers:
         version: 3.1.0
     devDependencies:
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
@@ -90,7 +90,7 @@ importers:
         version: link:../remark-content-blocks
       gatsby-transformer-remark:
         specifier: '>=6'
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))
       remark-directive:
         specifier: ^1.0.1
         version: 1.0.1
@@ -99,7 +99,7 @@ importers:
     dependencies:
       gatsby:
         specifier: '>2.0.0-alpha'
-        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
       unist-util-visit:
         specifier: 2.0.3
         version: 2.0.3
@@ -111,7 +111,7 @@ importers:
         version: 10.0.9
       gatsby-source-filesystem:
         specifier: ^5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       minimatch:
         specifier: ^10.0.0
         version: 10.2.5
@@ -127,13 +127,13 @@ importers:
         version: 4.1.7(vitest@4.1.8)
       gatsby:
         specifier: ^5.16.1
-        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       joi:
         specifier: ^17.0.0
         version: 17.13.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.8.0)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
@@ -172,8 +172,8 @@ importers:
         specifier: 11.1.2
         version: 11.1.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       unified:
         specifier: 11.0.5
         version: 11.0.5
@@ -218,8 +218,8 @@ importers:
         specifier: 0.31.10
         version: 0.31.10
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
@@ -358,10 +358,10 @@ importers:
         version: 4.0.0(webpack@5.106.2)
       terser-webpack-plugin:
         specifier: 5.6.0
-        version: 5.6.0(esbuild@0.28.0)(webpack@5.106.2)
+        version: 5.6.0(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.106.2)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       url:
         specifier: 0.11.4
         version: 0.11.4
@@ -370,7 +370,7 @@ importers:
         version: 4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
       webpack:
         specifier: 5.106.2
-        version: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+        version: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
       webpack-bundle-analyzer:
         specifier: 5.3.0
         version: 5.3.0
@@ -403,37 +403,37 @@ importers:
         version: 4.4.0
       gatsby:
         specifier: 5.16.1
-        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+        version: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       gatsby-plugin-feed:
         specifier: 5.16.0
-        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-sass:
         specifier: 6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       gatsby-plugin-sitemap:
         specifier: 6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-plugin-web-font-loader:
         specifier: 1.0.4
         version: 1.0.4
       gatsby-remark-embed-gist:
         specifier: 1.2.1
-        version: 1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react@18.3.1)
+        version: 1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react@18.3.1)
       gatsby-remark-embed-video:
         specifier: 3.2.1
         version: 3.2.1
       gatsby-remark-prismjs:
         specifier: 7.16.0
-        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0)
+        version: 7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0)
       gatsby-remark-twitter-cards:
         specifier: 0.6.1
-        version: 0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+        version: 0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
       gatsby-source-github-repository:
         specifier: workspace:*
         version: link:../../libraries/gatsby-source-github-repository
       gatsby-transformer-remark:
         specifier: 6.16.0
-        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+        version: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
       prismjs:
         specifier: 1.30.0
         version: 1.30.0
@@ -478,8 +478,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.8.0)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
@@ -533,8 +533,8 @@ importers:
         specifier: 4.1.5
         version: 4.1.5
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vite:
         specifier: 8.1.0
         version: 8.1.0(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)
@@ -568,25 +568,25 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@storybook/addon-docs':
         specifier: 10.4.0
-        version: 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+        version: 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))(webpack@5.106.2(esbuild@0.28.0))
       '@storybook/react':
         specifier: 10.4.0
-        version: 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       '@storybook/react-webpack5':
         specifier: 10.4.0
-        version: 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
       babel-loader:
         specifier: 10.1.1
-        version: 10.1.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+        version: 10.1.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.28.0))
       chromatic:
         specifier: 16.10.0
         version: 16.10.0
       css-loader:
         specifier: 7.1.4
-        version: 7.1.4(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+        version: 7.1.4(webpack@5.106.2(esbuild@0.28.0))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -598,16 +598,16 @@ importers:
         version: 1.99.0
       sass-loader:
         specifier: 16.0.8
-        version: 16.0.8(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+        version: 16.0.8(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0))
       storybook:
         specifier: 10.4.0
         version: 10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       style-loader:
         specifier: 4.0.0
-        version: 4.0.0(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+        version: 4.0.0(webpack@5.106.2(esbuild@0.28.0))
       webpack:
         specifier: 5.106.2
-        version: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+        version: 5.106.2(esbuild@0.28.0)
 
   services/webmention:
     dependencies:
@@ -650,10 +650,10 @@ importers:
         version: 0.28.0
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@25.8.0)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.8.0)(typescript@6.0.3)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.8.0)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))
@@ -12318,8 +12318,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -17462,10 +17462,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))':
+  '@storybook/addon-docs@10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))(webpack@5.106.2(esbuild@0.28.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.0(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.0(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))(webpack@5.106.2(esbuild@0.28.0))
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -17481,26 +17481,26 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-webpack5@10.4.0(esbuild@0.28.0)(postcss@8.5.15)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@10.4.0(esbuild@0.28.0)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)':
     dependencies:
       '@storybook/core-webpack': 10.4.0(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 7.1.4(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+      css-loader: 7.1.4(webpack@5.106.2(esbuild@0.28.0))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
-      html-webpack-plugin: 5.6.7(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0))
+      html-webpack-plugin: 5.6.7(webpack@5.106.2(esbuild@0.28.0))
       magic-string: 0.30.21
       storybook: 10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      style-loader: 4.0.0(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
-      terser-webpack-plugin: 5.6.0(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+      style-loader: 4.0.0(webpack@5.106.2(esbuild@0.28.0))
+      terser-webpack-plugin: 5.6.0(esbuild@0.28.0)(webpack@5.106.2(esbuild@0.28.0))
       ts-dedent: 2.2.0
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
-      webpack-dev-middleware: 6.1.3(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+      webpack: 5.106.2(esbuild@0.28.0)
+      webpack-dev-middleware: 6.1.3(webpack@5.106.2(esbuild@0.28.0))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@rspack/core'
@@ -17522,7 +17522,7 @@ snapshots:
       storybook: 10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.4.0(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))':
+  '@storybook/csf-plugin@10.4.0(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4))(webpack@5.106.2(esbuild@0.28.0))':
     dependencies:
       storybook: 10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
@@ -17530,7 +17530,7 @@ snapshots:
       esbuild: 0.28.0
       rollup: 4.60.4
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.8.4)
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.106.2(esbuild@0.28.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -17539,10 +17539,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/preset-react-webpack@10.4.0(esbuild@0.28.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/preset-react-webpack@10.4.0(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)':
     dependencies:
       '@storybook/core-webpack': 10.4.0(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0))
       '@types/semver': 7.7.1
       magic-string: 0.30.21
       react: 18.3.1
@@ -17552,9 +17552,9 @@ snapshots:
       semver: 7.8.1
       storybook: 10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.106.2(esbuild@0.28.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -17571,17 +17571,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0))':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
       micromatch: 4.0.8
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
       tslib: 2.8.1
-      typescript: 5.9.3
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      typescript: 6.0.3
+      webpack: 5.106.2(esbuild@0.28.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17594,16 +17594,16 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@storybook/react-webpack5@10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react-webpack5@10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)':
     dependencies:
-      '@storybook/builder-webpack5': 10.4.0(esbuild@0.28.0)(postcss@8.5.15)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 10.4.0(esbuild@0.28.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
-      '@storybook/react': 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 10.4.0(esbuild@0.28.0)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+      '@storybook/preset-react-webpack': 10.4.0(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+      '@storybook/react': 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       storybook: 10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@rspack/core'
@@ -17623,19 +17623,19 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react@10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.4.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-docgen: 8.0.3
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 18.3.1(react@18.3.1)
       storybook: 10.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17977,34 +17977,34 @@ snapshots:
 
   '@types/zen-observable@0.8.7': {}
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.8.3
-      tsutils: 3.21.0(typescript@5.9.3)
+      tsutils: 3.21.0(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
       debug: 4.4.3
       eslint: 7.32.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18013,21 +18013,21 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 7.32.0
-      tsutils: 3.21.0(typescript@5.9.3)
+      tsutils: 3.21.0(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@5.62.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -18035,20 +18035,20 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.8.3
-      tsutils: 3.21.0(typescript@5.9.3)
+      tsutils: 3.21.0(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@7.32.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       semver: 7.8.3
@@ -18665,19 +18665,19 @@ snapshots:
 
   babel-jsx-utils@1.1.0: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15)):
+  babel-loader@10.1.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
       '@babel/core': 7.29.0
       find-up: 5.0.0
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.106.2(esbuild@0.28.0)
 
   babel-loader@10.1.1(@babel/core@7.29.0)(webpack@5.106.2):
     dependencies:
       '@babel/core': 7.29.0
       find-up: 5.0.0
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
 
   babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
@@ -18741,28 +18741,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.7
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
 
-  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.7
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
 
-  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)):
+  babel-plugin-remove-graphql-queries@5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/runtime': 7.29.2
       '@babel/types': 7.29.7
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
@@ -19596,14 +19596,14 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.3
 
-  cosmiconfig@8.3.6(typescript@5.9.3):
+  cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   create-gatsby@3.16.0:
     dependencies:
@@ -19670,7 +19670,7 @@ snapshots:
       semver: 7.8.3
       webpack: 5.98.0(postcss@8.5.15)
 
-  css-loader@7.1.4(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15)):
+  css-loader@7.1.4(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -19681,7 +19681,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.1
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.106.2(esbuild@0.28.0)
 
   css-loader@7.1.4(webpack@5.106.2):
     dependencies:
@@ -19694,7 +19694,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.1
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
 
   css-minimizer-webpack-plugin@2.0.0(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
@@ -21621,20 +21621,20 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3):
+  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       babel-eslint: 10.1.0(eslint@7.32.0)
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   eslint-import-resolver-node@0.3.10:
     dependencies:
@@ -21644,11 +21644,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
@@ -21660,7 +21660,7 @@ snapshots:
       lodash: 4.18.1
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -21671,7 +21671,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@7.32.0)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -21683,7 +21683,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -22046,7 +22046,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
 
   file-loader@6.2.0(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
@@ -22139,7 +22139,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@7.32.0)(typescript@6.0.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@types/json-schema': 7.0.15
@@ -22154,12 +22154,12 @@ snapshots:
       schema-utils: 2.7.0
       semver: 7.8.3
       tapable: 1.1.3
-      typescript: 5.9.3
+      typescript: 6.0.3
       webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.15)
     optionalDependencies:
       eslint: 7.32.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(postcss@8.5.15)):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@7.32.0)(typescript@6.0.3)(webpack@5.98.0(postcss@8.5.15)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@types/json-schema': 7.0.15
@@ -22174,17 +22174,17 @@ snapshots:
       schema-utils: 2.7.0
       semver: 7.8.3
       tapable: 1.1.3
-      typescript: 5.9.3
+      typescript: 6.0.3
       webpack: 5.98.0(postcss@8.5.15)
     optionalDependencies:
       eslint: 7.32.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
       chokidar: 4.0.3
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
@@ -22193,8 +22193,8 @@ snapshots:
       schema-utils: 3.3.0
       semver: 7.8.3
       tapable: 2.3.3
-      typescript: 5.9.3
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      typescript: 6.0.3
+      webpack: 5.106.2(esbuild@0.28.0)
 
   form-data-encoder@2.1.4: {}
 
@@ -22376,13 +22376,13 @@ snapshots:
       '@parcel/transformer-js': 2.8.3(@parcel/core@2.8.3)
       '@parcel/transformer-json': 2.8.3(@parcel/core@2.8.3)
 
-  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  gatsby-plugin-feed@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       lodash.merge: 4.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -22393,7 +22393,7 @@ snapshots:
       - graphql
       - react-native-b4a
 
-  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.7
@@ -22401,10 +22401,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-page-utils: 3.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       globby: 11.1.0
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -22414,7 +22414,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.7
@@ -22422,10 +22422,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-page-utils: 3.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       globby: 11.1.0
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -22435,7 +22435,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-page-creator@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       '@babel/traverse': 7.29.7
@@ -22443,10 +22443,10 @@ snapshots:
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-page-utils: 3.16.0
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       globby: 11.1.0
       lodash: 4.18.1
     transitivePeerDependencies:
@@ -22456,10 +22456,10 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  gatsby-plugin-sass@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
+  gatsby-plugin-sass@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       resolve-url-loader: 3.1.5
       sass: 1.99.0
       sass-loader: 16.0.8(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
@@ -22469,17 +22469,17 @@ snapshots:
       - sass-embedded
       - webpack
 
-  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  gatsby-plugin-sitemap@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       common-tags: 1.8.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       minimatch: 3.1.5
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       sitemap: 7.1.3
 
-  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
@@ -22487,12 +22487,12 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
@@ -22500,12 +22500,12 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)):
+  gatsby-plugin-typescript@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
@@ -22513,17 +22513,17 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       fastq: 1.20.1
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.14.0
@@ -22536,12 +22536,12 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       fastq: 1.20.1
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.14.0
@@ -22554,12 +22554,12 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
+  gatsby-plugin-utils@4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0):
     dependencies:
       '@babel/runtime': 7.29.2
       fastq: 1.20.1
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gatsby-sharp: 1.16.0
       graphql: 16.14.0
@@ -22593,13 +22593,13 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  gatsby-remark-embed-gist@1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react@18.3.1):
+  gatsby-remark-embed-gist@1.2.1(encoding@0.1.13)(gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)))(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       async-unist-util-visit: 1.0.0
       cheerio: 1.2.0
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
-      gatsby-transformer-remark: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby-transformer-remark: 6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
       node-fetch: 2.7.0(encoding@0.1.13)
       parse-numeric-range: 1.3.0
       react: 18.3.1
@@ -22612,17 +22612,17 @@ snapshots:
       remark-burger: 1.0.1
       unist-util-visit: 2.0.3
 
-  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0):
+  gatsby-remark-prismjs@7.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(prismjs@1.30.0):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       parse-numeric-range: 1.3.0
       prismjs: 1.30.0
       unist-util-visit: 2.0.3
 
-  gatsby-remark-twitter-cards@0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+  gatsby-remark-twitter-cards@0.6.1(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
     dependencies:
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       jimp: 0.16.13
       path: 0.12.7
       wasm-twitter-card: 0.3.0
@@ -22649,23 +22649,23 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
+  gatsby-source-filesystem@5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/runtime': 7.29.2
       chokidar: 3.6.0
       file-type: 16.5.4
       fs-extra: 11.3.5
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       mime: 3.0.0
       pretty-bytes: 5.6.0
       valid-url: 1.0.9
       xstate: 4.38.3
 
-  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
+  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gray-matter: 4.0.3
       hast-util-raw: 6.1.0
@@ -22690,10 +22690,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)):
+  gatsby-transformer-remark@6.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)):
     dependencies:
       '@babel/runtime': 7.29.2
-      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
+      gatsby: 5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)
       gatsby-core-utils: 4.16.0
       gray-matter: 4.0.3
       hast-util-raw: 6.1.0
@@ -22727,7 +22727,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1):
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0
@@ -22755,8 +22755,8 @@ snapshots:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       '@sigmacomputing/babel-plugin-lodash': 3.3.5
       '@types/http-proxy': 1.17.17
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       '@vercel/webpack-asset-relocator-loader': 1.7.3
       acorn-loose: 8.5.2
       acorn-walk: 8.3.5
@@ -22768,7 +22768,7 @@ snapshots:
       babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
       babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -22793,9 +22793,9 @@ snapshots:
       enhanced-resolve: 5.21.2
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@6.0.3)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
@@ -22817,9 +22817,9 @@ snapshots:
       gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-page-utils: 3.16.0
       gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
-      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       gatsby-worker: 2.16.0
@@ -22866,7 +22866,7 @@ snapshots:
       query-string: 6.14.1
       raw-loader: 4.0.2(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
+      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@6.0.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
       react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@18.3.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
@@ -22933,7 +22933,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1):
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0
@@ -22961,8 +22961,8 @@ snapshots:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       '@sigmacomputing/babel-plugin-lodash': 3.3.5
       '@types/http-proxy': 1.17.17
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       '@vercel/webpack-asset-relocator-loader': 1.7.3
       acorn-loose: 8.5.2
       acorn-walk: 8.3.5
@@ -22974,7 +22974,7 @@ snapshots:
       babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
       babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -22999,9 +22999,9 @@ snapshots:
       enhanced-resolve: 5.21.2
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@6.0.3)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
@@ -23023,9 +23023,9 @@ snapshots:
       gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-page-utils: 3.16.0
       gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
-      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-worker: 2.16.0
@@ -23072,7 +23072,7 @@ snapshots:
       query-string: 6.14.1
       raw-loader: 4.0.2(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       react: 19.2.6
-      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
+      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@6.0.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       react-dom: 19.2.6(react@19.2.6)
       react-refresh: 0.14.2
       react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@19.2.6)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
@@ -23139,7 +23139,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1):
+  gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0
@@ -23167,8 +23167,8 @@ snapshots:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1)(webpack@5.98.0(postcss@8.5.15))
       '@sigmacomputing/babel-plugin-lodash': 3.3.5
       '@types/http-proxy': 1.17.17
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@6.0.3)
       '@vercel/webpack-asset-relocator-loader': 1.7.3
       acorn-loose: 8.5.2
       acorn-walk: 8.3.5
@@ -23180,7 +23180,7 @@ snapshots:
       babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.98.0(postcss@8.5.15))
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))
+      babel-plugin-remove-graphql-queries: 5.16.0(@babel/core@7.29.0)(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))
       babel-preset-gatsby: 3.16.0(@babel/core@7.29.0)(core-js@3.49.0)
       better-opn: 2.1.1
       bluebird: 3.7.2
@@ -23205,9 +23205,9 @@ snapshots:
       enhanced-resolve: 5.21.2
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)(typescript@5.9.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@5.9.3)
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@6.0.3)
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.9.3))(eslint@7.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.5(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
@@ -23229,9 +23229,9 @@ snapshots:
       gatsby-link: 5.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-page-utils: 3.16.0
       gatsby-parcel-config: 1.16.0(@parcel/core@2.8.3)
-      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
-      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))
-      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-page-creator: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
+      gatsby-plugin-typescript: 5.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))
+      gatsby-plugin-utils: 4.16.0(gatsby@5.16.1(babel-eslint@10.1.0(eslint@7.32.0))(encoding@0.1.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(type-fest@4.41.0)(typescript@6.0.3)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2))(webpack-hot-middleware@2.26.1))(graphql@16.14.0)
       gatsby-react-router-scroll: 6.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-script: 2.16.0(@gatsbyjs/reach-router@2.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       gatsby-worker: 2.16.0
@@ -23278,7 +23278,7 @@ snapshots:
       query-string: 6.14.1
       raw-loader: 4.0.2(webpack@5.98.0(postcss@8.5.15))
       react: 19.2.6
-      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(postcss@8.5.15))
+      react-dev-utils: 12.0.1(eslint@7.32.0)(typescript@6.0.3)(webpack@5.98.0(postcss@8.5.15))
       react-dom: 19.2.6(react@19.2.6)
       react-refresh: 0.14.2
       react-server-dom-webpack: 0.0.0-experimental-c8b778b7f-20220825(react@19.2.6)(webpack@5.98.0(postcss@8.5.15))
@@ -23780,7 +23780,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.7(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15)):
+  html-webpack-plugin@5.6.7(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -23788,7 +23788,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.106.2(esbuild@0.28.0)
 
   html-webpack-plugin@5.6.7(webpack@5.106.2):
     dependencies:
@@ -23798,7 +23798,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -26383,7 +26383,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
 
   raw-loader@4.0.2(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
@@ -26459,7 +26459,7 @@ snapshots:
       reactcss: 1.2.3(react@19.2.6)
       tinycolor2: 1.6.0
 
-  react-dev-utils@12.0.1(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
+  react-dev-utils@12.0.1(eslint@7.32.0)(typescript@6.0.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
       '@babel/code-frame': 7.29.7
       address: 1.2.2
@@ -26470,7 +26470,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@7.32.0)(typescript@6.0.3)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -26487,13 +26487,13 @@ snapshots:
       text-table: 0.2.0
       webpack: 5.98.0(esbuild@0.28.0)(postcss@8.5.15)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - eslint
       - supports-color
       - vue-template-compiler
 
-  react-dev-utils@12.0.1(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(postcss@8.5.15)):
+  react-dev-utils@12.0.1(eslint@7.32.0)(typescript@6.0.3)(webpack@5.98.0(postcss@8.5.15)):
     dependencies:
       '@babel/code-frame': 7.29.7
       address: 1.2.2
@@ -26504,7 +26504,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@7.32.0)(typescript@5.9.3)(webpack@5.98.0(postcss@8.5.15))
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@7.32.0)(typescript@6.0.3)(webpack@5.98.0(postcss@8.5.15))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -26521,7 +26521,7 @@ snapshots:
       text-table: 0.2.0
       webpack: 5.98.0(postcss@8.5.15)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -26557,9 +26557,9 @@ snapshots:
       '@types/node': 25.9.1
       '@types/react': 18.3.28
 
-  react-docgen-typescript@2.4.0(typescript@5.9.3):
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   react-docgen@7.1.1:
     dependencies:
@@ -27558,19 +27558,19 @@ snapshots:
       parse-srcset: 1.0.2
       postcss: 8.5.15
 
-  sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15)):
+  sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.99.0
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.106.2(esbuild@0.28.0)
 
   sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.99.0
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
 
   sass-loader@16.0.8(sass@1.99.0)(webpack@5.98.0(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
@@ -28295,13 +28295,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.98.0(postcss@8.5.15)
 
-  style-loader@4.0.0(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15)):
+  style-loader@4.0.0(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.106.2(esbuild@0.28.0)
 
   style-loader@4.0.0(webpack@5.106.2):
     dependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
 
   style-to-object@0.3.0:
     dependencies:
@@ -28434,13 +28434,13 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.6.0(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.0(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.106.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
     optionalDependencies:
       esbuild: 0.28.0
       postcss: 8.5.15
@@ -28463,17 +28463,6 @@ snapshots:
       schema-utils: 4.3.3
       terser: 5.47.1
       webpack: 5.106.2(esbuild@0.28.0)
-    optionalDependencies:
-      esbuild: 0.28.0
-    optional: true
-
-  terser-webpack-plugin@5.6.0(esbuild@0.28.0)(webpack@5.106.2):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.47.1
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
     optionalDependencies:
       esbuild: 0.28.0
 
@@ -28626,7 +28615,7 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@25.8.0)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -28640,7 +28629,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -28663,10 +28652,10 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsutils@3.21.0(typescript@5.9.3):
+  tsutils@3.21.0(typescript@6.0.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tsx@4.22.1:
     dependencies:
@@ -28751,7 +28740,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ua-parser-js@1.0.41: {}
 
@@ -29285,7 +29274,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-bundle-analyzer: 5.3.0
@@ -29309,7 +29298,7 @@ snapshots:
       schema-utils: 4.3.3
       webpack: 5.98.0(postcss@8.5.15)
 
-  webpack-dev-middleware@6.1.3(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15)):
+  webpack-dev-middleware@6.1.3(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -29317,7 +29306,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)
+      webpack: 5.106.2(esbuild@0.28.0)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.0)):
     dependencies:
@@ -29391,7 +29380,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2)
       ws: 8.20.1
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2)
+      webpack: 5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2)
       webpack-cli: 7.0.2(webpack-bundle-analyzer@5.3.0)(webpack-dev-server@5.2.4)(webpack@5.106.2)
     transitivePeerDependencies:
       - bufferutil
@@ -29629,9 +29618,8 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
-    optional: true
 
-  webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15):
+  webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15)(webpack-cli@7.0.2):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -29654,47 +29642,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.15))
-      watchpack: 2.5.1
-      webpack-sources: 3.4.1
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.106.2(esbuild@0.28.0)(webpack-cli@7.0.2):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.2
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.28.0)(webpack@5.106.2)
+      terser-webpack-plugin: 5.6.0(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.106.2)
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -30,7 +30,7 @@
     "@types/better-sqlite3": "7.6.13",
     "better-sqlite3": "12.10.0",
     "drizzle-kit": "0.31.10",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.8",
     "wrangler": "4.93.0"
   }

--- a/services/cms/package.json
+++ b/services/cms/package.json
@@ -43,7 +43,7 @@
     "stream-browserify": "3.0.0",
     "style-loader": "4.0.0",
     "terser-webpack-plugin": "5.6.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "url": "0.11.4",
     "vitest": "4.1.8",
     "webpack": "5.106.2",

--- a/services/personal-website/package.json
+++ b/services/personal-website/package.json
@@ -56,7 +56,7 @@
     "@types/sanitize-html": "2.16.1",
     "@vitejs/plugin-react": "6.0.2",
     "jsdom": "29.1.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.8"
   }
 }

--- a/services/personal-website/src/types/legacy-components.d.ts
+++ b/services/personal-website/src/types/legacy-components.d.ts
@@ -3,6 +3,8 @@ declare module '*.svg' {
   export default url
 }
 
+declare module '*.scss' {}
+
 declare module 'promise-image-loader' {
   export default function promiseImageLoader(image: HTMLImageElement): Promise<HTMLImageElement>
 }

--- a/services/personal-website/tsconfig.json
+++ b/services/personal-website/tsconfig.json
@@ -19,7 +19,6 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
       "react": ["./node_modules/@types/react"],
       "react/*": ["./node_modules/@types/react/*"]

--- a/services/reader/client/src/types/legacy-components.d.ts
+++ b/services/reader/client/src/types/legacy-components.d.ts
@@ -3,6 +3,8 @@ declare module '*.svg' {
   export default url
 }
 
+declare module '*.scss' {}
+
 declare module 'promise-image-loader' {
   export default function promiseImageLoader(image: HTMLImageElement): Promise<HTMLImageElement>
 }

--- a/services/reader/package.json
+++ b/services/reader/package.json
@@ -34,7 +34,7 @@
     "@types/react-dom": "18.3.7",
     "@vitejs/plugin-react": "6.0.2",
     "npm-run-all": "4.1.5",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "8.1.0",
     "vite-plugin-pwa": "1.3.0",
     "vitest": "4.1.8",

--- a/services/reader/tsconfig.json
+++ b/services/reader/tsconfig.json
@@ -19,7 +19,6 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
       "react": ["./node_modules/@types/react"],
       "react/*": ["./node_modules/@types/react/*"]

--- a/services/webmention/package.json
+++ b/services/webmention/package.json
@@ -19,7 +19,7 @@
     "aws-cdk": "2.1122.0",
     "esbuild": "0.28.0",
     "ts-node": "10.9.2",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.8"
   },
   "dependencies": {

--- a/services/webmention/tsconfig.json
+++ b/services/webmention/tsconfig.json
@@ -21,9 +21,7 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ]
+    "types": ["node"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
# Why?
Currently we're locked to TypeScript 5.

# What?
Bump to TypeScript 6.  No breaking changes other than needing to explicitly bring in some types.
