### PR TITLE
new inter-post navigation for weeknotes

### DIFF
--- a/components/legacy-components/src/weeknote-navigation/index.tsx
+++ b/components/legacy-components/src/weeknote-navigation/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import './weeknote-navigation.scss'
+import ArticleCard, { type Article } from '../article-card'
+
+type Props = {
+  previous?: Article | null
+  next?: Article | null
+}
+
+type Entry = { label: string; weeknote: Article }
+
+export default function WeeknoteNavigation({ previous, next }: Props) {
+  const entries = [
+    { label: 'Previous Week', weeknote: previous },
+    { label: 'Next Week', weeknote: next },
+  ].filter((entry): entry is Entry => Boolean(entry.weeknote))
+
+  if (entries.length === 0) return null
+
+  return (
+    <nav className="alex-weeknote-nav" aria-label="Weeknotes">
+      <ul>
+        {entries.map(({ label, weeknote }) => (
+          <li key={label}>
+            <span className="alex-weeknote-nav__label">{label}</span>
+            <ArticleCard article={weeknote} withBody={false} />
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/components/legacy-components/src/weeknote-navigation/weeknote-navigation.scss
+++ b/components/legacy-components/src/weeknote-navigation/weeknote-navigation.scss
@@ -1,0 +1,46 @@
+@use "../util-viewports/viewports" as *;
+@use "../util-palette/palette" as *;
+@use "../util-typography/type/variables" as *;
+@use "../util-typography/type/modular-scale" as *;
+@use "../util-typography/type/mixins" as *;
+
+.alex-weeknote-nav {
+  margin: 2em 0;
+  padding-top: 1.5em;
+  border-top: 1px solid $grey-2;
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+    padding-left: 0;
+    margin: 0;
+    list-style: none;
+
+    @include media(">tablet") {
+      flex-direction: row;
+    }
+  }
+
+  li {
+    @include media(">tablet") {
+      flex: 1;
+    }
+  }
+
+  .alex-card {
+    border-bottom: none;
+  }
+
+  h3 {
+    @include fontsize($fontsize: zeta);
+  }
+}
+
+.alex-weeknote-nav__label {
+  display: block;
+  color: $grey-4;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  @include fontsize($fontsize: iota);
+}

--- a/components/legacy-components/src/weeknote-navigation/weeknote-navigation.stories.tsx
+++ b/components/legacy-components/src/weeknote-navigation/weeknote-navigation.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import WeeknoteNavigation from '.'
+
+const previous = {
+  contentId: '1',
+  title: 'Weeknotes: Battery — Week 12, 2026',
+  slug: '/blog/weeknotes-week-12-2026',
+  date: '2026-03-22',
+}
+
+const next = {
+  contentId: '2',
+  title: 'Weeknotes: Sweet Amber — Week 14, 2026',
+  slug: '/blog/weeknotes-week-14-2026',
+  date: '2026-04-05',
+}
+
+const meta: Meta<typeof WeeknoteNavigation> = {
+  title: 'Legacy/Organisms/WeeknoteNavigation',
+  component: WeeknoteNavigation,
+  parameters: { layout: 'padded' },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Mid-series: both directions have somewhere to go.
+export const Default: Story = {
+  args: { previous, next },
+}
+
+// The newest weeknote: nothing newer exists, so only Previous renders.
+export const NewestWeeknote: Story = {
+  args: { previous, next: null },
+}
+
+// The oldest weeknote: nothing older exists, so only Next renders.
+export const OldestWeeknote: Story = {
+  args: { previous: null, next },
+}
+
+// Not a weeknote: renders nothing at all.
+export const Empty: Story = {
+  args: { previous: null, next: null },
+}

--- a/services/personal-website/src/components/related-articles.tsx
+++ b/services/personal-website/src/components/related-articles.tsx
@@ -1,98 +1,22 @@
 import React from "react"
-import { useStaticQuery, graphql } from "gatsby"
 import RelatedArticles from "@alexwilson/ds-legacy-components/src/related-articles"
 
-type Article = {
-  contentId: string
-  slug: string
-  date: string
-  title: string
-  topics: { topicId: string; topic: string; slug: string }[]
-}
-
-function isWeeknote(article: Article) {
-  return article.topics.some(({ topic }) => topic === "weeknotes")
-}
-
-function findPreviousWeeknote(articles: Article[], currentArticle: Article) {
-  return (
-    articles.find(
-      (article) =>
-        isWeeknote(article) &&
-        new Date(article.date) < new Date(currentArticle.date),
-    ) || null
-  )
-}
+import useArticles from "../hooks/useArticles"
+import { selectRelatedArticles } from "../lib/related-articles"
+import { type Article } from "../lib/weeknotes"
 
 type Props = {
   article: Article
 }
 
 const RelatedArticlesContainer = ({ article: currentArticle }: Props) => {
-  const data = useStaticQuery<{ posts: { nodes: Article[] } }>(graphql`
-    query RelatedArticles {
-      posts: allContent(
-        sort: { date: DESC }
-        filter: { type: { eq: "article" } }
-        limit: 1000
-      ) {
-        nodes {
-          contentId
-          slug
-          date
-          title
-          topics {
-            topicId
-            topic
-            slug
-          }
-        }
-      }
-    }
-  `)
+  const articles = useArticles()
 
-  const allArticles = data.posts.nodes
-  const currentArticleTopics =
-    currentArticle.topics.map((topic) => topic.topicId) || []
-
-  const maxArticles = 3
-  const relatedArticles = new Set<Article>()
-
-  const previousWeeknote = isWeeknote(currentArticle)
-    ? findPreviousWeeknote(allArticles, currentArticle)
-    : null
-  if (previousWeeknote) {
-    relatedArticles.add(previousWeeknote)
-  }
-
-  for (let granularity = 6; granularity >= 0; granularity--) {
-    if (relatedArticles.size >= maxArticles) break
-
-    for (const article of allArticles) {
-      if (article.contentId === currentArticle.contentId) continue
-      if (relatedArticles.size >= maxArticles) break
-
-      const relatedArticleIsWeeknote = isWeeknote(article)
-
-      if (granularity >= 1 && relatedArticleIsWeeknote) {
-        continue
-      }
-
-      let similarity = 0
-
-      for (const topic of article.topics) {
-        if (currentArticleTopics.includes(topic.topicId)) {
-          similarity++
-        }
-      }
-
-      if (similarity >= granularity && !relatedArticles.has(article)) {
-        relatedArticles.add(article)
-      }
-    }
-  }
-
-  return <RelatedArticles articles={Array.from(relatedArticles.values())} />
+  return (
+    <RelatedArticles
+      articles={selectRelatedArticles(articles, currentArticle)}
+    />
+  )
 }
 
 export default RelatedArticlesContainer

--- a/services/personal-website/src/components/weeknote-navigation.tsx
+++ b/services/personal-website/src/components/weeknote-navigation.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import WeeknoteNavigation from "@alexwilson/ds-legacy-components/src/weeknote-navigation"
+
+import useArticles from "../hooks/useArticles"
+import { selectWeeknoteNavigation, type Article } from "../lib/weeknotes"
+
+type Props = {
+  article: Article
+}
+
+const WeeknoteNavigationContainer = ({ article: currentArticle }: Props) => {
+  const articles = useArticles()
+  // `latest` belongs to the Read Next rail, not the pager.
+  const { previous, next } = selectWeeknoteNavigation(articles, currentArticle)
+
+  return <WeeknoteNavigation previous={previous} next={next} />
+}
+
+export default WeeknoteNavigationContainer

--- a/services/personal-website/src/hooks/useArticles.ts
+++ b/services/personal-website/src/hooks/useArticles.ts
@@ -1,0 +1,28 @@
+import { useStaticQuery, graphql } from "gatsby"
+import { type Article } from "../lib/weeknotes"
+
+export default function useArticles(): Article[] {
+  const data = useStaticQuery<{ posts: { nodes: Article[] } }>(graphql`
+    query Articles {
+      posts: allContent(
+        sort: { date: DESC }
+        filter: { type: { eq: "article" } }
+        limit: 1000
+      ) {
+        nodes {
+          contentId
+          slug
+          date
+          title
+          topics {
+            topicId
+            topic
+            slug
+          }
+        }
+      }
+    }
+  `)
+
+  return data.posts.nodes
+}

--- a/services/personal-website/src/lib/related-articles.test.ts
+++ b/services/personal-website/src/lib/related-articles.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest"
+import { selectRelatedArticles } from "./related-articles"
+import { isWeeknote, type Article } from "./weeknotes"
+
+const topic = (name: string) => ({
+  topicId: `t-${name}`,
+  topic: name,
+  slug: `/topic/${name}`,
+})
+
+const article = (
+  contentId: string,
+  date: string,
+  topics: string[] = [],
+): Article => ({
+  contentId,
+  slug: `/${contentId}`,
+  date,
+  title: contentId,
+  topics: topics.map(topic),
+})
+
+const weeknote = (contentId: string, date: string, extra: string[] = []) =>
+  article(contentId, date, ["weeknotes", ...extra])
+
+const ids = (articles: Article[]) => articles.map((a) => a.contentId)
+
+describe("selectRelatedArticles on a weeknote", () => {
+  it("leads with the latest weeknote, then recommends no other weeknote", () => {
+    const current = weeknote("wk3", "2026-01-18")
+    const articles = [
+      weeknote("wk5", "2026-02-01"),
+      weeknote("wk4", "2026-01-25"),
+      current,
+      article("essay", "2025-06-01", ["cooking"]),
+      weeknote("wk2", "2026-01-11"),
+    ]
+
+    // wk5 is the latest; wk4 and wk2 are weeknotes and must not be recommended.
+    expect(ids(selectRelatedArticles(articles, current))).toEqual([
+      "wk5",
+      "essay",
+    ])
+  })
+
+  it("fills behind the latest weeknote with topically similar posts first", () => {
+    const current = weeknote("wk3", "2026-01-18", ["cooking"])
+    const articles = [
+      weeknote("wk4", "2026-01-25"),
+      article("recent", "2026-01-20", ["kubernetes"]),
+      current,
+      article("cooking-post", "2024-01-01", ["cooking"]),
+    ]
+
+    // `cooking-post` is the oldest, but shares a topic, so it outranks `recent`.
+    expect(ids(selectRelatedArticles(articles, current))).toEqual([
+      "wk4",
+      "cooking-post",
+      "recent",
+    ])
+  })
+
+  it("offers no latest weeknote when already on the latest one", () => {
+    const current = weeknote("wk4", "2026-01-25")
+    const articles = [
+      current,
+      article("a", "2026-01-10"),
+      article("b", "2026-01-09"),
+      article("c", "2026-01-08"),
+      weeknote("wk3", "2026-01-18"),
+    ]
+
+    expect(ids(selectRelatedArticles(articles, current))).toEqual([
+      "a",
+      "b",
+      "c",
+    ])
+  })
+
+  it("falls back to recent non-weeknotes when there is no topical overlap", () => {
+    const current = weeknote("wk3", "2026-01-18")
+    const articles = [
+      weeknote("wk4", "2026-01-25"),
+      article("a", "2026-01-10"),
+      article("b", "2026-01-09"),
+      article("c", "2026-01-08"),
+      article("d", "2026-01-07"),
+      current,
+    ]
+
+    expect(ids(selectRelatedArticles(articles, current))).toEqual([
+      "wk4",
+      "a",
+      "b",
+    ])
+  })
+})
+
+describe("selectRelatedArticles off a weeknote", () => {
+  it("ranks by topic overlap, most similar first", () => {
+    const current = article("current", "2026-01-18", ["aws", "kubernetes"])
+    const articles = [
+      article("one-topic", "2026-01-17", ["aws"]),
+      article("two-topics", "2026-01-16", ["aws", "kubernetes"]),
+      current,
+    ]
+
+    expect(ids(selectRelatedArticles(articles, current))).toEqual([
+      "two-topics",
+      "one-topic",
+    ])
+  })
+
+  it("trails with the latest weeknote, behind the regular picks", () => {
+    const current = article("current", "2026-01-18", ["aws"])
+    const articles = [
+      weeknote("wk-new", "2026-02-01"),
+      article("aws-post", "2025-01-01", ["aws"]),
+      article("filler", "2024-06-01"),
+      current,
+      weeknote("wk-old", "2025-06-01"),
+    ]
+
+    // Two regular posts lead; the newest weeknote takes the last slot.
+    expect(ids(selectRelatedArticles(articles, current))).toEqual([
+      "aws-post",
+      "filler",
+      "wk-new",
+    ])
+  })
+
+  it("includes no more than one weeknote", () => {
+    const current = article("current", "2026-01-18", ["aws"])
+    const articles = [
+      weeknote("wk-new", "2026-02-01"),
+      weeknote("wk-mid", "2026-01-25"),
+      article("aws-post", "2025-01-01", ["aws"]),
+      current,
+      weeknote("wk-old", "2025-06-01"),
+    ]
+
+    const result = selectRelatedArticles(articles, current)
+    expect(result.filter(isWeeknote)).toHaveLength(1)
+    expect(ids(result)).toEqual(["aws-post", "wk-new"])
+  })
+
+  it("fills every slot with regular posts when no weeknote exists", () => {
+    const current = article("current", "2026-01-18", ["aws"])
+    const articles = [
+      current,
+      article("a", "2026-01-17", ["aws"]),
+      article("b", "2026-01-16", ["aws"]),
+      article("c", "2026-01-15", ["aws"]),
+      article("d", "2026-01-14", ["aws"]),
+    ]
+
+    expect(ids(selectRelatedArticles(articles, current))).toEqual(["a", "b", "c"])
+  })
+})

--- a/services/personal-website/src/lib/related-articles.ts
+++ b/services/personal-website/src/lib/related-articles.ts
@@ -1,0 +1,60 @@
+import {
+  isWeeknote,
+  selectWeeknoteNavigation,
+  type Article,
+} from "./weeknotes"
+
+const MAX_ARTICLES = 3
+const MAX_GRANULARITY = 6
+
+export function selectRelatedArticles(
+  articlesNewestFirst: Article[],
+  currentArticle: Article,
+): Article[] {
+  const currentArticleIsWeeknote = isWeeknote(currentArticle)
+  const currentArticleTopics = currentArticle.topics.map(
+    (topic) => topic.topicId,
+  )
+
+  const relatedArticles = new Set<Article>()
+
+  const { latest } = selectWeeknoteNavigation(articlesNewestFirst, currentArticle)
+  if (latest) {
+    relatedArticles.add(latest)
+  }
+
+  const trailingWeeknote = currentArticleIsWeeknote
+    ? null
+    : (articlesNewestFirst.find(isWeeknote) ?? null)
+  const topicalLimit = trailingWeeknote ? MAX_ARTICLES - 1 : MAX_ARTICLES
+
+  for (
+    let granularity = MAX_GRANULARITY;
+    granularity >= 0 && relatedArticles.size < topicalLimit;
+    granularity--
+  ) {
+    for (const article of articlesNewestFirst) {
+      if (relatedArticles.size >= topicalLimit) break
+      if (article.contentId === currentArticle.contentId) continue
+      if (relatedArticles.has(article)) continue
+
+      // Weeknotes are their own reading thread — never let them fill topical slots;
+      // the single weeknote in this rail is placed deliberately, above or below.
+      if (isWeeknote(article)) continue
+
+      const similarity = article.topics.filter((topic) =>
+        currentArticleTopics.includes(topic.topicId),
+      ).length
+
+      if (similarity >= granularity) {
+        relatedArticles.add(article)
+      }
+    }
+  }
+
+  if (trailingWeeknote && relatedArticles.size < MAX_ARTICLES) {
+    relatedArticles.add(trailingWeeknote)
+  }
+
+  return Array.from(relatedArticles)
+}

--- a/services/personal-website/src/lib/weeknotes.test.ts
+++ b/services/personal-website/src/lib/weeknotes.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest"
+import { isWeeknote, selectWeeknoteNavigation, type Article } from "./weeknotes"
+
+const topic = (name: string) => ({
+  topicId: `t-${name}`,
+  topic: name,
+  slug: `/topic/${name}`,
+})
+
+const article = (
+  contentId: string,
+  date: string,
+  topics: string[] = [],
+): Article => ({
+  contentId,
+  slug: `/${contentId}`,
+  date,
+  title: contentId,
+  topics: topics.map(topic),
+})
+
+const weeknote = (contentId: string, date: string, extra: string[] = []) =>
+  article(contentId, date, ["weeknotes", ...extra])
+
+// Newest first, as the GraphQL query returns them.
+const wk5 = weeknote("wk5", "2026-02-01")
+const wk4 = weeknote("wk4", "2026-01-25")
+const wk3 = weeknote("wk3", "2026-01-18")
+const wk2 = weeknote("wk2", "2026-01-11")
+const wk1 = weeknote("wk1", "2026-01-04")
+const essay = article("essay", "2026-01-20", ["cooking"])
+const articles = [wk5, wk4, essay, wk3, wk2, wk1]
+
+describe("isWeeknote", () => {
+  it("matches on the weeknotes topic", () => {
+    expect(isWeeknote(wk1)).toBe(true)
+    expect(isWeeknote(essay)).toBe(false)
+  })
+})
+
+describe("selectWeeknoteNavigation", () => {
+  it("returns nothing when the current article is not a weeknote", () => {
+    expect(selectWeeknoteNavigation(articles, essay)).toEqual({
+      previous: null,
+      next: null,
+      latest: null,
+    })
+  })
+
+  it("returns previous, next and latest for a weeknote mid-series", () => {
+    expect(selectWeeknoteNavigation(articles, wk2)).toEqual({
+      previous: wk1,
+      next: wk3,
+      latest: wk5,
+    })
+  })
+
+  it("ignores non-weeknotes when finding neighbours", () => {
+    // `essay` sits between wk3 and wk4 by date, but must not become a neighbour.
+    expect(selectWeeknoteNavigation(articles, wk3)).toMatchObject({
+      previous: wk2,
+      next: wk4,
+    })
+  })
+
+  it("omits next and latest on the newest weeknote, so both grey out", () => {
+    expect(selectWeeknoteNavigation(articles, wk5)).toEqual({
+      previous: wk4,
+      next: null,
+      latest: null,
+    })
+  })
+
+  it("keeps latest live on the second-newest, even though it is also next", () => {
+    expect(selectWeeknoteNavigation(articles, wk4)).toEqual({
+      previous: wk3,
+      next: wk5,
+      latest: wk5,
+    })
+  })
+
+  it("omits previous on the oldest weeknote", () => {
+    expect(selectWeeknoteNavigation(articles, wk1)).toEqual({
+      previous: null,
+      next: wk2,
+      latest: wk5,
+    })
+  })
+
+  it("returns nothing when the current weeknote is absent from the list", () => {
+    const orphan = weeknote("orphan", "2026-03-01")
+    expect(selectWeeknoteNavigation(articles, orphan)).toEqual({
+      previous: null,
+      next: null,
+      latest: null,
+    })
+  })
+})

--- a/services/personal-website/src/lib/weeknotes.ts
+++ b/services/personal-website/src/lib/weeknotes.ts
@@ -1,0 +1,38 @@
+export type Article = {
+  contentId: string
+  slug: string
+  date: string
+  title: string
+  topics: { topicId: string; topic: string; slug: string }[]
+}
+
+export type WeeknoteNavigation = {
+  previous: Article | null
+  next: Article | null
+  latest: Article | null
+}
+
+export function isWeeknote(article: Article) {
+  return article.topics.some(({ topic }) => topic === "weeknotes")
+}
+
+export function selectWeeknoteNavigation(
+  articlesNewestFirst: Article[],
+  currentArticle: Article,
+): WeeknoteNavigation {
+  const empty = { previous: null, next: null, latest: null }
+  if (!isWeeknote(currentArticle)) return empty
+
+  const weeknotes = articlesNewestFirst.filter(isWeeknote)
+  const position = weeknotes.findIndex(
+    (weeknote) => weeknote.contentId === currentArticle.contentId,
+  )
+  if (position === -1) return empty
+
+  return {
+    next: weeknotes[position - 1] ?? null,
+    previous: weeknotes[position + 1] ?? null,
+    // Null on the newest weeknote, where "latest" is where you already are.
+    latest: position === 0 ? null : weeknotes[0],
+  }
+}

--- a/services/personal-website/src/templates/article.tsx
+++ b/services/personal-website/src/templates/article.tsx
@@ -19,6 +19,7 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 import Article from "../schema-org/article"
 import RelatedArticles from "../components/related-articles"
+import WeeknoteNavigation from "../components/weeknote-navigation"
 
 type ArticleData = {
   content: {
@@ -116,6 +117,8 @@ const ArticleTemplate = ({ data, location }: PageProps<ArticleData>) => {
           className="alex-article__body article-description"
           itemProp="articleBody"
         />
+
+        <WeeknoteNavigation article={post} />
 
         <footer>
           <Infobox>


### PR DESCRIPTION
# Why?
Navigating between weeknotes is a bit weird.

# What?
Add a dedicated nav to the bottom of weeknotes, and change related items not to pull as many to make non-weeknotes more prominent.
