### PR TITLE
Move /about-me to /about

### DIFF
--- a/components/legacy-components/src/header/header.tsx
+++ b/components/legacy-components/src/header/header.tsx
@@ -225,7 +225,7 @@ class Header extends Component<HeaderProps, HeaderState> {
               ) : (
                 <>
                   <NavItem url="/" active={pathname === "/"}>Home</NavItem>
-                  <NavItem url="/about-me" active={pathname === "/about-me"}>About Me</NavItem>
+                  <NavItem url="/about" active={pathname === "/about"}>About Me</NavItem>
                   <NavItem url="/blog" active={section !== null && section === "blog"}>Writing</NavItem>
                   <NavItem url="/talks" active={section !== null && section === "talks"}>Speaking</NavItem>
                   <NavSpacer />

--- a/services/personal-website/gatsby-config.ts
+++ b/services/personal-website/gatsby-config.ts
@@ -9,7 +9,7 @@ const config: GatsbyConfig = {
     author: `@antoligy`,
     // The canonical page about the site's Person; the Page template marks it
     // as a schema.org ProfilePage. Site-level, not per-page frontmatter.
-    aboutPath: `/about-me`,
+    aboutPath: `/about`,
   },
   trailingSlash: "never",
   plugins: [

--- a/services/personal-website/gatsby-node.ts
+++ b/services/personal-website/gatsby-node.ts
@@ -150,7 +150,13 @@ export const createResolvers: GatsbyNode["createResolvers"] = ({ createResolvers
 }
 
 export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions }) => {
-  const { createPage } = actions
+  const { createPage, createRedirect } = actions
+
+  createRedirect({
+    fromPath: `/about-me`,
+    toPath: `/about`,
+    isPermanent: true,
+  })
   const articleTemplate = path.resolve(`./src/templates/article.tsx`)
   const talkTemplate = path.resolve(`./src/templates/talk.tsx`)
   const placeholderTemplate = path.resolve(`./src/templates/content-placeholder.tsx`)

--- a/services/personal-website/src/templates/article.tsx
+++ b/services/personal-website/src/templates/article.tsx
@@ -90,7 +90,7 @@ const ArticleTemplate = ({ data, location }: PageProps<ArticleData>) => {
                 itemScope
                 itemType="http://schema.org/Person"
               >
-                <a href="/about-me">
+                <a href="/about">
                   <span itemProp="name">Alex</span>
                 </a>
                 <meta itemProp="url" content={`https://alexwilson.tech/`} />

--- a/terraform/modules/fastly/vcl/redirects.vcl
+++ b/terraform/modules/fastly/vcl/redirects.vcl
@@ -3,6 +3,9 @@ table redirects {
   "/cv": "https://docs.google.com/document/d/1SlrbctqUQlhBtODC8c12Qft66b8j69jV1CSVcrYqdq0/",
   "/book-a-time": "https://fantastical.app/alexwilson/30m",
 
+  // Moved to the indie-web /about convention
+  "/about-me": "/about",
+
   // All pictures come from media.alexwilson.tech.
   "/pictures/**": "https://media.alexwilson.tech/**",
 


### PR DESCRIPTION
# Why?
Move the profile page from `/about-me` to `/about` to match the indie-web convention.

This is a breaking change: the old URL goes away, so we add redirects for it.

# What?
- The page route now comes from `/about` in the content frontmatter.
- Updated the header nav link and the article author link.
- Updated `aboutPath` in the site metadata so the ProfilePage JSON-LD still points at the right page.
- Added a Gatsby `createRedirect` from `/about-me` to `/about`.
- Added a 301 redirect in the Fastly VCL table.

# Anything else?
The `/about` route only exists once the frontmatter `path` is changed in the `alexwilson/content` repo. Until that ships, the redirects point at a 404, so land it together with this.

The Gatsby redirect is a fallback. Fastly serves the actual 301.
