### PR TITLE
chore(cms): add blob to csp

### DIFF
--- a/services/cms/worker/index.ts
+++ b/services/cms/worker/index.ts
@@ -22,7 +22,7 @@ const CSP = [
   "style-src 'self' 'unsafe-inline' https://static.alexwilson.tech https://fonts.googleapis.com",
   "img-src 'self' data: blob: https:",
   "font-src 'self' data: https://static.alexwilson.tech https://fonts.gstatic.com",
-  "connect-src 'self' https://alexwilson.tech https://static.alexwilson.tech https://api.github.com https://uploads.github.com https://raw.githubusercontent.com",
+  "connect-src 'self' blob: https://alexwilson.tech https://static.alexwilson.tech https://api.github.com https://uploads.github.com https://raw.githubusercontent.com",
   "frame-ancestors 'none'",
   "form-action 'self' https://github.com",
   "base-uri 'self'",


### PR DESCRIPTION
# Why?
Since we tightened the CSP of the CMS app, image uploads are blocked.

# What?
Add `blob` URLs explicitly to CSP.
