### PR TITLE
catch all errors when creating sessions

### DIFF
--- a/services/auth/src/__tests__/router.test.ts
+++ b/services/auth/src/__tests__/router.test.ts
@@ -113,3 +113,19 @@ describe('rate limiting', () => {
     expect(res.status).not.toBe(429)
   })
 })
+
+describe('sign-in error sanitisation', () => {
+  // AUTH_DB is undefined here, so the sign-in flow throws downstream. The
+  // response must not echo the raw error (which can carry DB internals) —
+  // it should redirect to the sanitised /auth/error page instead.
+  it('failing sign-in redirects to /auth/error without leaking the error', async () => {
+    const res = await app.fetch(
+      new Request('https://auth.test/auth/manage/sign-in'),
+      env,
+    )
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('/auth/error?error=server_error')
+    const body = await res.text()
+    expect(body).not.toMatch(/insert into|params:|Failed query/i)
+  })
+})

--- a/services/auth/src/manage.ts
+++ b/services/auth/src/manage.ts
@@ -70,7 +70,11 @@ export async function handleManageSignIn(c: Ctx, auth: Auth): Promise<Response> 
     headers.delete('content-length')
     return new Response(null, { status: 302, headers })
   } catch (e) {
-    return c.text(`Sign-in failed: ${(e as Error).message}`, 500)
+    // Never echo the raw error: it can carry DB internals (failed SQL +
+    // params) when the backing store is down. Log server-side, redirect to
+    // the sanitised error page. This surface is reachable pre-auth.
+    console.error('[manage] sign-in failed:', e)
+    return c.redirect('/auth/error?error=server_error', 302)
   }
 }
 
@@ -149,7 +153,8 @@ async function handlePost(c: Ctx, auth: Auth): Promise<Response> {
     try {
       await sessionsDomain.revoke(db, sessionId)
     } catch (e) {
-      return renderManage(c, auth, { kind: 'err', text: `Failed: ${(e as Error).message}` })
+      console.error('[manage] session revoke failed:', e)
+      return renderManage(c, auth, { kind: 'err', text: 'Something went wrong. Please try again.' })
     }
     return c.redirect('/auth/manage', 303)
   }
@@ -216,7 +221,8 @@ async function handlePost(c: Ctx, auth: Auth): Promise<Response> {
         throw new Error('unknown action')
     }
   } catch (e) {
-    return renderManage(c, auth, { kind: 'err', text: `Failed: ${(e as Error).message}` })
+    console.error(`[manage] action "${action}" failed:`, e)
+    return renderManage(c, auth, { kind: 'err', text: 'Something went wrong. Please try again.' })
   }
 
   return c.redirect('/auth/manage', 303)


### PR DESCRIPTION
# Why?

The auth worker leaked raw errors to the client. During a Durable Objects outage, the manage sign-in endpoint put the failed SQL insert and its params (verification/session data) straight into the response body. That endpoint is reachable before you sign in, so it was public.

# What?

Three `catch` blocks in `manage.ts` echoed `error.message` verbatim. They now log server-side and return something generic instead:

- Sign-in (public): redirects to the existing sanitised `/auth/error` page.
- Two admin actions: flash "Something went wrong".

Added a test that a failing sign-in redirects and never leaks the query or params.

# Anything else?

The two admin actions lose their specific validation text (e.g. "invalid role"), but those paths can't be hit through the UI. Happy to keep them if you'd rather.
